### PR TITLE
Fix user registration after database reset

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -1522,13 +1522,25 @@
         // Initialize data binder
         await dataBinder.init();
 
+        // Check if user exists in backend on page load
+        const { data: { session } } = await supabase.auth.getSession();
+        if (session?.user) {
+          await registerUserWithBackend(session.user);
+        }
+
         // Update user info in header
         updateUserInfo();
 
         // Set up auth state change listener to update user info
         if (supabase) {
-          supabase.auth.onAuthStateChange((event, session) => {
+          supabase.auth.onAuthStateChange(async (event, session) => {
             console.log("Auth state changed:", event, session?.user?.email);
+            
+            // Register user with backend on sign in (handles OAuth returns)
+            if ((event === 'SIGNED_IN' || event === 'USER_UPDATED') && session?.user) {
+              await registerUserWithBackend(session.user);
+            }
+            
             // Wait a moment for the data binder to update its auth manager
             setTimeout(updateUserInfo, 100);
           });
@@ -2899,6 +2911,10 @@
           if (error) throw error;
 
           console.log("Email login successful:", data.user.email);
+          
+          // Register user with backend (in case they don't exist)
+          await registerUserWithBackend(data.user);
+          
           closeAuthModal();
 
           // Update user info immediately
@@ -2953,7 +2969,10 @@
           if (data.user && !data.user.email_confirmed_at) {
             showAuthError("Please check your email and click the confirmation link before signing in.");
             showAuthForm("login");
-          } else {
+          } else if (data.user) {
+            // Register user with backend
+            await registerUserWithBackend(data.user);
+            
             closeAuthModal();
             // Update user info and refresh dashboard
             updateUserInfo();
@@ -2964,6 +2983,53 @@
           showAuthError(error.message || "Signup failed. Please try again.");
         } finally {
           hideAuthLoading();
+        }
+      }
+
+      // Register user with backend database
+      async function registerUserWithBackend(user) {
+        if (!user || !user.id || !user.email) {
+          console.error("Invalid user data for registration");
+          return false;
+        }
+
+        try {
+          const session = await supabase.auth.getSession();
+          if (!session.data.session) {
+            console.error("No session available for registration");
+            return false;
+          }
+
+          const response = await fetch("/v1/auth/register", {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              Authorization: `Bearer ${session.data.session.access_token}`,
+            },
+            body: JSON.stringify({
+              user_id: user.id,
+              email: user.email,
+              full_name: user.user_metadata?.full_name || null,
+            }),
+          });
+
+          if (!response.ok) {
+            // If user already exists (409 Conflict), that's fine
+            if (response.status === 409) {
+              console.log("User already registered in backend");
+              return true;
+            }
+            const errorData = await response.json();
+            console.error("Backend registration failed:", errorData);
+            return false;
+          }
+
+          const data = await response.json();
+          console.log("User registered with backend:", data);
+          return true;
+        } catch (error) {
+          console.error("Failed to register user with backend:", error);
+          return false;
         }
       }
 

--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -159,14 +159,11 @@ func (h *Handler) AuthProfile(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	user, err := h.DB.GetUser(userClaims.UserID)
+	// Auto-create user if they don't exist
+	user, err := h.DB.GetOrCreateUser(userClaims.UserID, userClaims.Email, nil)
 	if err != nil {
-		if strings.Contains(err.Error(), "not found") {
-			NotFound(w, r, "User not found")
-			return
-		}
 		sentry.CaptureException(err)
-		log.Error().Err(err).Str("user_id", userClaims.UserID).Msg("Failed to get user")
+		log.Error().Err(err).Str("user_id", userClaims.UserID).Msg("Failed to get or create user")
 		InternalError(w, r, err)
 		return
 	}

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -144,11 +144,11 @@ func (h *Handler) DashboardStats(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Get full user object from database
-	user, err := h.DB.GetUser(userClaims.UserID)
+	// Get full user object from database (auto-create if needed)
+	user, err := h.DB.GetOrCreateUser(userClaims.UserID, userClaims.Email, nil)
 	if err != nil {
-		log.Error().Err(err).Str("user_id", userClaims.UserID).Msg("Failed to get user from database")
-		Unauthorised(w, r, "User not found")
+		log.Error().Err(err).Str("user_id", userClaims.UserID).Msg("Failed to get or create user")
+		InternalError(w, r, err)
 		return
 	}
 
@@ -199,11 +199,11 @@ func (h *Handler) DashboardActivity(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Get full user object from database
-	user, err := h.DB.GetUser(userClaims.UserID)
+	// Get full user object from database (auto-create if needed)
+	user, err := h.DB.GetOrCreateUser(userClaims.UserID, userClaims.Email, nil)
 	if err != nil {
-		log.Error().Err(err).Str("user_id", userClaims.UserID).Msg("Failed to get user from database")
-		Unauthorised(w, r, "User not found")
+		log.Error().Err(err).Str("user_id", userClaims.UserID).Msg("Failed to get or create user")
+		InternalError(w, r, err)
 		return
 	}
 

--- a/internal/api/jobs.go
+++ b/internal/api/jobs.go
@@ -101,10 +101,11 @@ func (h *Handler) listJobs(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	user, err := h.DB.GetUser(userClaims.UserID)
+	// Auto-create user if they don't exist (handles new signups)
+	user, err := h.DB.GetOrCreateUser(userClaims.UserID, userClaims.Email, nil)
 	if err != nil {
-		log.Error().Err(err).Str("user_id", userClaims.UserID).Msg("Failed to get user from database")
-		Unauthorised(w, r, "User not found")
+		log.Error().Err(err).Str("user_id", userClaims.UserID).Msg("Failed to get or create user")
+		InternalError(w, r, err)
 		return
 	}
 
@@ -210,10 +211,11 @@ func (h *Handler) createJob(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	user, err := h.DB.GetUser(userClaims.UserID)
+	// Auto-create user if they don't exist (handles new signups)
+	user, err := h.DB.GetOrCreateUser(userClaims.UserID, userClaims.Email, nil)
 	if err != nil {
-		log.Error().Err(err).Str("user_id", userClaims.UserID).Msg("Failed to get user from database")
-		Unauthorised(w, r, "User not found")
+		log.Error().Err(err).Str("user_id", userClaims.UserID).Msg("Failed to get or create user")
+		InternalError(w, r, err)
 		return
 	}
 
@@ -280,10 +282,11 @@ func (h *Handler) getJob(w http.ResponseWriter, r *http.Request, jobID string) {
 		return
 	}
 
-	user, err := h.DB.GetUser(userClaims.UserID)
+	// Auto-create user if they don't exist (handles new signups)
+	user, err := h.DB.GetOrCreateUser(userClaims.UserID, userClaims.Email, nil)
 	if err != nil {
-		log.Error().Err(err).Str("user_id", userClaims.UserID).Msg("Failed to get user from database")
-		Unauthorised(w, r, "User not found")
+		log.Error().Err(err).Str("user_id", userClaims.UserID).Msg("Failed to get or create user")
+		InternalError(w, r, err)
 		return
 	}
 
@@ -349,10 +352,11 @@ func (h *Handler) updateJob(w http.ResponseWriter, r *http.Request, jobID string
 		return
 	}
 
-	user, err := h.DB.GetUser(userClaims.UserID)
+	// Auto-create user if they don't exist (handles new signups)
+	user, err := h.DB.GetOrCreateUser(userClaims.UserID, userClaims.Email, nil)
 	if err != nil {
-		log.Error().Err(err).Str("user_id", userClaims.UserID).Msg("Failed to get user from database")
-		Unauthorised(w, r, "User not found")
+		log.Error().Err(err).Str("user_id", userClaims.UserID).Msg("Failed to get or create user")
+		InternalError(w, r, err)
 		return
 	}
 
@@ -430,10 +434,11 @@ func (h *Handler) cancelJob(w http.ResponseWriter, r *http.Request, jobID string
 		return
 	}
 
-	user, err := h.DB.GetUser(userClaims.UserID)
+	// Auto-create user if they don't exist (handles new signups)
+	user, err := h.DB.GetOrCreateUser(userClaims.UserID, userClaims.Email, nil)
 	if err != nil {
-		log.Error().Err(err).Str("user_id", userClaims.UserID).Msg("Failed to get user from database")
-		Unauthorised(w, r, "User not found")
+		log.Error().Err(err).Str("user_id", userClaims.UserID).Msg("Failed to get or create user")
+		InternalError(w, r, err)
 		return
 	}
 
@@ -519,10 +524,11 @@ func (h *Handler) getJobTasks(w http.ResponseWriter, r *http.Request, jobID stri
 		return
 	}
 
-	user, err := h.DB.GetUser(userClaims.UserID)
+	// Auto-create user if they don't exist (handles new signups)
+	user, err := h.DB.GetOrCreateUser(userClaims.UserID, userClaims.Email, nil)
 	if err != nil {
-		log.Error().Err(err).Str("user_id", userClaims.UserID).Msg("Failed to get user from database")
-		Unauthorised(w, r, "User not found")
+		log.Error().Err(err).Str("user_id", userClaims.UserID).Msg("Failed to get or create user")
+		InternalError(w, r, err)
 		return
 	}
 


### PR DESCRIPTION
## Problem
After database reset, users could sign in via Supabase but got 401 errors because no user record existed in PostgreSQL database.

## Solution
Two-pronged approach for robustness:

### Frontend Fix
- Added registerUserWithBackend() function to call /v1/auth/register
- Calls registration after Supabase signup/login
- Handles OAuth returns via auth state change listener
- Registers on page load for existing sessions

### Backend Fix  
- Added GetOrCreateUser() to auto-create users from valid JWTs
- Updated all API handlers to use this instead of GetUser()
- Ensures any authenticated request creates missing users

## Testing
- Build passes locally ✅
- All Go tests pass ✅
- Ready for deployment to test environment