### PR TITLE
Fix promote_waiting_task signature cleanup

### DIFF
--- a/supabase/migrations/20260107093000_ensure_promote_function_signature_clean.sql
+++ b/supabase/migrations/20260107093000_ensure_promote_function_signature_clean.sql
@@ -1,0 +1,35 @@
+-- Ensure promote_waiting_task_for_job has clean TEXT signature
+-- This explicitly drops any legacy UUID signatures that may exist in preview databases
+-- Resolves "commit unexpectedly resulted in rollback" errors (BLUE-BANDED-BEE-7B)
+
+DROP FUNCTION IF EXISTS promote_waiting_task_for_job(UUID);
+DROP FUNCTION IF EXISTS promote_waiting_task_for_job(TEXT);
+
+CREATE FUNCTION promote_waiting_task_for_job(p_job_id TEXT)
+RETURNS VOID
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  -- Promote highest priority waiting task to pending for this job
+  -- Only promote if job has capacity
+  UPDATE tasks
+  SET status = 'pending'
+  WHERE id = (
+    SELECT t.id
+    FROM tasks t
+    INNER JOIN jobs j ON t.job_id = j.id
+    WHERE t.job_id = p_job_id
+      AND t.status = 'waiting'
+      AND j.status = 'running'
+      AND (j.concurrency IS NULL OR j.concurrency = 0 OR j.running_tasks < j.concurrency)
+    ORDER BY t.priority_score DESC, t.created_at ASC
+    LIMIT 1
+    FOR UPDATE OF t SKIP LOCKED
+  );
+END;
+$$;
+
+COMMENT ON FUNCTION promote_waiting_task_for_job(TEXT) IS
+'Promotes one waiting task to pending status when a job frees capacity.
+Uses FOR UPDATE OF t SKIP LOCKED to avoid locking job rows and prevent
+deadlocks with concurrent task claims. Accepts TEXT job_id to match jobs.id column type.';


### PR DESCRIPTION
## Summary

Fixes BLUE-BANDED-BEE-7B - "commit unexpectedly resulted in rollback" errors (81k+ occurrences since Nov 4, 2025, 99% in staging).

## Root Cause

The `promote_waiting_task_for_job` stored procedure had signature ambiguity in preview databases:
- Original migration created function with UUID parameter
- Code calls it with TEXT (job_id is string in Go)
- Preview databases may have had both signatures or wrong signature
- PostgreSQL silently rolled back transactions when signature didn't match

## Changes

- Add migration that explicitly drops both UUID and TEXT versions of the function
- Recreates with clean TEXT signature matching `jobs.id` column type
- Ensures all preview databases have consistent function signature

## Testing

- Migration applies cleanly to main database
- No quota dependencies (safe to merge before quota PR)
- Will be merged into all 3 open PRs to fix their preview databases

Fixes BLUE-BANDED-BEE-7B

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved task scheduling reliability by refining how waiting tasks are promoted to active status, with enhanced priority handling and concurrent operation safeguards to prevent scheduling conflicts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->