### PR TITLE
Add organisation switcher to dashboard

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -2263,7 +2263,8 @@
               } else {
                 const err = await switchRes.json();
                 console.error("Failed to switch org:", err);
-                currentOrgName.textContent = activeOrg.name;
+                currentOrgName.textContent =
+                  window.BB_ACTIVE_ORG?.name || activeOrg.name;
                 if (window.showNotification) {
                   window.showNotification(
                     "Failed to switch organisation",
@@ -2273,7 +2274,8 @@
               }
             } catch (err) {
               console.error("Error switching org:", err);
-              currentOrgName.textContent = activeOrg.name;
+              currentOrgName.textContent =
+                window.BB_ACTIVE_ORG?.name || activeOrg.name;
               if (window.showNotification) {
                 window.showNotification(
                   "Failed to switch organisation",


### PR DESCRIPTION
## Summary
- Adds organisation switcher dropdown to dashboard header for multi-org users
- Single org users see org name only (no dropdown)
- Multi-org users can switch active organisation via dropdown
- Dashboard auto-refreshes after switching

## Changes
- HTML: Organisation dropdown component in header
- CSS: Styles for switcher button, dropdown, and items
- JavaScript: `initOrgSwitcher()` function to fetch orgs and handle switching

## Test plan
- [ ] Verify single-org user sees org name without dropdown
- [ ] Verify multi-org user sees dropdown with all organisations
- [ ] Verify clicking org item switches active organisation
- [ ] Verify dashboard refreshes with new org data after switch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Organisation switcher added to the dashboard header for multi‑organisation support.
  * Dropdown lists available organisations, highlights the active organisation, hides the chevron when only one org exists.
  * Selecting an organisation updates the active state, can refresh the dashboard, and closes the dropdown on outside clicks.

* **Bug Fixes**
  * Improved initialization, error handling and diagnostics when loading or switching organisations; switcher is hidden on failures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->