### PR TITLE
Fix transaction race bugs (CP/C6 Sentry)

### DIFF
--- a/internal/db/batch.go
+++ b/internal/db/batch.go
@@ -429,6 +429,24 @@ func (bm *BatchManager) flushTaskUpdates(ctx context.Context, updates []*TaskUpd
 		}
 	}
 
+	// Build the set of jobs that freed capacity — done before the tx so promotes
+	// can run in a separate transaction after the batch commits. Keeping promotes
+	// inside the batch tx caused CP Sentry errors: a failed promote left Postgres
+	// in an aborted-transaction state, and the subsequent COMMIT returned ROLLBACK.
+	jobIDsToPromote := make(map[string]bool)
+	for _, task := range completedTasks {
+		jobIDsToPromote[task.JobID] = true
+	}
+	for _, task := range failedTasks {
+		jobIDsToPromote[task.JobID] = true
+	}
+	for _, task := range skippedTasks {
+		jobIDsToPromote[task.JobID] = true
+	}
+	for _, task := range waitingTasks {
+		jobIDsToPromote[task.JobID] = true
+	}
+
 	err := bm.queue.ExecuteWithContext(ctx, func(txCtx context.Context, tx *sql.Tx) error {
 		// Batch update completed tasks
 		if len(completedTasks) > 0 {
@@ -471,45 +489,30 @@ func (bm *BatchManager) flushTaskUpdates(ctx context.Context, updates []*TaskUpd
 			}
 		}
 
-		// Promote waiting→pending for jobs that freed capacity
-		// Completed/failed/skipped tasks all free up job slots
-		jobIDsToPromote := make(map[string]bool)
-		for _, task := range completedTasks {
-			jobIDsToPromote[task.JobID] = true
-		}
-		for _, task := range failedTasks {
-			jobIDsToPromote[task.JobID] = true
-		}
-		for _, task := range skippedTasks {
-			jobIDsToPromote[task.JobID] = true
-		}
-		for _, task := range waitingTasks {
-			jobIDsToPromote[task.JobID] = true
-		}
-
-		// Call promote_waiting_task_for_job() for each affected job
-		promotedCount := 0
-		for jobID := range jobIDsToPromote {
-			_, err := tx.ExecContext(txCtx, `SELECT promote_waiting_task_for_job($1)`, jobID)
-			if err != nil {
-				log.Warn().
-					Err(err).
-					Str("job_id", jobID).
-					Msg("Failed to promote waiting task for job")
-				// Don't fail the entire batch - just log and continue
-			} else {
-				promotedCount++
-			}
-		}
-
-		if promotedCount > 0 {
-			log.Debug().
-				Int("jobs_promoted", promotedCount).
-				Msg("Promoted waiting tasks to pending")
-		}
-
 		return nil
 	})
+
+	// Promote waiting→pending in a separate transaction after the batch commits.
+	// Best-effort: a failed promote just means that job waits for the next poll cycle.
+	if err == nil && len(jobIDsToPromote) > 0 {
+		promoteCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		promotedCount := 0
+		promoteErr := bm.queue.ExecuteWithContext(promoteCtx, func(txCtx context.Context, tx *sql.Tx) error {
+			for jobID := range jobIDsToPromote {
+				if _, err := tx.ExecContext(txCtx, `SELECT promote_waiting_task_for_job($1)`, jobID); err != nil {
+					return fmt.Errorf("promote job %s: %w", jobID, err)
+				}
+				promotedCount++
+			}
+			return nil
+		})
+		if promoteErr != nil {
+			log.Warn().Err(promoteErr).Int("jobs_total", len(jobIDsToPromote)).Msg("Failed to promote waiting tasks after batch")
+		} else if promotedCount > 0 {
+			log.Debug().Int("jobs_promoted", promotedCount).Msg("Promoted waiting tasks to pending")
+		}
+	}
 
 	duration := time.Since(start)
 

--- a/internal/db/queue.go
+++ b/internal/db/queue.go
@@ -472,7 +472,12 @@ func (q *DbQueue) executeOnce(ctx context.Context, fn func(*sql.Tx) error) error
 	commitStart := time.Now()
 	if err := tx.Commit(); err != nil {
 		commitDuration := time.Since(commitStart)
-		sentry.CaptureException(err)
+		// sql.ErrTxDone means the context expired between fn completing and commit;
+		// database/sql auto-rolled-back the tx. This is a known race — retried
+		// upstream, not an unhandled exception worth capturing in Sentry.
+		if !errors.Is(err, sql.ErrTxDone) {
+			sentry.CaptureException(err)
+		}
 		log.Error().
 			Err(err).
 			Dur("begin_duration", beginDuration).
@@ -536,7 +541,9 @@ func (q *DbQueue) executeOnceWithContext(ctx context.Context, fn func(context.Co
 	commitStart := time.Now()
 	if err := tx.Commit(); err != nil {
 		commitDuration := time.Since(commitStart)
-		sentry.CaptureException(err)
+		if !errors.Is(err, sql.ErrTxDone) {
+			sentry.CaptureException(err)
+		}
 		log.Error().
 			Err(err).
 			Dur("begin_duration", beginDuration).


### PR DESCRIPTION
## Summary
- **CP fix (`batch.go`)**: `promote_waiting_task_for_job` errors were swallowed inside the batch transaction, leaving Postgres in an aborted-transaction state. A subsequent `COMMIT` then returned `ROLLBACK` ("commit unexpectedly resulted in rollback"). Fix: build `jobIDsToPromote` before the batch tx, run all promotes in a separate transaction after the batch commits. Failed promotes are still best-effort (log + continue) — the next poll cycle picks them up.
- **C6 fix (`queue.go`)**: `sql.ErrTxDone` from `tx.Commit()` is a known context-deadline race where `database/sql` auto-rolls back the transaction between fn completing and commit being called. The retry loop already handles this correctly — it was generating noisy Sentry events unnecessarily. Fix: gate `sentry.CaptureException` behind `!errors.Is(err, sql.ErrTxDone)` in both `executeOnce` and `executeOnceWithContext`.

## Test plan
- [ ] Deploy and run load test — confirm CP/C6 Sentry events stop appearing
- [ ] Confirm `Promoted waiting tasks to pending` log still appears after batches
- [ ] Confirm batch failures still log correctly on genuine errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  - Improved database error handling to better manage race conditions during transaction commits.
  - Enhanced batch job promotion reliability with refined error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->