### PR TITLE
feat(security): implement system_role authentication for admin endpoints

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -20,6 +20,47 @@ When deploying Cache Warmer:
 4. Follow the principle of least privilege
 5. Regularly update dependencies
 
+## System Administrator Role
+
+Blue Banded Bee distinguishes between two types of administrative access:
+
+- **System Administrator** (`system_role: "system_admin"`) - Blue Banded Bee operators with system-level access
+- **Organisation Administrator** (`role: "admin"` or `"owner"`) - Client administrators within their organisation
+
+### Setting Up a System Administrator
+
+System administrators can only be configured server-side for security reasons:
+
+1. **In Supabase Dashboard:**
+   - Navigate to Authentication > Users
+   - Select the user who needs system administrator privileges
+   - In the "Raw app_metadata" section, add:
+     ```json
+     {
+       "system_role": "system_admin"
+     }
+     ```
+   - Save the changes
+
+2. **Security Requirements:**
+   - System administrator privileges cannot be granted client-side
+   - Only Supabase project administrators can modify `app_metadata`
+   - Regular users cannot elevate their own permissions
+
+### System Administrator Capabilities
+
+System administrators have access to restricted endpoints such as:
+
+- `/admin/reset-db` - Database schema reset (development environments only)
+- Other system-level operations (as implemented)
+
+**Important Security Notes:**
+- System administrator endpoints are hidden in production environments
+- Database reset functionality requires both `system_role: "system_admin"` and explicit environment configuration:
+  - `APP_ENV != "production"` 
+  - `ALLOW_DB_RESET=true` environment variable
+- All system administrator actions are logged and tracked in Sentry for audit purposes
+
 ## Configuration
 
 Sensitive configuration should be set via environment variables, never in code or config files.

--- a/docs/API.md
+++ b/docs/API.md
@@ -20,7 +20,7 @@ This document defines the comprehensive API design for Blue Banded Bee's multi-i
 - `/v1/auth/register` - User registration
 - `/v1/auth/profile` - User profile (authenticated)
 - `/v1/auth/session` - Session validation
-- `/admin/reset-db` - Admin database reset (secured)
+- `/admin/reset-db` - Admin database reset (system administrators only)
 
 🔄 **Next Implementation Phase:**
 - Complete CRUD operations for jobs (cancel, retry)
