### PR TITLE
Increase maintenance timeout for recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ On merge, CI will:
     failures to prevent database hammering
   - Tasks from cancelled/failed jobs are marked as failed immediately instead of
     retrying
+  - Increased maintenance statement timeout from 5s to 30s to allow recovery
+    batches to complete when processing large backlogs
   - Fixes issue where thousands of tasks could remain stuck indefinitely due to
     all-or-nothing transaction rollbacks
 - **Monitoring and Alerting**: Reduced Sentry event spam whilst improving alert

--- a/internal/db/queue.go
+++ b/internal/db/queue.go
@@ -113,9 +113,10 @@ func (q *DbQueue) ExecuteMaintenance(ctx context.Context, fn func(*sql.Tx) error
 	}
 
 	// Keep maintenance units short-lived to minimise pool impact.
+	// Allow 35s to accommodate recovery batches processing large backlogs.
 	if _, ok := ctx.Deadline(); !ok {
 		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeout(ctx, 10*time.Second)
+		ctx, cancel = context.WithTimeout(ctx, 35*time.Second)
 		defer cancel()
 	}
 
@@ -128,8 +129,9 @@ func (q *DbQueue) ExecuteMaintenance(ctx context.Context, fn func(*sql.Tx) error
 		_ = tx.Rollback()
 	}()
 
-	// Apply a tight statement timeout so maintenance never blocks the pool.
-	if _, err := tx.ExecContext(ctx, `SET LOCAL statement_timeout = '5s'`); err != nil {
+	// Apply a statement timeout so maintenance never blocks the pool indefinitely.
+	// Set to 30s to allow recovery batches time to process large backlogs.
+	if _, err := tx.ExecContext(ctx, `SET LOCAL statement_timeout = '30s'`); err != nil {
 		log.Warn().Err(err).Msg("Failed to set maintenance statement timeout")
 	}
 


### PR DESCRIPTION
Recovery batches were timing out at 5s when processing
large backlogs. Increased to 30s to allow completion.
