### PR TITLE
Add multi-organisation support

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -95,7 +95,11 @@
       "Bash(flyctl status:*)",
       "Bash(for i in 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30)",
       "Bash(do echo -n \"Check $i: \")",
-      "Bash(done)"
+      "Bash(done)",
+      "mcp__plugin_serena_serena__initial_instructions",
+      "mcp__plugin_serena_serena__list_dir",
+      "mcp__plugin_serena_serena__get_symbols_overview",
+      "mcp__plugin_serena_serena__activate_project"
     ],
     "deny": []
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,34 @@ On merge, CI will:
 4. Create a git tag and GitHub release
 5. Commit the updated changelog
 
-## [Unreleased]
+## [Unreleased:minor]
+
+### Added
+
+- **Multi-Organisation Support**: Users can now belong to multiple organisations
+  and switch between them
+  - New `organisation_members` table for many-to-many user-org relationships
+  - New `active_organisation_id` column on users for session persistence
+  - New `platform_org_mappings` table for Webflow/Shopify integration
+  - New endpoints: `GET /v1/organisations` (list user's orgs) and
+    `POST /v1/organisations/switch` (switch active org)
+  - Helper functions `GetActiveOrganisation()` and
+    `GetActiveOrganisationWithUser()` for consistent org context across handlers
+  - `GetEffectiveOrganisationID()` provides backward compatibility (returns
+    active org if set, otherwise legacy `organisation_id`)
+
+### Security
+
+- **Scheduler Jobs Query**: Fixed missing `organisation_id` filter in
+  `getSchedulerJobs` query that could potentially expose jobs across
+  organisations
+
+### Changed
+
+- **Organisation Scoping**: All 19 API endpoints now filter data by user's
+  active organisation (4 dashboard, 8 jobs, 5 schedulers, 2 new org endpoints)
+- **Stricter Validation**: Users without an organisation now receive HTTP 400
+  "User must belong to an organisation" instead of empty results
 
 ## [0.18.10] – 2025-12-29
 

--- a/docs/plans/platform-auth-plan.md
+++ b/docs/plans/platform-auth-plan.md
@@ -1,0 +1,28 @@
+# Platform Auth Plan
+
+## Goal
+
+Implement many-to-many organisation membership, active-organisation scoping, and
+platform org mapping (Webflow/Shopify) so multi-org users only see data for the
+org they selected.
+
+## Decisions
+
+- Webflow: map **workspace ID → BBB organisation**.
+- Shopify: map **Plus org ID when available**, otherwise **shop/store ID**.
+- Multi-org users must use **active organisation context** for all queries (no
+  cross-org listings).
+- Platform mappings belong to a single BBB org; users gain access only through
+  org membership.
+
+## Plan
+
+1. Add `organisation_members` (many-to-many) and backfill from
+   `users.organisation_id`.
+2. Add `active_organisation_id` (user/session) and require it for all list/query
+   endpoints.
+3. Update RLS policies to use `organisation_members` plus
+   `active_organisation_id` checks.
+4. Add `platform_org_mappings` and implement Webflow/Shopify org mapping flow.
+5. Ensure org switcher UX + API only returns data for the selected org.
+6. Verify with targeted tests and migration checks.

--- a/internal/api/dashboard_endpoints_test.go
+++ b/internal/api/dashboard_endpoints_test.go
@@ -31,6 +31,7 @@ func TestDashboardStatsIntegration(t *testing.T) {
 					OrganisationID: &orgID,
 				}
 				mockDB.On("GetOrCreateUser", "test-user-123", "test@example.com", (*string)(nil)).Return(user, nil)
+				mockDB.On("GetEffectiveOrganisationID", mock.AnythingOfType("*db.User")).Return(orgID)
 
 				// Mock successful job stats
 				stats := &db.JobStats{
@@ -72,6 +73,7 @@ func TestDashboardStatsIntegration(t *testing.T) {
 					OrganisationID: &orgID,
 				}
 				mockDB.On("GetOrCreateUser", "test-user-123", "test@example.com", (*string)(nil)).Return(user, nil)
+				mockDB.On("GetEffectiveOrganisationID", mock.AnythingOfType("*db.User")).Return(orgID)
 
 				stats := &db.JobStats{
 					TotalJobs:         25,
@@ -106,6 +108,7 @@ func TestDashboardStatsIntegration(t *testing.T) {
 					OrganisationID: &orgID,
 				}
 				mockDB.On("GetOrCreateUser", "test-user-123", "test@example.com", (*string)(nil)).Return(user, nil)
+				mockDB.On("GetEffectiveOrganisationID", mock.AnythingOfType("*db.User")).Return(orgID)
 				mockDB.On("GetJobStats", "org-123", mock.AnythingOfType("*time.Time"), mock.AnythingOfType("*time.Time")).Return(nil, assert.AnError)
 			},
 			expectedStatus: http.StatusInternalServerError,
@@ -182,6 +185,7 @@ func TestDashboardActivityIntegration(t *testing.T) {
 					OrganisationID: &orgID,
 				}
 				mockDB.On("GetOrCreateUser", "test-user-123", "test@example.com", (*string)(nil)).Return(user, nil)
+				mockDB.On("GetEffectiveOrganisationID", mock.AnythingOfType("*db.User")).Return(orgID)
 
 				// Mock successful activity data
 				activity := []db.ActivityPoint{
@@ -229,6 +233,7 @@ func TestDashboardActivityIntegration(t *testing.T) {
 					OrganisationID: &orgID,
 				}
 				mockDB.On("GetOrCreateUser", "test-user-123", "test@example.com", (*string)(nil)).Return(user, nil)
+				mockDB.On("GetEffectiveOrganisationID", mock.AnythingOfType("*db.User")).Return(orgID)
 				mockDB.On("GetJobActivity", "org-123", mock.AnythingOfType("*time.Time"), mock.AnythingOfType("*time.Time")).Return(nil, assert.AnError)
 			},
 			expectedStatus: http.StatusInternalServerError,
@@ -255,7 +260,7 @@ func TestDashboardActivityIntegration(t *testing.T) {
 
 				assert.Equal(t, float64(401), response["status"])
 				assert.Equal(t, "UNAUTHORISED", response["code"])
-				assert.Equal(t, "Authentication required", response["message"])
+				assert.Equal(t, "User information not found", response["message"])
 			},
 		},
 	}

--- a/internal/api/handlers_db_test.go
+++ b/internal/api/handlers_db_test.go
@@ -182,3 +182,25 @@ func (m *MockDBWithRealDB) GetDomainNames(ctx context.Context, domainIDs []int) 
 func (m *MockDBWithRealDB) GetLastJobStartTimeForScheduler(ctx context.Context, schedulerID string) (*time.Time, error) {
 	return nil, nil
 }
+
+func (m *MockDBWithRealDB) ListUserOrganisations(userID string) ([]db.UserOrganisation, error) {
+	return nil, nil
+}
+
+func (m *MockDBWithRealDB) ValidateOrganisationMembership(userID, organisationID string) (bool, error) {
+	return false, nil
+}
+
+func (m *MockDBWithRealDB) SetActiveOrganisation(userID, organisationID string) error {
+	return nil
+}
+
+func (m *MockDBWithRealDB) GetEffectiveOrganisationID(user *db.User) string {
+	if user.ActiveOrganisationID != nil && *user.ActiveOrganisationID != "" {
+		return *user.ActiveOrganisationID
+	}
+	if user.OrganisationID != nil {
+		return *user.OrganisationID
+	}
+	return ""
+}

--- a/internal/api/jobs.go
+++ b/internal/api/jobs.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Harvey-AU/blue-banded-bee/internal/auth"
 	"github.com/Harvey-AU/blue-banded-bee/internal/db"
 	"github.com/Harvey-AU/blue-banded-bee/internal/jobs"
 )