@@ -623,6 +623,40 @@ GET /health
   }
 }
 ```
+
+### System Administrator Endpoints
+
+These endpoints require system administrator privileges. See [SECURITY.md](../SECURITY.md#system-administrator-role) for setup instructions.
+
+#### Database Reset (Development Only)
+```http
+POST /admin/reset-db
+Authorization: Bearer <jwt_token>
+```
+
+**Requirements:**
+- Valid JWT authentication
+- `system_role: "system_admin"` in user's `app_metadata`
+- `APP_ENV != "production"`
+- `ALLOW_DB_RESET=true` environment variable
+
+**Response (200):**
+```json
+{
+  "status": "success",
+  "data": null,
+  "message": "Database schema reset successfully",
+  "meta": {
+    "timestamp": "2023-05-18T12:34:56Z",
+    "version": "1.0.0"
+  }
+}
+```
+
+**Security Notes:**
+- Returns 404 in production environments
+- All reset actions are logged and tracked in Sentry
+- Only Blue Banded Bee operators should have system administrator access
 
 ## Error Handling
 

--- a/internal/api/admin.go
+++ b/internal/api/admin.go
@@ -20,7 +20,7 @@ func (h *Handler) AdminResetDatabase(w http.ResponseWriter, r *http.Request) {
 	// Check if this is running in development environment
 	env := os.Getenv("APP_ENV")
 	if env == "production" {
-		NotFound(w, r) // Return 404 in production to hide the endpoint
+		NotFound(w, r, "Not found") // Return 404 in production to hide the endpoint
 		return
 	}
 

--- a/internal/api/admin.go
+++ b/internal/api/admin.go
@@ -106,7 +106,7 @@ func (h *Handler) AdminResetDatabase(w http.ResponseWriter, r *http.Request) {
 // This is distinct from organisation-level admin roles - system admins are Blue Banded Bee operators
 // who have elevated privileges for system-level operations like database resets
 func hasSystemAdminRole(claims *auth.UserClaims) bool {
-	if claims.AppMetadata == nil {
+	if claims == nil || claims.AppMetadata == nil {
 		return false
 	}
 

--- a/internal/api/admin.go
+++ b/internal/api/admin.go
@@ -4,11 +4,13 @@ import (
 	"net/http"
 	"os"
 
+	"github.com/Harvey-AU/blue-banded-bee/internal/auth"
+	"github.com/getsentry/sentry-go"
 	"github.com/rs/zerolog/log"
 )
 
 // AdminResetDatabase handles the admin database reset endpoint
-// TODO: This should be properly secured or removed in production
+// Requires valid JWT with admin role and explicit environment enablement
 func (h *Handler) AdminResetDatabase(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		MethodNotAllowed(w, r)
@@ -18,24 +20,102 @@ func (h *Handler) AdminResetDatabase(w http.ResponseWriter, r *http.Request) {
 	// Check if this is running in development environment
 	env := os.Getenv("APP_ENV")
 	if env == "production" {
-		Forbidden(w, r, "Database reset not allowed in production")
+		NotFound(w, r) // Return 404 in production to hide the endpoint
 		return
 	}
 
-	// TODO: Add proper admin authentication
-	// For now, only allow if explicitly enabled
+	// Require explicit enablement
 	if os.Getenv("ALLOW_DB_RESET") != "true" {
-		Forbidden(w, r, "Database reset not enabled")
+		Forbidden(w, r, "Database reset not enabled. Set ALLOW_DB_RESET=true to enable")
 		return
 	}
 
-	log.Warn().Msg("Database reset requested")
+	// Get user claims from context (set by AuthMiddleware)
+	claims, ok := auth.GetUserFromContext(r.Context())
+	if !ok {
+		Unauthorised(w, r, "Authentication required for admin endpoint")
+		return
+	}
 
+	// Verify system admin role
+	if !hasSystemAdminRole(claims) {
+		log.Warn().
+			Str("user_id", claims.UserID).
+			Str("email", claims.Email).
+			Msg("Non-system-admin user attempted to access database reset endpoint")
+		Forbidden(w, r, "System administrator privileges required")
+		return
+	}
+
+	// Verify user exists in database
+	user, err := h.DB.GetUser(claims.UserID)
+	if err != nil {
+		log.Error().Err(err).Str("user_id", claims.UserID).Msg("Failed to verify admin user")
+		Unauthorised(w, r, "User verification failed")
+		return
+	}
+
+	// Log the admin action with full context
+	log.Warn().
+		Str("user_id", user.ID).
+		Str("email", user.Email).
+		Str("org_id", func() string {
+			if user.OrganisationID != nil {
+				return *user.OrganisationID
+			}
+			return "none"
+		}()).
+		Str("remote_addr", r.RemoteAddr).
+		Str("user_agent", r.Header.Get("User-Agent")).
+		Msg("Admin database reset requested")
+
+	// Capture in Sentry for audit trail
+	sentry.WithScope(func(scope *sentry.Scope) {
+		scope.SetTag("event_type", "admin_action")
+		scope.SetTag("action", "database_reset")
+		scope.SetUser(sentry.User{
+			ID:    user.ID,
+			Email: user.Email,
+		})
+		scope.SetContext("admin_action", map[string]interface{}{
+			"endpoint":   "/admin/reset-db",
+			"user_agent": r.Header.Get("User-Agent"),
+			"ip_address": r.RemoteAddr,
+		})
+		sentry.CaptureMessage("Admin database reset action")
+	})
+
+	// Perform the database reset
 	if err := h.DB.ResetSchema(); err != nil {
-		log.Error().Err(err).Msg("Failed to reset database schema")
+		log.Error().Err(err).
+			Str("user_id", user.ID).
+			Msg("Failed to reset database schema")
 		InternalError(w, r, err)
 		return
 	}
 
+	log.Info().
+		Str("user_id", user.ID).
+		Str("email", user.Email).
+		Msg("Database schema reset completed by admin")
+
 	WriteSuccess(w, r, nil, "Database schema reset successfully")
+}
+
+// hasSystemAdminRole checks if the user has system administrator privileges via app_metadata
+// This is distinct from organisation-level admin roles - system admins are Blue Banded Bee operators
+// who have elevated privileges for system-level operations like database resets
+func hasSystemAdminRole(claims *auth.UserClaims) bool {
+	if claims.AppMetadata == nil {
+		return false
+	}
+
+	// Check for system_role = "system_admin" in app_metadata
+	if systemRole, exists := claims.AppMetadata["system_role"]; exists {
+		if roleStr, ok := systemRole.(string); ok && roleStr == "system_admin" {
+			return true
+		}
+	}
+
+	return false
 }

--- a/internal/api/admin_test.go
+++ b/internal/api/admin_test.go
@@ -1,0 +1,266 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/Harvey-AU/blue-banded-bee/internal/auth"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHasSystemAdminRole(t *testing.T) {
+	tests := []struct {
+		name     string
+		claims   *auth.UserClaims
+		expected bool
+	}{
+		{
+			name: "user with correct system_role should return true",
+			claims: &auth.UserClaims{
+				UserID: "test-user-1",
+				Email:  "admin@example.com",
+				AppMetadata: map[string]interface{}{
+					"system_role": "system_admin",
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "user with different role should return false",
+			claims: &auth.UserClaims{
+				UserID: "test-user-2",
+				Email:  "user@example.com",
+				AppMetadata: map[string]interface{}{
+					"system_role": "admin",
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "user with owner role should return false",
+			claims: &auth.UserClaims{
+				UserID: "test-user-3",
+				Email:  "owner@example.com",
+				AppMetadata: map[string]interface{}{
+					"system_role": "owner",
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "user with nil app_metadata should return false",
+			claims: &auth.UserClaims{
+				UserID:      "test-user-4",
+				Email:       "user@example.com",
+				AppMetadata: nil,
+			},
+			expected: false,
+		},
+		{
+			name: "user with empty app_metadata should return false",
+			claims: &auth.UserClaims{
+				UserID:      "test-user-5",
+				Email:       "user@example.com",
+				AppMetadata: map[string]interface{}{},
+			},
+			expected: false,
+		},
+		{
+			name: "user with system_role set to wrong value should return false",
+			claims: &auth.UserClaims{
+				UserID: "test-user-6",
+				Email:  "user@example.com",
+				AppMetadata: map[string]interface{}{
+					"system_role": "wrong_value",
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "user with system_role as integer should return false",
+			claims: &auth.UserClaims{
+				UserID: "test-user-7",
+				Email:  "user@example.com",
+				AppMetadata: map[string]interface{}{
+					"system_role": 123,
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "user with system_role as boolean should return false",
+			claims: &auth.UserClaims{
+				UserID: "test-user-8",
+				Email:  "user@example.com",
+				AppMetadata: map[string]interface{}{
+					"system_role": true,
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "user with system_role as float should return false",
+			claims: &auth.UserClaims{
+				UserID: "test-user-9",
+				Email:  "user@example.com",
+				AppMetadata: map[string]interface{}{
+					"system_role": 12.5,
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "user with system_role as array should return false",
+			claims: &auth.UserClaims{
+				UserID: "test-user-10",
+				Email:  "user@example.com",
+				AppMetadata: map[string]interface{}{
+					"system_role": []string{"system_admin"},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "user with system_role as map should return false",
+			claims: &auth.UserClaims{
+				UserID: "test-user-11",
+				Email:  "user@example.com",
+				AppMetadata: map[string]interface{}{
+					"system_role": map[string]string{"role": "system_admin"},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "user with other metadata but no system_role should return false",
+			claims: &auth.UserClaims{
+				UserID: "test-user-12",
+				Email:  "user@example.com",
+				AppMetadata: map[string]interface{}{
+					"organization": "example.com",
+					"tier":         "premium",
+					"admin":        true,
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "user with system_role key but nil value should return false",
+			claims: &auth.UserClaims{
+				UserID: "test-user-13",
+				Email:  "user@example.com",
+				AppMetadata: map[string]interface{}{
+					"system_role": nil,
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "user with empty string system_role should return false",
+			claims: &auth.UserClaims{
+				UserID: "test-user-14",
+				Email:  "user@example.com",
+				AppMetadata: map[string]interface{}{
+					"system_role": "",
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "user with system_role containing extra whitespace should return false",
+			claims: &auth.UserClaims{
+				UserID: "test-user-15",
+				Email:  "user@example.com",
+				AppMetadata: map[string]interface{}{
+					"system_role": " system_admin ",
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "user with case-insensitive system_admin should return false",
+			claims: &auth.UserClaims{
+				UserID: "test-user-16",
+				Email:  "user@example.com",
+				AppMetadata: map[string]interface{}{
+					"system_role": "SYSTEM_ADMIN",
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "user with mixed case system_admin should return false",
+			claims: &auth.UserClaims{
+				UserID: "test-user-17",
+				Email:  "user@example.com",
+				AppMetadata: map[string]interface{}{
+					"system_role": "System_Admin",
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := hasSystemAdminRole(tt.claims)
+			assert.Equal(t, tt.expected, result, "hasSystemAdminRole() result should match expected value")
+		})
+	}
+}
+
+func TestHasSystemAdminRoleWithNilClaims(t *testing.T) {
+	// Test with nil claims - should return false
+	result := hasSystemAdminRole(nil)
+	assert.False(t, result, "hasSystemAdminRole() should return false when given nil claims")
+}
+
+func TestHasSystemAdminRoleEdgeCases(t *testing.T) {
+	t.Run("multiple system_admin values in metadata", func(t *testing.T) {
+		// Test with valid system_role but other confusing metadata
+		claims := &auth.UserClaims{
+			UserID: "test-user",
+			Email:  "admin@example.com",
+			AppMetadata: map[string]interface{}{
+				"system_role":    "system_admin",
+				"role":           "user",           // different role field
+				"admin":          false,            // contradictory admin field
+				"permissions":    []string{"read"}, // other permission structure
+				"system_admin":   false,            // similar but different key
+				"SystemRole":     "system_admin",   // different case key
+				"system_role_v2": "system_admin",   // similar key
+			},
+		}
+		result := hasSystemAdminRole(claims)
+		assert.True(t, result, "should return true when system_role is correctly set to system_admin")
+	})
+
+	t.Run("unicode and special characters in role", func(t *testing.T) {
+		testCases := []struct {
+			role     interface{}
+			expected bool
+		}{
+			{"system_admin", true},              // correct value
+			{"system_admin🔑", false},           // with emoji
+			{"system_admin\n", false},           // with newline
+			{"system_admin\t", false},           // with tab
+			{"system_admin\x00", false},         // with null character
+			{"系统管理员", false},                    // chinese characters
+			{"système_admin", false},            // french characters
+			{"system‑admin", false},             // en dash instead of underscore
+			{"system—admin", false},             // em dash instead of underscore
+			{"system_admin­", false},            // soft hyphen at end
+		}
+
+		for _, tc := range testCases {
+			claims := &auth.UserClaims{
+				UserID: "test-user",
+				Email:  "admin@example.com",
+				AppMetadata: map[string]interface{}{
+					"system_role": tc.role,
+				},
+			}
+			result := hasSystemAdminRole(claims)
+			assert.Equal(t, tc.expected, result, "role value %v should return %v", tc.role, tc.expected)
+		}
+	})
+}

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -52,8 +52,8 @@ func (h *Handler) SetupRoutes(mux *http.ServeMux) {
 	// Webhook endpoints (no auth required)
 	mux.HandleFunc("/v1/webhooks/webflow/", h.WebflowWebhook) // Note: trailing slash for path params
 
-	// Admin endpoints (require special authentication)
-	mux.HandleFunc("/admin/reset-db", h.AdminResetDatabase)
+	// Admin endpoints (require authentication and admin role)
+	mux.Handle("/admin/reset-db", auth.AuthMiddleware(http.HandlerFunc(h.AdminResetDatabase)))
 
 	// Debug endpoints (no auth required)
 	mux.HandleFunc("/debug/fgtrace", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary
- Updated `internal/api/admin.go` to use `system_role: system_admin` for authentication
- Added system administrator documentation to `SECURITY.md`
- Updated `docs/API.md` with endpoint documentation

## Changes
- Replace generic admin role check with specific `system_role` check in app_metadata
- Distinguish between system administrators (Blue Banded Bee operators) and organisation admins (clients)
- Rename `hasAdminRole` to `hasSystemAdminRole` for clarity
- Maintain all existing security measures (environment checks, feature flags, audit logging)

## Security Impact
This change enhances security by preventing organisation-level administrators from accessing system-level operations. Only users with `app_metadata.system_role = "system_admin"` set in Supabase can access admin endpoints.

## Test Plan
- [x] Unit tests pass
- [x] Integration tests pass
- [x] Admin endpoints reject users without system_role
- [x] Admin endpoints accept users with system_role = "system_admin"
- [x] Audit logging captures admin actions
- [x] Endpoint returns 404 in production environment

## Documentation
- Updated SECURITY.md with system administrator setup instructions
- Updated API.md with endpoint requirements and examples