### PR TITLE
Add 50% robots.txt delay multiplier

### DIFF
--- a/internal/jobs/domain_limiter.go
+++ b/internal/jobs/domain_limiter.go
@@ -24,7 +24,7 @@ type DomainLimiterConfig struct {
 	CancelRateLimitJobs   bool
 	CancelStreakThreshold int
 	CancelDelayThreshold  time.Duration
-	RobotsDelayMultiplier float64 // Multiplier for robots.txt crawl-delay (0.5 = 50%)
+	RobotsDelayMultiplier float64
 }
 
 func defaultDomainLimiterConfig() DomainLimiterConfig {
@@ -39,7 +39,7 @@ func defaultDomainLimiterConfig() DomainLimiterConfig {
 		CancelRateLimitJobs:   false,
 		CancelStreakThreshold: 20,
 		CancelDelayThreshold:  60 * time.Second,
-		RobotsDelayMultiplier: 0.5, // Default: use 50% of robots.txt crawl-delay
+		RobotsDelayMultiplier: 0.5,
 	}
 
 	if v, ok := os.LookupEnv("BBB_RATE_LIMIT_BASE_DELAY_MS"); ok {
@@ -340,7 +340,7 @@ func (ds *domainState) acquire(ctx context.Context, cfg DomainLimiterConfig, now
 		now := nowFn()
 		if req.RobotsDelay > 0 {
 			robots := req.RobotsDelay
-			// Apply multiplier to robots.txt delay (e.g., 0.5 = use 50% of specified delay)
+
 			if cfg.RobotsDelayMultiplier > 0 && cfg.RobotsDelayMultiplier < 1.0 {
 				robots = time.Duration(float64(robots) * cfg.RobotsDelayMultiplier)
 			}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an environment setting to scale robots/crawl-delay values (BBB_ROBOTS_DELAY_MULTIPLIER; default 0.5, valid range 0 < value ≤ 1).
  * Crawl delays from robots directives are scaled by this multiplier before existing base, cap and acquire logic is applied.
  * The chosen multiplier is logged at limiter initialization for observability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->