@@ -144,21 +143,10 @@ type JobResponse struct {
 func (h *Handler) listJobs(w http.ResponseWriter, r *http.Request) {
 	logger := loggerWithRequest(r)
 
-	userClaims, ok := auth.GetUserFromContext(r.Context())
-	if !ok {
-		Unauthorised(w, r, "User information not found")
-		return
-	}
-
-	// Auto-create user if they don't exist (handles new signups)
-	user, err := h.DB.GetOrCreateUser(userClaims.UserID, userClaims.Email, nil)
-	if err != nil {
-		if HandlePoolSaturation(w, r, err) {
-			return
-		}
-		logger.Error().Err(err).Str("user_id", userClaims.UserID).Msg("Failed to get or create user")
-		InternalError(w, r, err)
-		return
+	// Get active organisation (validates auth and membership)
+	orgID := h.GetActiveOrganisation(w, r)
+	if orgID == "" {
+		return // Error already written
 	}
 
 	// Parse query parameters
@@ -190,10 +178,6 @@ func (h *Handler) listJobs(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Get jobs from database
-	orgID := ""
-	if user.OrganisationID != nil {
-		orgID = *user.OrganisationID
-	}
 	jobs, total, err := h.DB.ListJobsWithOffset(orgID, limit, offset, status, dateRange, tzOffset)
 	if err != nil {
 		if HandlePoolSaturation(w, r, err) {
@@ -254,10 +238,17 @@ func (h *Handler) createJobFromRequest(ctx context.Context, user *db.User, req C
 		maxPages = *req.MaxPages
 	}
 
+	// Use effective organisation (active org takes precedence over legacy org)
+	effectiveOrgID := h.DB.GetEffectiveOrganisationID(user)
+	var orgIDPtr *string
+	if effectiveOrgID != "" {
+		orgIDPtr = &effectiveOrgID
+	}
+
 	opts := &jobs.JobOptions{
 		Domain:         req.Domain,
 		UserID:         &user.ID,
-		OrganisationID: user.OrganisationID,
+		OrganisationID: orgIDPtr,
 		UseSitemap:     useSitemap,
 		Concurrency:    concurrency,
 		FindLinks:      findLinks,
@@ -274,22 +265,13 @@ func (h *Handler) createJobFromRequest(ctx context.Context, user *db.User, req C
 func (h *Handler) createJob(w http.ResponseWriter, r *http.Request) {
 	logger := loggerWithRequest(r)
 
-	userClaims, ok := auth.GetUserFromContext(r.Context())
+	// Get user and active organisation (validates auth and membership)
+	user, _, ok := h.GetActiveOrganisationWithUser(w, r)
 	if !ok {
-		Unauthorised(w, r, "User information not found")
-		return
+		return // Error already written
 	}
 
-	// Auto-create user if they don't exist (handles new signups)
-	user, err := h.DB.GetOrCreateUser(userClaims.UserID, userClaims.Email, nil)
-	if err != nil {
-		if HandlePoolSaturation(w, r, err) {
-			return
-		}
-		logger.Error().Err(err).Str("user_id", userClaims.UserID).Msg("Failed to get or create user")
-		InternalError(w, r, err)
-		return
-	}
+	_ = logger
 
 	var req CreateJobRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -353,24 +335,15 @@ func (h *Handler) createJob(w http.ResponseWriter, r *http.Request) {
 func (h *Handler) getJob(w http.ResponseWriter, r *http.Request, jobID string) {
 	logger := loggerWithRequest(r)
 
-	userClaims, ok := auth.GetUserFromContext(r.Context())
-	if !ok {
-		Unauthorised(w, r, "User information not found")
-		return
+	// Get active organisation (validates auth and membership)
+	orgID := h.GetActiveOrganisation(w, r)
+	if orgID == "" {
+		return // Error already written
 	}
 
-	// Auto-create user if they don't exist (handles new signups)
-	user, err := h.DB.GetOrCreateUser(userClaims.UserID, userClaims.Email, nil)
-	if err != nil {
-		if HandlePoolSaturation(w, r, err) {
-			return
-		}
-		logger.Error().Err(err).Str("user_id", userClaims.UserID).Msg("Failed to get or create user")
-		InternalError(w, r, err)
-		return
-	}
+	_ = logger // logger available for future use
 
-	response, err := h.fetchJobResponse(r.Context(), jobID, user.OrganisationID)
+	response, err := h.fetchJobResponse(r.Context(), jobID, &orgID)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			NotFound(w, r, "Job not found")
@@ -508,18 +481,10 @@ type JobActionRequest struct {
 func (h *Handler) updateJob(w http.ResponseWriter, r *http.Request, jobID string) {
 	logger := loggerWithRequest(r)
 
-	userClaims, ok := auth.GetUserFromContext(r.Context())
-	if !ok {
-		Unauthorised(w, r, "User information not found")
-		return
-	}
-
-	// Auto-create user if they don't exist (handles new signups)
-	user, err := h.DB.GetOrCreateUser(userClaims.UserID, userClaims.Email, nil)
-	if err != nil {
-		logger.Error().Err(err).Str("user_id", userClaims.UserID).Msg("Failed to get or create user")
-		InternalError(w, r, err)
-		return
+	// Get active organisation (validates auth and membership)
+	activeOrgID := h.GetActiveOrganisation(w, r)
+	if activeOrgID == "" {
+		return // Error already written
 	}
 
 	var req JobActionRequest
@@ -528,21 +493,23 @@ func (h *Handler) updateJob(w http.ResponseWriter, r *http.Request, jobID string
 		return
 	}
 
-	// Verify job belongs to user's organisation
-	var orgID string
-	err = h.DB.GetDB().QueryRowContext(r.Context(), `
+	// Verify job belongs to user's active organisation
+	var jobOrgID string
+	err := h.DB.GetDB().QueryRowContext(r.Context(), `
 		SELECT organisation_id FROM jobs WHERE id = $1
-	`, jobID).Scan(&orgID)
+	`, jobID).Scan(&jobOrgID)
 
 	if err != nil {
 		NotFound(w, r, "Job not found")
 		return
 	}
 
-	if user.OrganisationID == nil || *user.OrganisationID != orgID {
+	if activeOrgID != jobOrgID {
 		Unauthorised(w, r, "Job access denied")
 		return
 	}
+
+	_ = logger // logger available for future use
 
 	resultJobID := jobID
 	switch req.Action {
@@ -591,35 +558,29 @@ func (h *Handler) updateJob(w http.ResponseWriter, r *http.Request, jobID string
 func (h *Handler) cancelJob(w http.ResponseWriter, r *http.Request, jobID string) {
 	logger := loggerWithRequest(r)
 
-	userClaims, ok := auth.GetUserFromContext(r.Context())
-	if !ok {
-		Unauthorised(w, r, "User information not found")
-		return
+	// Get active organisation (validates auth and membership)
+	activeOrgID := h.GetActiveOrganisation(w, r)
+	if activeOrgID == "" {
+		return // Error already written
 	}
 
-	// Auto-create user if they don't exist (handles new signups)
-	user, err := h.DB.GetOrCreateUser(userClaims.UserID, userClaims.Email, nil)
-	if err != nil {
-		logger.Error().Err(err).Str("user_id", userClaims.UserID).Msg("Failed to get or create user")
-		InternalError(w, r, err)
-		return
-	}
-
-	// Verify job belongs to user's organisation
-	var orgID string
-	err = h.DB.GetDB().QueryRowContext(r.Context(), `
+	// Verify job belongs to user's active organisation
+	var jobOrgID string
+	err := h.DB.GetDB().QueryRowContext(r.Context(), `
 		SELECT organisation_id FROM jobs WHERE id = $1
-	`, jobID).Scan(&orgID)
+	`, jobID).Scan(&jobOrgID)
 
 	if err != nil {
 		NotFound(w, r, "Job not found")
 		return
 	}
 
-	if user.OrganisationID == nil || *user.OrganisationID != orgID {
+	if activeOrgID != jobOrgID {
 		Unauthorised(w, r, "Job access denied")
 		return
 	}
+
+	_ = logger // logger available for future use
 
 	err = h.JobsManager.CancelJob(r.Context(), jobID)
 	if err != nil {
@@ -713,35 +674,24 @@ func parseTaskQueryParams(r *http.Request) TaskQueryParams {
 // validateJobAccess validates user authentication and job access permissions
 // Returns the user if validation succeeds, or writes HTTP error and returns nil
 func (h *Handler) validateJobAccess(w http.ResponseWriter, r *http.Request, jobID string) *db.User {
-	logger := loggerWithRequest(r)
-
-	// Extract user claims from context
-	userClaims, ok := auth.GetUserFromContext(r.Context())
+	// Get user and active organisation (validates auth and membership)
+	user, activeOrgID, ok := h.GetActiveOrganisationWithUser(w, r)
 	if !ok {
-		Unauthorised(w, r, "User information not found")
-		return nil
+		return nil // Error already written
 	}
 
-	// Auto-create user if they don't exist (handles new signups)
-	user, err := h.DB.GetOrCreateUser(userClaims.UserID, userClaims.Email, nil)
-	if err != nil {
-		logger.Error().Err(err).Str("user_id", userClaims.UserID).Msg("Failed to get or create user")
-		InternalError(w, r, err)
-		return nil
-	}
-
-	// Verify job belongs to user's organisation
-	var orgID string
-	err = h.DB.GetDB().QueryRowContext(r.Context(), `
+	// Verify job belongs to user's active organisation
+	var jobOrgID string
+	err := h.DB.GetDB().QueryRowContext(r.Context(), `
 		SELECT organisation_id FROM jobs WHERE id = $1
-	`, jobID).Scan(&orgID)
+	`, jobID).Scan(&jobOrgID)
 
 	if err != nil {
 		NotFound(w, r, "Job not found")
 		return nil
 	}
 
-	if user.OrganisationID == nil || *user.OrganisationID != orgID {
+	if activeOrgID != jobOrgID {
 		Unauthorised(w, r, "Job access denied")
 		return nil
 	}

--- a/internal/api/jobs_create_test.go
+++ b/internal/api/jobs_create_test.go
@@ -36,6 +36,7 @@ func TestCreateJobIntegration(t *testing.T) {
 					OrganisationID: &orgID,
 				}
 				mockDB.On("GetOrCreateUser", "test-user-123", "test@example.com", (*string)(nil)).Return(user, nil)
+				mockDB.On("GetEffectiveOrganisationID", mock.AnythingOfType("*db.User")).Return(orgID)
 
 				createdJob := &jobs.Job{
 					ID:             "job-456",
@@ -93,6 +94,7 @@ func TestCreateJobIntegration(t *testing.T) {
 					OrganisationID: &orgID,
 				}
 				mockDB.On("GetOrCreateUser", "test-user-123", "test@example.com", (*string)(nil)).Return(user, nil)
+				mockDB.On("GetEffectiveOrganisationID", mock.AnythingOfType("*db.User")).Return(orgID)
 
 				createdJob := &jobs.Job{
 					ID:             "job-789",
@@ -138,6 +140,7 @@ func TestCreateJobIntegration(t *testing.T) {
 					OrganisationID: &orgID,
 				}
 				mockDB.On("GetOrCreateUser", "test-user-123", "test@example.com", (*string)(nil)).Return(user, nil)
+				mockDB.On("GetEffectiveOrganisationID", mock.AnythingOfType("*db.User")).Return(orgID)
 				// JobManager should not be called
 			},
 			expectedStatus: http.StatusBadRequest,
@@ -184,6 +187,7 @@ func TestCreateJobIntegration(t *testing.T) {
 					OrganisationID: &orgID,
 				}
 				mockDB.On("GetOrCreateUser", "test-user-123", "test@example.com", (*string)(nil)).Return(user, nil)
+				mockDB.On("GetEffectiveOrganisationID", mock.AnythingOfType("*db.User")).Return(orgID)
 				jm.On("CreateJob", mock.AnythingOfType("*context.valueCtx"), mock.AnythingOfType("*jobs.JobOptions")).Return(nil, assert.AnError)
 			},
 			expectedStatus: http.StatusInternalServerError,

--- a/internal/api/jobs_retrieval_test.go
+++ b/internal/api/jobs_retrieval_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/Harvey-AU/blue-banded-bee/internal/db"
 	"github.com/Harvey-AU/blue-banded-bee/internal/jobs"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
+	testifymock "github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -177,6 +177,7 @@ func TestGetJobIntegration(t *testing.T) {
 				OrganisationID: &tt.orgID,
 			}
 			mockDB.On("GetOrCreateUser", tt.userID, "test@example.com", (*string)(nil)).Return(user, nil)
+			mockDB.On("GetEffectiveOrganisationID", testifymock.AnythingOfType("*db.User")).Return(tt.orgID)
 
 			// Mock GetDB to return our sqlmock instance
 			mockDB.On("GetDB").Return(mockSQL)
@@ -241,7 +242,7 @@ func TestUpdateJobIntegration(t *testing.T) {
 			},
 			setupMocks: func(jm *MockJobManager) {
 				// Mock successful cancel
-				jm.On("CancelJob", mock.AnythingOfType("*context.valueCtx"), "job-456").Return(nil)
+				jm.On("CancelJob", testifymock.AnythingOfType("*context.valueCtx"), "job-456").Return(nil)
 
 				// Mock GetJobStatus for response
 				job := &jobs.Job{
@@ -256,7 +257,7 @@ func TestUpdateJobIntegration(t *testing.T) {
 					CreatedAt:      time.Now().UTC(),
 					CompletedAt:    time.Now().UTC(),
 				}
-				jm.On("GetJobStatus", mock.AnythingOfType("*context.valueCtx"), "job-456").Return(job, nil)
+				jm.On("GetJobStatus", testifymock.AnythingOfType("*context.valueCtx"), "job-456").Return(job, nil)
 			},
 			expectedStatus: http.StatusOK,
 			checkResponse: func(t *testing.T, rec *httptest.ResponseRecorder) {
@@ -401,6 +402,7 @@ func TestUpdateJobIntegration(t *testing.T) {
 				OrganisationID: &tt.orgID,
 			}
 			mockDB.On("GetOrCreateUser", tt.userID, "test@example.com", (*string)(nil)).Return(user, nil)
+			mockDB.On("GetEffectiveOrganisationID", testifymock.AnythingOfType("*db.User")).Return(tt.orgID)
 
 			// Mock GetDB only for tests that reach SQL queries
 			if tt.name != "invalid_json_payload" {
@@ -478,7 +480,7 @@ func TestCancelJobIntegration(t *testing.T) {
 			},
 			setupMocks: func(jm *MockJobManager) {
 				// Mock successful cancellation
-				jm.On("CancelJob", mock.AnythingOfType("*context.valueCtx"), "job-123").Return(nil)
+				jm.On("CancelJob", testifymock.AnythingOfType("*context.valueCtx"), "job-123").Return(nil)
 			},
 			expectedStatus: http.StatusOK,
 			checkResponse: func(t *testing.T, rec *httptest.ResponseRecorder) {
@@ -529,7 +531,7 @@ func TestCancelJobIntegration(t *testing.T) {
 			},
 			setupMocks: func(jm *MockJobManager) {
 				// Mock CancelJob failure
-				jm.On("CancelJob", mock.AnythingOfType("*context.valueCtx"), "job-123").Return(assert.AnError)
+				jm.On("CancelJob", testifymock.AnythingOfType("*context.valueCtx"), "job-123").Return(assert.AnError)
 			},
 			expectedStatus: http.StatusInternalServerError,
 			checkResponse: func(t *testing.T, rec *httptest.ResponseRecorder) {
@@ -570,6 +572,7 @@ func TestCancelJobIntegration(t *testing.T) {
 					OrganisationID: &tt.orgID,
 				}
 				mockDB.On("GetOrCreateUser", tt.userID, "test@example.com", (*string)(nil)).Return(user, nil)
+				mockDB.On("GetEffectiveOrganisationID", testifymock.AnythingOfType("*db.User")).Return(tt.orgID)
 				mockDB.On("GetDB").Return(mockSQL)
 			}
 
@@ -759,6 +762,7 @@ func TestGetJobTasksIntegration(t *testing.T) {
 				OrganisationID: &tt.orgID,
 			}
 			mockDB.On("GetOrCreateUser", tt.userID, "test@example.com", (*string)(nil)).Return(user, nil)
+			mockDB.On("GetEffectiveOrganisationID", testifymock.AnythingOfType("*db.User")).Return(tt.orgID)
 
 			// Mock GetDB to return our sqlmock instance
 			mockDB.On("GetDB").Return(mockSQL)

--- a/internal/api/organisations.go
+++ b/internal/api/organisations.go
@@ -1,0 +1,127 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/Harvey-AU/blue-banded-bee/internal/auth"
+)
+
+// OrganisationsHandler handles GET /v1/organisations
+func (h *Handler) OrganisationsHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		MethodNotAllowed(w, r)
+		return
+	}
+	h.listUserOrganisations(w, r)
+}
+
+// listUserOrganisations returns all organisations the user is a member of
+func (h *Handler) listUserOrganisations(w http.ResponseWriter, r *http.Request) {
+	userClaims, ok := auth.GetUserFromContext(r.Context())
+	if !ok {
+		Unauthorised(w, r, "User information not found")
+		return
+	}
+
+	// Ensure user exists in database
+	_, err := h.DB.GetOrCreateUser(userClaims.UserID, userClaims.Email, nil)
+	if err != nil {
+		InternalError(w, r, err)
+		return
+	}
+
+	orgs, err := h.DB.ListUserOrganisations(userClaims.UserID)
+	if err != nil {
+		InternalError(w, r, err)
+		return
+	}
+
+	// Format organisations for response
+	type OrgResponse struct {
+		ID        string `json:"id"`
+		Name      string `json:"name"`
+		CreatedAt string `json:"created_at"`
+	}
+
+	formattedOrgs := make([]OrgResponse, len(orgs))
+	for i, org := range orgs {
+		formattedOrgs[i] = OrgResponse{
+			ID:        org.ID,
+			Name:      org.Name,
+			CreatedAt: org.CreatedAt.Format(time.RFC3339),
+		}
+	}
+
+	WriteSuccess(w, r, map[string]interface{}{
+		"organisations": formattedOrgs,
+	}, "Organisations retrieved successfully")
+}
+
+// SwitchOrganisationHandler handles POST /v1/organisations/switch
+func (h *Handler) SwitchOrganisationHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		MethodNotAllowed(w, r)
+		return
+	}
+	h.switchOrganisation(w, r)
+}
+
+// SwitchOrganisationRequest represents the request to switch active organisation
+type SwitchOrganisationRequest struct {
+	OrganisationID string `json:"organisation_id"`
+}
+
+func (h *Handler) switchOrganisation(w http.ResponseWriter, r *http.Request) {
+	userClaims, ok := auth.GetUserFromContext(r.Context())
+	if !ok {
+		Unauthorised(w, r, "User information not found")
+		return
+	}
+
+	var req SwitchOrganisationRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		BadRequest(w, r, "Invalid JSON request body")
+		return
+	}
+
+	if req.OrganisationID == "" {
+		BadRequest(w, r, "organisation_id is required")
+		return
+	}
+
+	// Validate membership
+	valid, err := h.DB.ValidateOrganisationMembership(userClaims.UserID, req.OrganisationID)
+	if err != nil {
+		InternalError(w, r, err)
+		return
+	}
+	if !valid {
+		Forbidden(w, r, "Not a member of this organisation")
+		return
+	}
+
+	// Set active organisation
+	err = h.DB.SetActiveOrganisation(userClaims.UserID, req.OrganisationID)
+	if err != nil {
+		InternalError(w, r, err)
+		return
+	}
+
+	// Get organisation details for response
+	org, err := h.DB.GetOrganisation(req.OrganisationID)
+	if err != nil {
+		InternalError(w, r, err)
+		return
+	}
+
+	WriteSuccess(w, r, map[string]interface{}{
+		"organisation": map[string]interface{}{
+			"id":         org.ID,
+			"name":       org.Name,
+			"created_at": org.CreatedAt.Format(time.RFC3339),
+			"updated_at": org.UpdatedAt.Format(time.RFC3339),
+		},
+	}, "Organisation switched successfully")
+}

--- a/internal/api/schedulers.go
+++ b/internal/api/schedulers.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Harvey-AU/blue-banded-bee/internal/auth"
 	"github.com/Harvey-AU/blue-banded-bee/internal/db"
 	"github.com/Harvey-AU/blue-banded-bee/internal/util"
 	"github.com/google/uuid"
@@ -97,23 +96,13 @@ func (h *Handler) SchedulerHandler(w http.ResponseWriter, r *http.Request) {
 func (h *Handler) createScheduler(w http.ResponseWriter, r *http.Request) {
 	logger := loggerWithRequest(r)
 
-	userClaims, ok := auth.GetUserFromContext(r.Context())
-	if !ok {
-		Unauthorised(w, r, "User information not found")
-		return
+	// Get active organisation (validates auth and membership)
+	orgID := h.GetActiveOrganisation(w, r)
+	if orgID == "" {
+		return // Error already written
 	}
 
-	user, err := h.DB.GetOrCreateUser(userClaims.UserID, userClaims.Email, nil)
-	if err != nil {
-		logger.Error().Err(err).Str("user_id", userClaims.UserID).Msg("Failed to get or create user")
-		InternalError(w, r, err)
-		return
-	}
-
-	if user.OrganisationID == nil {
-		BadRequest(w, r, "User must belong to an organisation")
-		return
-	}
+	_ = logger
 
 	var req SchedulerRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -140,7 +129,7 @@ func (h *Handler) createScheduler(w http.ResponseWriter, r *http.Request) {
 
 	// Get or create domain
 	var domainID int
-	err = h.DB.GetDB().QueryRowContext(r.Context(), `
+	err := h.DB.GetDB().QueryRowContext(r.Context(), `
 		INSERT INTO domains(name) VALUES($1)
 		ON CONFLICT (name) DO UPDATE SET name=EXCLUDED.name
 		RETURNING id
@@ -156,7 +145,7 @@ func (h *Handler) createScheduler(w http.ResponseWriter, r *http.Request) {
 	err = h.DB.GetDB().QueryRowContext(r.Context(), `
 		SELECT id FROM schedulers
 		WHERE domain_id = $1 AND organisation_id = $2
-	`, domainID, *user.OrganisationID).Scan(&existingID)
+	`, domainID, orgID).Scan(&existingID)
 	if err == nil {
 		BadRequest(w, r, "Scheduler already exists for this domain")
 		return
@@ -198,7 +187,7 @@ func (h *Handler) createScheduler(w http.ResponseWriter, r *http.Request) {
 	scheduler := &db.Scheduler{
 		ID:                    uuid.New().String(),
 		DomainID:              domainID,
-		OrganisationID:        *user.OrganisationID,
+		OrganisationID:        orgID,
 		ScheduleIntervalHours: *req.ScheduleIntervalHours,
 		NextRunAt:             now.Add(time.Duration(*req.ScheduleIntervalHours) * time.Hour),
 		IsEnabled:             isEnabled,
@@ -226,27 +215,15 @@ func (h *Handler) createScheduler(w http.ResponseWriter, r *http.Request) {
 func (h *Handler) listSchedulers(w http.ResponseWriter, r *http.Request) {
 	logger := loggerWithRequest(r)
 
-	userClaims, ok := auth.GetUserFromContext(r.Context())
-	if !ok {
-		Unauthorised(w, r, "User information not found")
-		return
+	// Get active organisation (validates auth and membership)
+	orgID := h.GetActiveOrganisation(w, r)
+	if orgID == "" {
+		return // Error already written
 	}
 
-	user, err := h.DB.GetOrCreateUser(userClaims.UserID, userClaims.Email, nil)
+	schedulers, err := h.DB.ListSchedulers(r.Context(), orgID)
 	if err != nil {
-		logger.Error().Err(err).Str("user_id", userClaims.UserID).Msg("Failed to get or create user")
-		InternalError(w, r, err)
-		return
-	}
-
-	if user.OrganisationID == nil {
-		WriteSuccess(w, r, []SchedulerResponse{}, "No schedulers found")
-		return
-	}
-
-	schedulers, err := h.DB.ListSchedulers(r.Context(), *user.OrganisationID)
-	if err != nil {
-		logger.Error().Err(err).Str("organisation_id", *user.OrganisationID).Msg("Failed to list schedulers")
+		logger.Error().Err(err).Str("organisation_id", orgID).Msg("Failed to list schedulers")
 		InternalError(w, r, err)
 		return
 	}
@@ -289,17 +266,10 @@ func (h *Handler) listSchedulers(w http.ResponseWriter, r *http.Request) {
 func (h *Handler) getScheduler(w http.ResponseWriter, r *http.Request, schedulerID string) {
 	logger := loggerWithRequest(r)
 
-	userClaims, ok := auth.GetUserFromContext(r.Context())
-	if !ok {
-		Unauthorised(w, r, "User information not found")
-		return
-	}
-
-	user, err := h.DB.GetOrCreateUser(userClaims.UserID, userClaims.Email, nil)
-	if err != nil {
-		logger.Error().Err(err).Str("user_id", userClaims.UserID).Msg("Failed to get or create user")
-		InternalError(w, r, err)
-		return
+	// Get active organisation (validates auth and membership)
+	orgID := h.GetActiveOrganisation(w, r)
+	if orgID == "" {
+		return // Error already written
 	}
 
 	scheduler, err := h.DB.GetScheduler(r.Context(), schedulerID)
@@ -313,7 +283,7 @@ func (h *Handler) getScheduler(w http.ResponseWriter, r *http.Request, scheduler
 		return
 	}
 
-	if user.OrganisationID == nil || *user.OrganisationID != scheduler.OrganisationID {
+	if orgID != scheduler.OrganisationID {
 		Unauthorised(w, r, "Scheduler access denied")
 		return
 	}
@@ -335,17 +305,10 @@ func (h *Handler) getScheduler(w http.ResponseWriter, r *http.Request, scheduler
 func (h *Handler) updateScheduler(w http.ResponseWriter, r *http.Request, schedulerID string) {
 	logger := loggerWithRequest(r)
 
-	userClaims, ok := auth.GetUserFromContext(r.Context())
-	if !ok {
-		Unauthorised(w, r, "User information not found")
-		return
-	}
-
-	user, err := h.DB.GetOrCreateUser(userClaims.UserID, userClaims.Email, nil)
-	if err != nil {
-		logger.Error().Err(err).Str("user_id", userClaims.UserID).Msg("Failed to get or create user")
-		InternalError(w, r, err)
-		return
+	// Get active organisation (validates auth and membership)
+	orgID := h.GetActiveOrganisation(w, r)
+	if orgID == "" {
+		return // Error already written
 	}
 
 	scheduler, err := h.DB.GetScheduler(r.Context(), schedulerID)
@@ -359,7 +322,7 @@ func (h *Handler) updateScheduler(w http.ResponseWriter, r *http.Request, schedu
 		return
 	}
 
-	if user.OrganisationID == nil || *user.OrganisationID != scheduler.OrganisationID {
+	if orgID != scheduler.OrganisationID {
 		Unauthorised(w, r, "Scheduler access denied")
 		return
 	}
@@ -442,17 +405,10 @@ func (h *Handler) updateScheduler(w http.ResponseWriter, r *http.Request, schedu
 func (h *Handler) deleteScheduler(w http.ResponseWriter, r *http.Request, schedulerID string) {
 	logger := loggerWithRequest(r)
 
-	userClaims, ok := auth.GetUserFromContext(r.Context())
-	if !ok {
-		Unauthorised(w, r, "User information not found")
-		return
-	}
-
-	user, err := h.DB.GetOrCreateUser(userClaims.UserID, userClaims.Email, nil)
-	if err != nil {
-		logger.Error().Err(err).Str("user_id", userClaims.UserID).Msg("Failed to get or create user")
-		InternalError(w, r, err)
-		return
+	// Get active organisation (validates auth and membership)
+	orgID := h.GetActiveOrganisation(w, r)
+	if orgID == "" {
+		return // Error already written
 	}
 
 	scheduler, err := h.DB.GetScheduler(r.Context(), schedulerID)
@@ -466,7 +422,7 @@ func (h *Handler) deleteScheduler(w http.ResponseWriter, r *http.Request, schedu
 		return
 	}
 
-	if user.OrganisationID == nil || *user.OrganisationID != scheduler.OrganisationID {
+	if orgID != scheduler.OrganisationID {
 		Unauthorised(w, r, "Scheduler access denied")
 		return
 	}
@@ -488,17 +444,10 @@ func (h *Handler) deleteScheduler(w http.ResponseWriter, r *http.Request, schedu
 func (h *Handler) getSchedulerJobs(w http.ResponseWriter, r *http.Request, schedulerID string) {
 	logger := loggerWithRequest(r)
 
-	userClaims, ok := auth.GetUserFromContext(r.Context())
-	if !ok {
-		Unauthorised(w, r, "User information not found")
-		return
-	}
-
-	user, err := h.DB.GetOrCreateUser(userClaims.UserID, userClaims.Email, nil)
-	if err != nil {
-		logger.Error().Err(err).Str("user_id", userClaims.UserID).Msg("Failed to get or create user")
-		InternalError(w, r, err)
-		return
+	// Get active organisation (validates auth and membership)
+	orgID := h.GetActiveOrganisation(w, r)
+	if orgID == "" {
+		return // Error already written
 	}
 
 	scheduler, err := h.DB.GetScheduler(r.Context(), schedulerID)
@@ -512,7 +461,7 @@ func (h *Handler) getSchedulerJobs(w http.ResponseWriter, r *http.Request, sched
 		return
 	}
 
-	if user.OrganisationID == nil || *user.OrganisationID != scheduler.OrganisationID {
+	if orgID != scheduler.OrganisationID {
 		Unauthorised(w, r, "Scheduler access denied")
 		return
 	}
@@ -532,19 +481,19 @@ func (h *Handler) getSchedulerJobs(w http.ResponseWriter, r *http.Request, sched
 		}
 	}
 
-	// Query jobs for this scheduler
+	// Query jobs for this scheduler - SECURITY FIX: Added organisation_id filter
 	query := `
 		SELECT j.id, d.name as domain, j.status, j.total_tasks, j.completed_tasks,
 		       j.failed_tasks, j.skipped_tasks, j.progress, j.created_at,
 		       j.started_at, j.completed_at
 		FROM jobs j
 		JOIN domains d ON j.domain_id = d.id
-		WHERE j.scheduler_id = $1
+		WHERE j.scheduler_id = $1 AND j.organisation_id = $2
 		ORDER BY j.created_at DESC
-		LIMIT $2 OFFSET $3
+		LIMIT $3 OFFSET $4
 	`
 
-	rows, err := h.DB.GetDB().QueryContext(r.Context(), query, schedulerID, limit, offset)
+	rows, err := h.DB.GetDB().QueryContext(r.Context(), query, schedulerID, orgID, limit, offset)
 	if err != nil {
 		logger.Error().Err(err).Str("scheduler_id", schedulerID).Msg("Failed to query scheduler jobs")
 		InternalError(w, r, err)
@@ -580,11 +529,11 @@ func (h *Handler) getSchedulerJobs(w http.ResponseWriter, r *http.Request, sched
 		jobs = append(jobs, job)
 	}
 
-	// Get total count
+	// Get total count - SECURITY FIX: Added organisation_id filter
 	var total int
 	err = h.DB.GetDB().QueryRowContext(r.Context(), `
-		SELECT COUNT(*) FROM jobs WHERE scheduler_id = $1
-	`, schedulerID).Scan(&total)
+		SELECT COUNT(*) FROM jobs WHERE scheduler_id = $1 AND organisation_id = $2
+	`, schedulerID, orgID).Scan(&total)
 	if err != nil {
 		logger.Error().Err(err).Str("scheduler_id", schedulerID).Msg("Failed to count scheduler jobs")
 		InternalError(w, r, err)

--- a/internal/api/share_links_test.go
+++ b/internal/api/share_links_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/Harvey-AU/blue-banded-bee/internal/auth"
 	"github.com/Harvey-AU/blue-banded-bee/internal/db"
 	"github.com/stretchr/testify/assert"
+	testifymock "github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -61,6 +62,7 @@ func TestCreateJobShareLinkCreatesNewToken(t *testing.T) {
 	}
 
 	mockDB.On("GetOrCreateUser", user.ID, user.Email, (*string)(nil)).Return(user, nil)
+	mockDB.On("GetEffectiveOrganisationID", testifymock.AnythingOfType("*db.User")).Return(orgID)
 	mockDB.On("GetDB").Return(sqlDB)
 	mock.ExpectQuery(`SELECT organisation_id FROM jobs WHERE id = \$1`).
 		WithArgs("job-123").
@@ -114,6 +116,7 @@ func TestCreateJobShareLinkReturnsExistingToken(t *testing.T) {
 	}
 
 	mockDB.On("GetOrCreateUser", user.ID, user.Email, (*string)(nil)).Return(user, nil)
+	mockDB.On("GetEffectiveOrganisationID", testifymock.AnythingOfType("*db.User")).Return(orgID)
 	mockDB.On("GetDB").Return(sqlDB)
 	mock.ExpectQuery(`SELECT organisation_id FROM jobs WHERE id = \$1`).
 		WithArgs("job-456").
@@ -162,6 +165,7 @@ func TestGetJobShareLinkSuccess(t *testing.T) {
 	}
 
 	mockDB.On("GetOrCreateUser", user.ID, user.Email, (*string)(nil)).Return(user, nil)
+	mockDB.On("GetEffectiveOrganisationID", testifymock.AnythingOfType("*db.User")).Return(orgID)
 	mockDB.On("GetDB").Return(sqlDB)
 	mock.ExpectQuery(`SELECT organisation_id FROM jobs WHERE id = \$1`).
 		WithArgs("job-222").
@@ -211,6 +215,7 @@ func TestGetJobShareLinkNotFound(t *testing.T) {
 	}
 
 	mockDB.On("GetOrCreateUser", user.ID, user.Email, (*string)(nil)).Return(user, nil)
+	mockDB.On("GetEffectiveOrganisationID", testifymock.AnythingOfType("*db.User")).Return(orgID)
 	mockDB.On("GetDB").Return(sqlDB)
 	mock.ExpectQuery(`SELECT organisation_id FROM jobs WHERE id = \$1`).
 		WithArgs("job-333").
@@ -254,6 +259,7 @@ func TestRevokeJobShareLinkSuccess(t *testing.T) {
 	}
 
 	mockDB.On("GetOrCreateUser", user.ID, user.Email, (*string)(nil)).Return(user, nil)
+	mockDB.On("GetEffectiveOrganisationID", testifymock.AnythingOfType("*db.User")).Return(orgID)
 	mockDB.On("GetDB").Return(sqlDB)
 	mock.ExpectQuery(`SELECT organisation_id FROM jobs WHERE id = \$1`).
 		WithArgs("job-001").
@@ -300,6 +306,7 @@ func TestRevokeJobShareLinkNotFound(t *testing.T) {
 	}
 
 	mockDB.On("GetOrCreateUser", user.ID, user.Email, (*string)(nil)).Return(user, nil)
+	mockDB.On("GetEffectiveOrganisationID", testifymock.AnythingOfType("*db.User")).Return(orgID)
 	mockDB.On("GetDB").Return(sqlDB)
 	mock.ExpectQuery(`SELECT organisation_id FROM jobs WHERE id = \$1`).
 		WithArgs("job-404").

--- a/internal/api/test_mocks.go
+++ b/internal/api/test_mocks.go
@@ -254,6 +254,29 @@ func (m *MockDBClient) GetDomainNames(ctx context.Context, domainIDs []int) (map
 	return args.Get(0).(map[int]string), args.Error(1)
 }
 
+func (m *MockDBClient) ListUserOrganisations(userID string) ([]db.UserOrganisation, error) {
+	args := m.Called(userID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]db.UserOrganisation), args.Error(1)
+}
+
+func (m *MockDBClient) ValidateOrganisationMembership(userID, organisationID string) (bool, error) {
+	args := m.Called(userID, organisationID)
+	return args.Bool(0), args.Error(1)
+}
+
+func (m *MockDBClient) SetActiveOrganisation(userID, organisationID string) error {
+	args := m.Called(userID, organisationID)
+	return args.Error(0)
+}
+
+func (m *MockDBClient) GetEffectiveOrganisationID(user *db.User) string {
+	args := m.Called(user)
+	return args.String(0)
+}
+
 // Test helpers
 func createTestHandler() (*Handler, *MockDBClient, *MockJobManager) {
 	mockDB := new(MockDBClient)

--- a/internal/api/webhook_endpoints_test.go
+++ b/internal/api/webhook_endpoints_test.go
@@ -44,6 +44,7 @@ func TestWebflowWebhookIntegration(t *testing.T) {
 					OrganisationID: stringPtr("webhook-org-456"),
 				}
 				mockDB.On("GetUserByWebhookToken", "test-webhook-token-123").Return(user, nil)
+				mockDB.On("GetEffectiveOrganisationID", mock.AnythingOfType("*db.User")).Return("webhook-org-456")
 
 				// Mock successful job creation
 				createdJob := &jobs.Job{
@@ -237,6 +238,7 @@ func TestWebflowWebhookEdgeCases(t *testing.T) {
 					OrganisationID: stringPtr("webhook-org-456"),
 				}
 				mockDB.On("GetUserByWebhookToken", "test-token").Return(user, nil)
+				mockDB.On("GetEffectiveOrganisationID", mock.AnythingOfType("*db.User")).Return("webhook-org-456")
 
 				// Mock job creation failure
 				jm.On("CreateJob", mock.Anything, mock.AnythingOfType("*jobs.JobOptions")).Return(nil, assert.AnError)

--- a/internal/db/users.go
+++ b/internal/db/users.go
@@ -12,12 +12,13 @@ import (
 
 // User represents a user in the system
 type User struct {
-	ID             string    `json:"id"`
-	Email          string    `json:"email"`
-	FullName       *string   `json:"full_name,omitempty"`
-	OrganisationID *string   `json:"organisation_id,omitempty"`
-	CreatedAt      time.Time `json:"created_at"`
-	UpdatedAt      time.Time `json:"updated_at"`
+	ID                   string    `json:"id"`
+	Email                string    `json:"email"`
+	FullName             *string   `json:"full_name,omitempty"`
+	OrganisationID       *string   `json:"organisation_id,omitempty"`
+	ActiveOrganisationID *string   `json:"active_organisation_id,omitempty"`
+	CreatedAt            time.Time `json:"created_at"`
+	UpdatedAt            time.Time `json:"updated_at"`
 }
 
 // Organisation represents an organisation in the system
@@ -33,14 +34,14 @@ func (db *DB) GetUser(userID string) (*User, error) {
 	user := &User{}
 
 	query := `
-		SELECT id, email, full_name, organisation_id, created_at, updated_at
+		SELECT id, email, full_name, organisation_id, active_organisation_id, created_at, updated_at
 		FROM users
 		WHERE id = $1
 	`
 
 	err := db.client.QueryRow(query, userID).Scan(
 		&user.ID, &user.Email, &user.FullName, &user.OrganisationID,
-		&user.CreatedAt, &user.UpdatedAt,
+		&user.ActiveOrganisationID, &user.CreatedAt, &user.UpdatedAt,
 	)
 	if err != nil {
 		if err == sql.ErrNoRows {
@@ -57,14 +58,14 @@ func (db *DB) GetUserByWebhookToken(webhookToken string) (*User, error) {
 	user := &User{}
 
 	query := `
-		SELECT id, email, full_name, organisation_id, created_at, updated_at
+		SELECT id, email, full_name, organisation_id, active_organisation_id, created_at, updated_at
 		FROM users
 		WHERE webhook_token = $1
 	`
 
 	err := db.client.QueryRow(query, webhookToken).Scan(
 		&user.ID, &user.Email, &user.FullName, &user.OrganisationID,
-		&user.CreatedAt, &user.UpdatedAt,
+		&user.ActiveOrganisationID, &user.CreatedAt, &user.UpdatedAt,
 	)
 	if err != nil {
 		if err == sql.ErrNoRows {
@@ -303,7 +304,7 @@ func (db *DB) GetOrganisation(organisationID string) (*Organisation, error) {
 
 func (db *DB) GetOrganisationMembers(organisationID string) ([]*User, error) {
 	query := `
-		SELECT id, email, full_name, organisation_id, created_at, updated_at
+		SELECT id, email, full_name, organisation_id, active_organisation_id, created_at, updated_at
 		FROM users
 		WHERE organisation_id = $1
 		ORDER BY created_at ASC
@@ -320,7 +321,7 @@ func (db *DB) GetOrganisationMembers(organisationID string) ([]*User, error) {
 		user := &User{}
 		err := rows.Scan(
 			&user.ID, &user.Email, &user.FullName, &user.OrganisationID,
-			&user.CreatedAt, &user.UpdatedAt,
+			&user.ActiveOrganisationID, &user.CreatedAt, &user.UpdatedAt,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to scan user: %w", err)
@@ -406,17 +407,18 @@ func (db *DB) CreateUser(userID, email string, fullName *string, orgName string)
 		}
 	}
 
-	// Create user with organisation reference
+	// Create user with organisation reference and active organisation
 	user := &User{
-		ID:             userID,
-		Email:          email,
-		FullName:       fullName,
-		OrganisationID: &org.ID,
+		ID:                   userID,
+		Email:                email,
+		FullName:             fullName,
+		OrganisationID:       &org.ID,
+		ActiveOrganisationID: &org.ID,
 	}
 
 	userQuery := `
-		INSERT INTO users (id, email, full_name, organisation_id, created_at, updated_at)
-		VALUES ($1, $2, $3, $4, NOW(), NOW())
+		INSERT INTO users (id, email, full_name, organisation_id, active_organisation_id, created_at, updated_at)
+		VALUES ($1, $2, $3, $4, $4, NOW(), NOW())
 		RETURNING created_at, updated_at
 	`
 
@@ -425,6 +427,18 @@ func (db *DB) CreateUser(userID, email string, fullName *string, orgName string)
 	)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create user: %w", err)
+	}
+
+	// Add user to organisation_members table
+	memberQuery := `
+		INSERT INTO organisation_members (user_id, organisation_id, created_at)
+		VALUES ($1, $2, NOW())
+		ON CONFLICT (user_id, organisation_id) DO NOTHING
+	`
+
+	_, err = tx.Exec(memberQuery, user.ID, org.ID)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to add organisation membership: %w", err)
 	}
 
 	// Commit transaction
@@ -439,4 +453,132 @@ func (db *DB) CreateUser(userID, email string, fullName *string, orgName string)
 		Msg("Created new user with organisation")
 
 	return user, org, nil
+}
+
+// UserOrganisation represents an organisation a user belongs to
+type UserOrganisation struct {
+	ID        string    `json:"id"`
+	Name      string    `json:"name"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+// ListUserOrganisations returns all organisations a user is a member of
+func (db *DB) ListUserOrganisations(userID string) ([]UserOrganisation, error) {
+	query := `
+		SELECT o.id, o.name, o.created_at
+		FROM organisations o
+		INNER JOIN organisation_members om ON o.id = om.organisation_id
+		WHERE om.user_id = $1
+		ORDER BY o.name
+	`
+
+	rows, err := db.client.Query(query, userID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list user organisations: %w", err)
+	}
+	defer rows.Close()
+
+	var orgs []UserOrganisation
+	for rows.Next() {
+		var org UserOrganisation
+		if err := rows.Scan(&org.ID, &org.Name, &org.CreatedAt); err != nil {
+			return nil, fmt.Errorf("failed to scan organisation: %w", err)
+		}
+		orgs = append(orgs, org)
+	}
+
+	if err = rows.Err(); err != nil {
+		return nil, fmt.Errorf("failed to iterate organisation rows: %w", err)
+	}
+
+	return orgs, nil
+}
+
+// ValidateOrganisationMembership checks if a user is a member of an organisation
+func (db *DB) ValidateOrganisationMembership(userID, organisationID string) (bool, error) {
+	query := `
+		SELECT EXISTS(
+			SELECT 1 FROM organisation_members
+			WHERE user_id = $1 AND organisation_id = $2
+		)
+	`
+
+	var exists bool
+	err := db.client.QueryRow(query, userID, organisationID).Scan(&exists)
+	if err != nil {
+		return false, fmt.Errorf("failed to validate organisation membership: %w", err)
+	}
+
+	return exists, nil
+}
+
+// SetActiveOrganisation sets the user's active organisation
+func (db *DB) SetActiveOrganisation(userID, organisationID string) error {
+	// First validate membership
+	isMember, err := db.ValidateOrganisationMembership(userID, organisationID)
+	if err != nil {
+		return err
+	}
+	if !isMember {
+		return fmt.Errorf("user is not a member of organisation")
+	}
+
+	query := `
+		UPDATE users
+		SET active_organisation_id = $2, updated_at = NOW()
+		WHERE id = $1
+	`
+
+	result, err := db.client.Exec(query, userID, organisationID)
+	if err != nil {
+		return fmt.Errorf("failed to set active organisation: %w", err)
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("failed to get rows affected: %w", err)
+	}
+	if rowsAffected == 0 {
+		return fmt.Errorf("user not found")
+	}
+
+	log.Info().
+		Str("user_id", userID).
+		Str("organisation_id", organisationID).
+		Msg("Set active organisation")
+
+	return nil
+}
+
+// AddOrganisationMember adds a user as a member of an organisation
+func (db *DB) AddOrganisationMember(userID, organisationID string) error {
+	query := `
+		INSERT INTO organisation_members (user_id, organisation_id, created_at)
+		VALUES ($1, $2, NOW())
+		ON CONFLICT (user_id, organisation_id) DO NOTHING
+	`
+
+	_, err := db.client.Exec(query, userID, organisationID)
+	if err != nil {
+		return fmt.Errorf("failed to add organisation member: %w", err)
+	}
+
+	log.Info().
+		Str("user_id", userID).
+		Str("organisation_id", organisationID).
+		Msg("Added organisation member")
+
+	return nil
+}
+
+// GetEffectiveOrganisationID returns the user's effective organisation ID
+// (active_organisation_id if set, otherwise organisation_id for backward compatibility)
+func (db *DB) GetEffectiveOrganisationID(user *User) string {
+	if user.ActiveOrganisationID != nil && *user.ActiveOrganisationID != "" {
+		return *user.ActiveOrganisationID
+	}
+	if user.OrganisationID != nil {
+		return *user.OrganisationID
+	}
+	return ""
 }

--- a/internal/mocks/db.go
+++ b/internal/mocks/db.go
@@ -243,3 +243,30 @@ func (m *MockDB) GetLastJobStartTimeForScheduler(ctx context.Context, schedulerI
 	}
 	return args.Get(0).(*time.Time), args.Error(1)
 }
+
+// ListUserOrganisations mocks the ListUserOrganisations method
+func (m *MockDB) ListUserOrganisations(userID string) ([]db.UserOrganisation, error) {
+	args := m.Called(userID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]db.UserOrganisation), args.Error(1)
+}
+
+// ValidateOrganisationMembership mocks the ValidateOrganisationMembership method
+func (m *MockDB) ValidateOrganisationMembership(userID, organisationID string) (bool, error) {
+	args := m.Called(userID, organisationID)
+	return args.Bool(0), args.Error(1)
+}
+
+// SetActiveOrganisation mocks the SetActiveOrganisation method
+func (m *MockDB) SetActiveOrganisation(userID, organisationID string) error {
+	args := m.Called(userID, organisationID)
+	return args.Error(0)
+}
+
+// GetEffectiveOrganisationID mocks the GetEffectiveOrganisationID method
+func (m *MockDB) GetEffectiveOrganisationID(user *db.User) string {
+	args := m.Called(user)
+	return args.String(0)
+}

--- a/supabase/migrations/20251229045502_create_organisation_members.sql
+++ b/supabase/migrations/20251229045502_create_organisation_members.sql
@@ -1,0 +1,48 @@
+-- Migration: Create organisation_members table for many-to-many user-org relationships
+-- Part of platform auth implementation for multi-organisation support
+
+-- =============================================================================
+-- TABLE CREATION
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS organisation_members (
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    organisation_id UUID NOT NULL REFERENCES organisations(id) ON DELETE CASCADE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (user_id, organisation_id)
+);
+
+COMMENT ON TABLE organisation_members IS 'Many-to-many relationship between users and organisations';
+
+-- =============================================================================
+-- INDEXES
+-- =============================================================================
+
+-- Reverse lookup: find all members of an organisation
+CREATE INDEX IF NOT EXISTS idx_org_members_org
+ON organisation_members(organisation_id);
+
+-- =============================================================================
+-- ROW LEVEL SECURITY
+-- =============================================================================
+
+ALTER TABLE organisation_members ENABLE ROW LEVEL SECURITY;
+
+-- Users can view their own memberships
+CREATE POLICY "Users can view own memberships"
+ON organisation_members FOR SELECT
+USING (user_id = (SELECT auth.uid()));
+
+-- Users can view other members of organisations they belong to
+CREATE POLICY "Users can view org co-members"
+ON organisation_members FOR SELECT
+USING (
+    organisation_id IN (
+        SELECT om.organisation_id
+        FROM organisation_members om
+        WHERE om.user_id = (SELECT auth.uid())
+    )
+);
+
+-- Service role can manage all memberships (for backend operations)
+-- Note: INSERT/UPDATE/DELETE operations will be handled by the backend using service role

--- a/supabase/migrations/20251229045543_backfill_organisation_members.sql
+++ b/supabase/migrations/20251229045543_backfill_organisation_members.sql
@@ -1,0 +1,33 @@
+-- Migration: Backfill organisation_members from existing users.organisation_id
+-- Part of platform auth implementation for multi-organisation support
+
+-- =============================================================================
+-- BACKFILL DATA
+-- =============================================================================
+
+-- Insert existing user-org relationships from the legacy organisation_id column
+-- Existing users become members of their current organisation
+INSERT INTO organisation_members (user_id, organisation_id, created_at)
+SELECT
+    u.id AS user_id,
+    u.organisation_id,
+    u.created_at  -- Preserve original relationship timestamp
+FROM users u
+WHERE u.organisation_id IS NOT NULL
+ON CONFLICT (user_id, organisation_id) DO NOTHING;  -- Idempotent for safe re-runs
+
+-- =============================================================================
+-- VERIFICATION
+-- =============================================================================
+
+DO $$
+DECLARE
+    users_with_org INTEGER;
+    members_created INTEGER;
+BEGIN
+    SELECT COUNT(*) INTO users_with_org FROM users WHERE organisation_id IS NOT NULL;
+    SELECT COUNT(*) INTO members_created FROM organisation_members;
+
+    RAISE NOTICE 'Backfill complete: % users with organisations, % memberships created',
+                 users_with_org, members_created;
+END $$;

--- a/supabase/migrations/20251229045612_add_active_organisation_id.sql
+++ b/supabase/migrations/20251229045612_add_active_organisation_id.sql
@@ -1,0 +1,64 @@
+-- Migration: Add active_organisation_id for organisation context switching
+-- Part of platform auth implementation for multi-organisation support
+
+-- =============================================================================
+-- SCHEMA CHANGES
+-- =============================================================================
+
+-- Add column to track user's currently active organisation
+ALTER TABLE users
+ADD COLUMN IF NOT EXISTS active_organisation_id UUID REFERENCES organisations(id);
+
+COMMENT ON COLUMN users.active_organisation_id IS 'Currently selected organisation for multi-org users. Falls back to organisation_id during transition.';
+
+-- Backfill with current organisation_id (preserves existing behaviour)
+UPDATE users
+SET active_organisation_id = organisation_id
+WHERE organisation_id IS NOT NULL
+  AND active_organisation_id IS NULL;
+
+-- =============================================================================
+-- INDEXES
+-- =============================================================================
+
+-- Index for efficient lookup during RLS policy evaluation
+CREATE INDEX IF NOT EXISTS idx_users_active_org
+ON users(active_organisation_id)
+WHERE active_organisation_id IS NOT NULL;
+
+-- =============================================================================
+-- HELPER FUNCTIONS
+-- =============================================================================
+
+-- Update existing helper function with backward compatibility
+-- Uses COALESCE to fall back to legacy organisation_id during transition
+CREATE OR REPLACE FUNCTION public.user_organisation_id()
+RETURNS uuid AS $$
+    SELECT COALESCE(active_organisation_id, organisation_id)
+    FROM users
+    WHERE id = auth.uid()
+$$ LANGUAGE sql STABLE SECURITY DEFINER;
+
+COMMENT ON FUNCTION public.user_organisation_id() IS 'Returns active org, falling back to legacy organisation_id for backward compatibility';
+
+-- New function to check if user is a member of a specific organisation
+CREATE OR REPLACE FUNCTION public.user_is_member_of(org_id uuid)
+RETURNS boolean AS $$
+    SELECT EXISTS (
+        SELECT 1 FROM organisation_members
+        WHERE user_id = auth.uid()
+          AND organisation_id = org_id
+    )
+$$ LANGUAGE sql STABLE SECURITY DEFINER;
+
+COMMENT ON FUNCTION public.user_is_member_of(uuid) IS 'Checks if current user is a member of the specified organisation';
+
+-- New function to get all organisations the user belongs to
+CREATE OR REPLACE FUNCTION public.user_organisations()
+RETURNS SETOF uuid AS $$
+    SELECT organisation_id
+    FROM organisation_members
+    WHERE user_id = auth.uid()
+$$ LANGUAGE sql STABLE SECURITY DEFINER;
+
+COMMENT ON FUNCTION public.user_organisations() IS 'Returns all organisation IDs the current user is a member of';

--- a/supabase/migrations/20251229045647_create_platform_org_mappings.sql
+++ b/supabase/migrations/20251229045647_create_platform_org_mappings.sql
@@ -1,0 +1,78 @@
+-- Migration: Create platform_org_mappings for Webflow/Shopify workspace mapping
+-- Part of platform auth implementation for multi-organisation support
+
+-- =============================================================================
+-- TABLE CREATION
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS platform_org_mappings (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+
+    -- Platform identification
+    platform TEXT NOT NULL CHECK (platform IN ('webflow', 'shopify')),
+    platform_id TEXT NOT NULL,   -- Workspace ID (Webflow) or Shop/Org ID (Shopify)
+    platform_name TEXT,          -- Human-readable name for UI
+
+    -- BBB organisation link
+    organisation_id UUID NOT NULL REFERENCES organisations(id) ON DELETE CASCADE,
+
+    -- Metadata
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    created_by UUID REFERENCES users(id),  -- Who created the mapping
+
+    -- Each platform+platform_id combo maps to exactly one org
+    CONSTRAINT unique_platform_mapping UNIQUE(platform, platform_id)
+);
+
+COMMENT ON TABLE platform_org_mappings IS 'Maps external platform identities (Webflow workspaces, Shopify stores) to BBB organisations';
+COMMENT ON COLUMN platform_org_mappings.platform IS 'Platform type: webflow or shopify';
+COMMENT ON COLUMN platform_org_mappings.platform_id IS 'Webflow workspace ID or Shopify shop/org ID';
+COMMENT ON COLUMN platform_org_mappings.platform_name IS 'Human-readable platform name (e.g., workspace or store name)';
+
+-- =============================================================================
+-- INDEXES
+-- =============================================================================
+
+-- Primary lookup: resolve platform identity to org
+CREATE INDEX IF NOT EXISTS idx_platform_mappings_lookup
+ON platform_org_mappings(platform, platform_id);
+
+-- Find all mappings for an organisation
+CREATE INDEX IF NOT EXISTS idx_platform_mappings_org
+ON platform_org_mappings(organisation_id);
+
+-- =============================================================================
+-- ROW LEVEL SECURITY
+-- =============================================================================
+
+ALTER TABLE platform_org_mappings ENABLE ROW LEVEL SECURITY;
+
+-- Users can view mappings for organisations they belong to
+CREATE POLICY "Users can view own org mappings"
+ON platform_org_mappings FOR SELECT
+USING (
+    organisation_id IN (SELECT public.user_organisations())
+);
+
+-- Service role can manage all mappings (for backend operations)
+-- Note: INSERT/UPDATE/DELETE operations will be handled by the backend using service role
+
+-- =============================================================================
+-- HELPER FUNCTION
+-- =============================================================================
+
+-- Resolve platform identity to BBB organisation
+-- Uses SECURITY INVOKER so RLS applies - backend uses service role to bypass when needed
+CREATE OR REPLACE FUNCTION public.resolve_platform_org(
+    p_platform TEXT,
+    p_platform_id TEXT
+)
+RETURNS uuid AS $$
+    SELECT organisation_id
+    FROM platform_org_mappings
+    WHERE platform = p_platform
+      AND platform_id = p_platform_id
+$$ LANGUAGE sql STABLE SECURITY INVOKER;
+
+COMMENT ON FUNCTION public.resolve_platform_org(TEXT, TEXT) IS 'Returns the BBB organisation_id for a given platform identity';

--- a/supabase/migrations/20251229050132_update_rls_for_multi_org.sql
+++ b/supabase/migrations/20251229050132_update_rls_for_multi_org.sql
@@ -1,0 +1,185 @@
+-- Migration: Update RLS policies to use organisation_members and active_organisation_id
+-- Part of platform auth implementation for multi-organisation support
+-- IMPORTANT: Deploy this AFTER Go code is updated to use new org context
+
+-- =============================================================================
+-- ORGANISATIONS TABLE
+-- =============================================================================
+
+DROP POLICY IF EXISTS "Users can access own organisation" ON organisations;
+DROP POLICY IF EXISTS "Users can access member organisations" ON organisations;
+
+-- Users can view organisations they are members of
+CREATE POLICY "Users can view member organisations"
+ON organisations FOR SELECT
+USING (
+    id IN (SELECT public.user_organisations())
+);
+
+-- Users can modify organisations they are members of (INSERT/UPDATE/DELETE)
+-- Note: Organisation creation typically happens via service role during registration
+CREATE POLICY "Users can modify member organisations"
+ON organisations FOR INSERT
+WITH CHECK (
+    id IN (SELECT public.user_organisations())
+);
+
+CREATE POLICY "Users can update member organisations"
+ON organisations FOR UPDATE
+USING (
+    id IN (SELECT public.user_organisations())
+)
+WITH CHECK (
+    id IN (SELECT public.user_organisations())
+);
+
+CREATE POLICY "Users can delete member organisations"
+ON organisations FOR DELETE
+USING (
+    id IN (SELECT public.user_organisations())
+);
+
+-- =============================================================================
+-- JOBS TABLE
+-- =============================================================================
+
+DROP POLICY IF EXISTS "Organisation members can access jobs" ON jobs;
+
+-- Users can access jobs for their active organisation only
+-- Double-checks both active org match AND membership validation
+CREATE POLICY "Users can access active org jobs"
+ON jobs FOR ALL
+USING (
+    organisation_id = public.user_organisation_id()
+    AND public.user_is_member_of(organisation_id)
+);
+
+-- =============================================================================
+-- TASKS TABLE
+-- =============================================================================
+
+DROP POLICY IF EXISTS "Organisation members can access tasks" ON tasks;
+
+-- Tasks accessible via job membership
+CREATE POLICY "Users can access active org tasks"
+ON tasks FOR ALL
+USING (
+    EXISTS (
+        SELECT 1 FROM jobs j
+        WHERE j.id = tasks.job_id
+          AND j.organisation_id = public.user_organisation_id()
+          AND public.user_is_member_of(j.organisation_id)
+    )
+);
+
+-- =============================================================================
+-- SCHEDULERS TABLE
+-- =============================================================================
+
+DROP POLICY IF EXISTS "Users can view own org schedulers" ON schedulers;
+DROP POLICY IF EXISTS "Users can create own org schedulers" ON schedulers;
+DROP POLICY IF EXISTS "Users can update own org schedulers" ON schedulers;
+DROP POLICY IF EXISTS "Users can delete own org schedulers" ON schedulers;
+
+CREATE POLICY "Users can view active org schedulers"
+ON schedulers FOR SELECT
+USING (
+    organisation_id = public.user_organisation_id()
+    AND public.user_is_member_of(organisation_id)
+);
+
+CREATE POLICY "Users can create active org schedulers"
+ON schedulers FOR INSERT
+WITH CHECK (
+    organisation_id = public.user_organisation_id()
+    AND public.user_is_member_of(organisation_id)
+);
+
+CREATE POLICY "Users can update active org schedulers"
+ON schedulers FOR UPDATE
+USING (
+    organisation_id = public.user_organisation_id()
+    AND public.user_is_member_of(organisation_id)
+)
+WITH CHECK (
+    organisation_id = public.user_organisation_id()
+    AND public.user_is_member_of(organisation_id)
+);
+
+CREATE POLICY "Users can delete active org schedulers"
+ON schedulers FOR DELETE
+USING (
+    organisation_id = public.user_organisation_id()
+    AND public.user_is_member_of(organisation_id)
+);
+
+-- =============================================================================
+-- JOB_SHARE_LINKS TABLE
+-- =============================================================================
+
+DROP POLICY IF EXISTS "Users can view own org share links" ON job_share_links;
+DROP POLICY IF EXISTS "Users can create share links for own org jobs" ON job_share_links;
+DROP POLICY IF EXISTS "Users can update own org share links" ON job_share_links;
+DROP POLICY IF EXISTS "Users can delete own org share links" ON job_share_links;
+
+CREATE POLICY "Users can view active org share links"
+ON job_share_links FOR SELECT
+USING (
+    EXISTS (
+        SELECT 1 FROM jobs j
+        WHERE j.id = job_share_links.job_id
+          AND j.organisation_id = public.user_organisation_id()
+          AND public.user_is_member_of(j.organisation_id)
+    )
+);
+
+CREATE POLICY "Users can create active org share links"
+ON job_share_links FOR INSERT
+WITH CHECK (
+    EXISTS (
+        SELECT 1 FROM jobs j
+        WHERE j.id = job_share_links.job_id
+          AND j.organisation_id = public.user_organisation_id()
+          AND public.user_is_member_of(j.organisation_id)
+    )
+);
+
+CREATE POLICY "Users can update active org share links"
+ON job_share_links FOR UPDATE
+USING (
+    EXISTS (
+        SELECT 1 FROM jobs j
+        WHERE j.id = job_share_links.job_id
+          AND j.organisation_id = public.user_organisation_id()
+          AND public.user_is_member_of(j.organisation_id)
+    )
+)
+WITH CHECK (
+    EXISTS (
+        SELECT 1 FROM jobs j
+        WHERE j.id = job_share_links.job_id
+          AND j.organisation_id = public.user_organisation_id()
+          AND public.user_is_member_of(j.organisation_id)
+    )
+);
+
+CREATE POLICY "Users can delete active org share links"
+ON job_share_links FOR DELETE
+USING (
+    EXISTS (
+        SELECT 1 FROM jobs j
+        WHERE j.id = job_share_links.job_id
+          AND j.organisation_id = public.user_organisation_id()
+          AND public.user_is_member_of(j.organisation_id)
+    )
+);
+
+-- =============================================================================
+-- NOTES
+-- =============================================================================
+
+-- Domains and Pages RLS policies already work via jobs join - no changes needed
+-- They inherit the new job policies automatically
+
+-- The user_organisation_id() function uses COALESCE to fall back to legacy
+-- organisation_id during transition, ensuring backward compatibility


### PR DESCRIPTION
## Summary
- Implements many-to-many organisation membership via `organisation_members` table
- Adds `active_organisation_id` to users for multi-org context switching
- Creates `platform_org_mappings` table for Webflow/Shopify integration
- Updates all 19 API endpoints to filter by active organisation
- Fixes security issue in scheduler jobs query (missing org filter)

## Changes
- **5 database migrations**: Creates new tables and updates RLS policies
- **DB layer**: Adds `GetEffectiveOrganisationID`, `ListUserOrganisations`, `SetActiveOrganisation`
- **API layer**: New `/v1/organisations` and `/v1/organisations/switch` endpoints
- **Test updates**: All test files updated with new mock expectations

## Test plan
- [x] All tests pass locally (`go test ./...`)
- [x] Code formatted (`go fmt ./...`)
- [ ] CI passes
- [ ] Verify migrations apply cleanly to preview DB

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-organisation support: users can list organisations, switch active organisation, and platform mappings (Webflow/Shopify) link external identities to organisations.
* **Security**
  * Organisation-scoped access enforced everywhere with tightened row-level policies to prevent cross-organisation data access.
* **Documentation**
  * Added Platform Auth Plan and updated changelog to document multi-org migration and rollout.
* **Tests**
  * Test suites updated to mock and validate active-organisation flows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->