### PR TITLE
Adaptive DB pressure controller

### DIFF
--- a/docs/architecture/CONFIG_REFERENCE.md
+++ b/docs/architecture/CONFIG_REFERENCE.md
@@ -21,7 +21,7 @@ DB_MAX_OPEN_CONNS (110)
 ```
 
 Direct DB calls (page writes, domain lookups, etc.) bypass the queue semaphore
-and draw from the shared pool. With 120 semaphore slots out of 146 available, 26
+and draw from the shared pool. With 88 semaphore slots out of 110 total, 22
 connections remain for non-semaphored direct calls.
 
 ---
@@ -32,8 +32,8 @@ connections remain for non-semaphored direct calls.
 
 | Env var / constant       | Production value     | Code default | What it controls                           |
 | ------------------------ | -------------------- | ------------ | ------------------------------------------ |
-| `DB_MAX_OPEN_CONNS`      | **150** (`fly.toml`) | 70           | Hard cap on open connections to pgBouncer  |
-| `DB_MAX_IDLE_CONNS`      | **30** (`fly.toml`)  | 20           | Idle connections kept warm                 |
+| `DB_MAX_OPEN_CONNS`      | **110** (`fly.toml`) | 70           | Hard cap on open connections to pgBouncer  |
+| `DB_MAX_IDLE_CONNS`      | **25** (`fly.toml`)  | 20           | Idle connections kept warm                 |
 | `defaultConnMaxLifetime` | hardcoded            | 5 min        | Max connection lifetime                    |
 | `defaultConnMaxIdleTime` | hardcoded            | 2 min        | Idle connection eviction                   |
 | `statementTimeoutMs`     | hardcoded            | 60s          | Per-statement timeout (added to DSN)       |

--- a/docs/architecture/CONFIG_REFERENCE.md
+++ b/docs/architecture/CONFIG_REFERENCE.md
@@ -12,11 +12,12 @@ inventory of env vars and their classification (secret vs non-secret), see
 ## Key relationships
 
 ```
-DB_MAX_OPEN_CONNS (150)
-  └── DB_POOL_RESERVED_CONNECTIONS (4)  →  available = 146
-        └── DB_QUEUE_MAX_CONCURRENCY (120)  →  semaphore = min(120, 146) = 120
-              └── base workers (30) × WORKER_CONCURRENCY (20) = 600 task slots
-                    └── max workers (160) — capped below the 180-conn Supabase pool
+DB_MAX_OPEN_CONNS (110)
+  └── DB_POOL_RESERVED_CONNECTIONS (4)  →  available = 106
+        └── DB_QUEUE_MAX_CONCURRENCY (88)  →  hard cap = min(88, 106) = 88
+              └── PressureController soft limit  →  88 down to 10, self-tuning
+                    └── base workers (30) × WORKER_CONCURRENCY (20) = 600 task slots
+                          └── max workers (130) — capped below the 180-conn Supabase pool
 ```
 
 Direct DB calls (page writes, domain lookups, etc.) bypass the queue semaphore
@@ -50,22 +51,49 @@ Supabase connection pool size is configured on the Supabase dashboard (currently
 
 ## Queue semaphore
 
-**Source:** `internal/db/queue.go`
+**Source:** `internal/db/queue.go`, `internal/db/pressure.go`
 
 Wraps a semaphore around all task-claim and batch-update DB operations. Direct
 DB calls (page writes, domain lookups, etc.) bypass this gate and draw directly
 from the pool.
 
-| Env var / constant             | Production value     | Default | What it controls                                                            |
-| ------------------------------ | -------------------- | ------- | --------------------------------------------------------------------------- |
-| `DB_QUEUE_MAX_CONCURRENCY`     | **120** (`fly.toml`) | 12      | Semaphore slots for queue ops; effective = `min(this, MAX_OPEN − RESERVED)` |
-| `DB_POOL_RESERVED_CONNECTIONS` | **4** (unset)        | 4       | Connections held back from the semaphore budget                             |
-| `DB_POOL_WARN_THRESHOLD`       | **0.90** (unset)     | 0.90    | Log warn at 90% pool usage                                                  |
-| `DB_POOL_REJECT_THRESHOLD`     | **0.95** (unset)     | 0.95    | Fire Sentry "DB pool saturated" at 95%                                      |
-| `defaultExecuteTimeout`        | hardcoded            | 30s     | Context timeout for `Execute`/`ExecuteWithContext` when caller has none     |
-| `DB_TX_MAX_RETRIES`            | **5** (`fly.toml`)   | 3       | Transaction retry attempts on retryable errors                              |
-| `DB_TX_BACKOFF_BASE_MS`        | **200ms** (unset)    | 200ms   | Initial TX retry backoff                                                    |
-| `DB_TX_BACKOFF_MAX_MS`         | **1500ms** (unset)   | 1500ms  | Max TX retry backoff                                                        |
+The semaphore has two limits:
+
+- **Hard limit** — `min(DB_QUEUE_MAX_CONCURRENCY, MAX_OPEN − RESERVED)`, set at
+  startup. The channel capacity never exceeds this.
+- **Soft limit** — the pressure-adjusted effective limit maintained by
+  `PressureController`. Starts at the hard limit and moves between `minLimit`
+  (10) and the hard limit based on observed `pool_wait_total`.
+
+| Env var / constant             | Production value    | Default | What it controls                                                        |
+| ------------------------------ | ------------------- | ------- | ----------------------------------------------------------------------- |
+| `DB_QUEUE_MAX_CONCURRENCY`     | **88** (`fly.toml`) | 12      | Semaphore hard cap; effective = `min(this, MAX_OPEN − RESERVED)`        |
+| `DB_POOL_RESERVED_CONNECTIONS` | **4** (unset)       | 4       | Connections held back from the semaphore budget                         |
+| `DB_POOL_WARN_THRESHOLD`       | **0.90** (unset)    | 0.90    | Log warn at 90% pool usage                                              |
+| `DB_POOL_REJECT_THRESHOLD`     | **0.95** (unset)    | 0.95    | Fire Sentry "DB pool saturated" at 95%                                  |
+| `defaultExecuteTimeout`        | hardcoded           | 30s     | Context timeout for `Execute`/`ExecuteWithContext` when caller has none |
+| `DB_TX_MAX_RETRIES`            | **5** (`fly.toml`)  | 3       | Transaction retry attempts on retryable errors                          |
+| `DB_TX_BACKOFF_BASE_MS`        | **200ms** (unset)   | 200ms   | Initial TX retry backoff                                                |
+| `DB_TX_BACKOFF_MAX_MS`         | **1500ms** (unset)  | 1500ms  | Max TX retry backoff                                                    |
+
+### Adaptive pressure controller
+
+**Source:** `internal/db/pressure.go`
+
+Automatically reduces the semaphore soft limit when Supabase is under load and
+restores it when pressure eases. Signal is `pool_wait_total` per transaction —
+the cumulative time spent waiting to acquire a semaphore slot.
+
+| Env var / constant          | Default | What it controls                                                |
+| --------------------------- | ------- | --------------------------------------------------------------- |
+| `GNH_PRESSURE_HIGH_MARK_MS` | 300ms   | EMA above this triggers a reduction (step −5, floor 10)         |
+| `GNH_PRESSURE_LOW_MARK_MS`  | 50ms    | EMA below this triggers restoration (step +5, ceiling hard cap) |
+| `pressureEMAAlpha`          | 0.15    | Smoothing factor — lower = slower to react, more stable         |
+| `pressureCooldown`          | 15s     | Minimum gap between consecutive adjustments                     |
+| `pressureWarmupSamples`     | 5       | Observations required before the controller acts                |
+
+Typical lifecycle under load: limit 88 → 83 → 78 … → 10 (floor), then recovers
+as pool wait drops back below 50ms.
 
 ---
 

--- a/docs/architecture/CONFIG_REFERENCE.md
+++ b/docs/architecture/CONFIG_REFERENCE.md
@@ -62,8 +62,8 @@ The semaphore has two limits:
 - **Hard limit** — `min(DB_QUEUE_MAX_CONCURRENCY, MAX_OPEN − RESERVED)`, set at
   startup. The channel capacity never exceeds this.
 - **Soft limit** — the pressure-adjusted effective limit maintained by
-  `PressureController`. Starts at the hard limit and moves between `minLimit`
-  (10) and the hard limit based on observed `pool_wait_total`.
+  `PressureController`. Starts at `pressureInitialLimit` (55) and moves between
+  `minLimit` (10) and the hard limit based on observed `pool_wait_total`.
 
 | Env var / constant             | Production value    | Default | What it controls                                                        |
 | ------------------------------ | ------------------- | ------- | ----------------------------------------------------------------------- |
@@ -84,16 +84,20 @@ Automatically reduces the semaphore soft limit when Supabase is under load and
 restores it when pressure eases. Signal is `pool_wait_total` per transaction —
 the cumulative time spent waiting to acquire a semaphore slot.
 
-| Env var / constant          | Default | What it controls                                                |
-| --------------------------- | ------- | --------------------------------------------------------------- |
-| `GNH_PRESSURE_HIGH_MARK_MS` | 300ms   | EMA above this triggers a reduction (step −5, floor 10)         |
-| `GNH_PRESSURE_LOW_MARK_MS`  | 50ms    | EMA below this triggers restoration (step +5, ceiling hard cap) |
-| `pressureEMAAlpha`          | 0.15    | Smoothing factor — lower = slower to react, more stable         |
-| `pressureCooldown`          | 15s     | Minimum gap between consecutive adjustments                     |
-| `pressureWarmupSamples`     | 5       | Observations required before the controller acts                |
+| Env var / constant          | Default | What it controls                                                           |
+| --------------------------- | ------- | -------------------------------------------------------------------------- |
+| `GNH_PRESSURE_HIGH_MARK_MS` | 500ms   | EMA above this triggers a reduction (step −10, floor 10, every 10s)        |
+| `GNH_PRESSURE_LOW_MARK_MS`  | 100ms   | EMA below this triggers restoration (step +3, ceiling hard cap, every 30s) |
+| `pressureEMAAlpha`          | 0.15    | Smoothing factor — lower = slower to react, more stable                    |
+| `pressureInitialLimit`      | 55      | Starting soft limit — conservative to protect DB on restart under load     |
+| `pressureWarmupSamples`     | 5       | Observations required before the controller acts                           |
 
-Typical lifecycle under load: limit 88 → 83 → 78 … → 10 (floor), then recovers
-as pool wait drops back below 50ms.
+Deadband: EMA between 100ms and 500ms → limit holds steady. If
+`GNH_PRESSURE_LOW_MARK_MS >= GNH_PRESSURE_HIGH_MARK_MS` the controller logs a
+warning and falls back to defaults.
+
+Typical lifecycle under load: limit 55 → 45 → 35 … → 10 (floor), then recovers 3
+slots every 30s as pool wait drops back below 100ms.
 
 ---
 
@@ -124,7 +128,7 @@ limiter when adaptive delays are active.
 
 | Env var / constant                  | Production value      | Default           | What it controls                                                    |
 | ----------------------------------- | --------------------- | ----------------- | ------------------------------------------------------------------- |
-| `GNH_MAX_WORKERS`                   | **160** (`fly.toml`)  | 160 (staging: 10) | Max workers ceiling; staging env always uses 10                     |
+| `GNH_MAX_WORKERS`                   | **130** (`fly.toml`)  | 160 (staging: 10) | Max workers ceiling; staging env always uses 10                     |
 | `GNH_WORKER_SCALE_COOLDOWN_SECONDS` | **120s** (`fly.toml`) | 15s               | Minimum time between scale decisions                                |
 | `GNH_WORKER_IDLE_THRESHOLD`         | **10** (`fly.toml`)   | 0                 | Idle worker count before scale-down; 0 = disabled                   |
 | `GNH_HEALTH_PROBE_INTERVAL_SECONDS` | **30s** (`fly.toml`)  | 0                 | Health probe interval (min 10s); 0 = disabled                       |

--- a/internal/db/pressure.go
+++ b/internal/db/pressure.go
@@ -12,71 +12,89 @@ import (
 )
 
 // Default tuning constants for the pressure controller.
-// Override via GNH_PRESSURE_HIGH_MARK_MS and GNH_PRESSURE_LOW_MARK_MS.
+// High/low marks are overridable via env vars; everything else is hardcoded.
 const (
-	pressureHighMarkDefaultMs = 300.0           // EMA above this → shed load
-	pressureLowMarkDefaultMs  = 50.0            // EMA below this → restore capacity
-	pressureEMAAlpha          = 0.15            // smoothing factor (lower = smoother)
-	pressureStep              = int32(5)        // slots to add/remove per adjustment
-	pressureMinLimit          = int32(10)       // never drop below this
-	pressureCooldown          = 15 * time.Second // min gap between adjustments
-	pressureWarmupSamples     = 5               // samples before acting
+	pressureHighMarkDefaultMs = 500.0            // EMA above this → shed load
+	pressureLowMarkDefaultMs  = 100.0            // EMA below this → restore capacity
+	pressureEMAAlpha          = 0.15             // smoothing factor (lower = smoother)
+	pressureStepDown          = int32(10)        // slots removed per shed adjustment
+	pressureStepUp            = int32(3)         // slots added per restore adjustment
+	pressureMinLimit          = int32(10)        // never drop below this
+	pressureCooldownDown      = 10 * time.Second // min gap between shed adjustments
+	pressureCooldownUp        = 30 * time.Second // min gap between restore adjustments
+	pressureWarmupSamples     = 5                // samples required before acting
+	pressureInitialLimit      = int32(55)        // conservative start — known-safe level
 )
 
 // PressureController adaptively adjusts the queue semaphore's effective limit
 // based on observed pool_wait_total per transaction.
 //
 // Signal: every completed Execute / ExecuteWithContext call reports its
-// cumulative pool_wait_total. An exponential moving average of those samples
-// is compared against highMark / lowMark:
+// cumulative pool_wait_total. An EMA of those samples is compared against
+// highMark / lowMark thresholds:
 //
-//   - EMA > highMark → reduce effective limit by step (floor: minLimit)
-//   - EMA < lowMark  → restore effective limit by step (ceiling: maxLimit)
+//   - EMA > highMark → reduce limit by stepDown every cooldownDown (floor: minLimit)
+//   - EMA < lowMark  → restore limit by stepUp every cooldownUp (ceiling: maxLimit)
+//   - Between marks  → hold steady
 //
-// Adjustments are rate-limited by cooldown to prevent thrashing.
+// Shedding is faster than restoring by design: react quickly to protect
+// Supabase, but open capacity back up cautiously.
+//
+// The controller starts at pressureInitialLimit (55) rather than maxLimit so
+// that a restart under load doesn't immediately saturate the DB before the
+// EMA has warmed up.
 type PressureController struct {
-	mu         sync.Mutex
-	ema        float64
-	samples    int
-	lastAdjust time.Time
+	mu            sync.Mutex
+	ema           float64
+	samples       int
+	lastScaleDown time.Time
+	lastScaleUp   time.Time
 
 	// limit is read on every hot-path call to ensurePoolCapacity, so it must
 	// be accessed atomically. Writes happen at most once per cooldown period.
 	limit    atomic.Int32
 	maxLimit int32
 
-	// tuning
-	highMark float64
-	lowMark  float64
-	step     int32
-	minLimit int32
-	cooldown time.Duration
+	// tuning — split by direction for asymmetric behaviour
+	highMark     float64
+	lowMark      float64
+	stepDown     int32
+	stepUp       int32
+	cooldownDown time.Duration
+	cooldownUp   time.Duration
+	minLimit     int32
 }
 
-// newPressureController creates a controller whose effective limit starts at
-// maxLimit and is adjusted dynamically as pool-wait observations arrive.
+// newPressureController creates a controller that starts at pressureInitialLimit
+// (clamped to maxLimit) and adjusts dynamically as pool-wait observations arrive.
 func newPressureController(maxLimit int) *PressureController {
-	pc := &PressureController{
-		maxLimit: int32(maxLimit),
-		highMark: parsePressureFloat("GNH_PRESSURE_HIGH_MARK_MS", pressureHighMarkDefaultMs),
-		lowMark:  parsePressureFloat("GNH_PRESSURE_LOW_MARK_MS", pressureLowMarkDefaultMs),
-		step:     pressureStep,
-		minLimit: pressureMinLimit,
-		cooldown: pressureCooldown,
+	initial := pressureInitialLimit
+	if int32(maxLimit) < initial {
+		initial = int32(maxLimit)
 	}
-	pc.limit.Store(int32(maxLimit))
+	pc := &PressureController{
+		maxLimit:     int32(maxLimit),
+		highMark:     parsePressureFloat("GNH_PRESSURE_HIGH_MARK_MS", pressureHighMarkDefaultMs),
+		lowMark:      parsePressureFloat("GNH_PRESSURE_LOW_MARK_MS", pressureLowMarkDefaultMs),
+		stepDown:     pressureStepDown,
+		stepUp:       pressureStepUp,
+		minLimit:     pressureMinLimit,
+		cooldownDown: pressureCooldownDown,
+		cooldownUp:   pressureCooldownUp,
+	}
+	pc.limit.Store(initial)
 	return pc
 }
 
 // EffectiveLimit returns the current pressure-adjusted concurrency ceiling.
-// This is safe to call from multiple goroutines concurrently.
+// Safe to call from multiple goroutines concurrently.
 func (pc *PressureController) EffectiveLimit() int32 {
 	return pc.limit.Load()
 }
 
 // Record adds a pool_wait observation (cumulative milliseconds for one
 // transaction) and adjusts the effective limit when thresholds are crossed.
-// It is safe to call concurrently.
+// Safe to call concurrently.
 func (pc *PressureController) Record(poolWaitMs float64) {
 	pc.mu.Lock()
 	defer pc.mu.Unlock()
@@ -102,19 +120,18 @@ func (pc *PressureController) EMA() float64 {
 }
 
 // maybeAdjust checks whether a threshold has been crossed and fires an
-// adjustment if the cooldown period has elapsed. Must be called with mu held.
+// adjustment if the relevant cooldown has elapsed. Must be called with mu held.
 func (pc *PressureController) maybeAdjust() {
-	if time.Since(pc.lastAdjust) < pc.cooldown {
-		return
-	}
-
 	current := pc.limit.Load()
 
 	switch {
 	case pc.ema > pc.highMark && current > pc.minLimit:
-		newLimit := max(current-pc.step, pc.minLimit)
+		if time.Since(pc.lastScaleDown) < pc.cooldownDown {
+			return
+		}
+		newLimit := max(current-pc.stepDown, pc.minLimit)
 		pc.limit.Store(newLimit)
-		pc.lastAdjust = time.Now()
+		pc.lastScaleDown = time.Now()
 		log.Warn().
 			Float64("pool_wait_ema_ms", pc.ema).
 			Int32("limit_before", current).
@@ -123,9 +140,12 @@ func (pc *PressureController) maybeAdjust() {
 			Msg("DB pressure high — reducing queue concurrency")
 
 	case pc.ema < pc.lowMark && current < pc.maxLimit:
-		newLimit := min(current+pc.step, pc.maxLimit)
+		if time.Since(pc.lastScaleUp) < pc.cooldownUp {
+			return
+		}
+		newLimit := min(current+pc.stepUp, pc.maxLimit)
 		pc.limit.Store(newLimit)
-		pc.lastAdjust = time.Now()
+		pc.lastScaleUp = time.Now()
 		log.Info().
 			Float64("pool_wait_ema_ms", pc.ema).
 			Int32("limit_before", current).

--- a/internal/db/pressure.go
+++ b/internal/db/pressure.go
@@ -161,6 +161,13 @@ func (pc *PressureController) maybeAdjust() {
 			Int32("limit_after", newLimit).
 			Int32("limit_ceiling", pc.maxLimit).
 			Msg("DB pressure high — reducing queue concurrency")
+		if newLimit == pc.minLimit {
+			log.Error().
+				Float64("pool_wait_ema_ms", pc.ema).
+				Int32("limit", newLimit).
+				Int32("limit_ceiling", pc.maxLimit).
+				Msg("DB pressure at floor — queue concurrency fully shed, Supabase severely overloaded")
+		}
 
 	case pc.ema < pc.lowMark && current < pc.maxLimit:
 		if time.Since(pc.lastScaleUp) < pc.cooldownUp {
@@ -175,6 +182,13 @@ func (pc *PressureController) maybeAdjust() {
 			Int32("limit_after", newLimit).
 			Int32("limit_ceiling", pc.maxLimit).
 			Msg("DB pressure eased — restoring queue concurrency")
+		if newLimit == pc.maxLimit {
+			log.Info().
+				Float64("pool_wait_ema_ms", pc.ema).
+				Int32("limit", newLimit).
+				Int32("limit_ceiling", pc.maxLimit).
+				Msg("DB pressure cleared — queue concurrency fully restored")
+		}
 	}
 }
 

--- a/internal/db/pressure.go
+++ b/internal/db/pressure.go
@@ -9,6 +9,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/getsentry/sentry-go"
 	"github.com/rs/zerolog/log"
 )
 
@@ -169,6 +170,19 @@ func (pc *PressureController) maybeAdjust() {
 				Int32("concurrency_floor", pc.minLimit).
 				Int32("concurrency_ceiling", pc.maxLimit).
 				Msg("DB pressure at floor — queue concurrency fully shed, Supabase severely overloaded")
+			sentry.WithScope(func(scope *sentry.Scope) {
+				scope.SetLevel(sentry.LevelWarning)
+				scope.SetTag("event_type", "db_pressure")
+				scope.SetTag("state", "floor")
+				scope.SetContext("db_pressure", map[string]any{
+					"pool_wait_ema_ms":  pc.ema,
+					"ema_high_mark_ms":  pc.highMark,
+					"concurrency_slots": newLimit,
+					"concurrency_floor": pc.minLimit,
+					"concurrency_ceiling": pc.maxLimit,
+				})
+				sentry.CaptureMessage("DB pressure at floor — queue concurrency fully shed")
+			})
 		}
 
 	case pc.ema < pc.lowMark && current < pc.maxLimit:

--- a/internal/db/pressure.go
+++ b/internal/db/pressure.go
@@ -79,10 +79,26 @@ func newPressureController(maxLimit int) *PressureController {
 	if safeMax < initial {
 		initial = safeMax
 	}
+	highMark := parsePressureFloat("GNH_PRESSURE_HIGH_MARK_MS", pressureHighMarkDefaultMs)
+	lowMark := parsePressureFloat("GNH_PRESSURE_LOW_MARK_MS", pressureLowMarkDefaultMs)
+
+	// Ensure a valid deadband. If env vars collapse or invert the band, log and
+	// fall back to defaults so the controller behaves predictably.
+	if lowMark >= highMark {
+		log.Warn().
+			Float64("low_mark", lowMark).
+			Float64("high_mark", highMark).
+			Float64("default_low", pressureLowMarkDefaultMs).
+			Float64("default_high", pressureHighMarkDefaultMs).
+			Msg("GNH_PRESSURE_LOW_MARK_MS >= GNH_PRESSURE_HIGH_MARK_MS — falling back to defaults")
+		lowMark = pressureLowMarkDefaultMs
+		highMark = pressureHighMarkDefaultMs
+	}
+
 	pc := &PressureController{
 		maxLimit:     safeMax,
-		highMark:     parsePressureFloat("GNH_PRESSURE_HIGH_MARK_MS", pressureHighMarkDefaultMs),
-		lowMark:      parsePressureFloat("GNH_PRESSURE_LOW_MARK_MS", pressureLowMarkDefaultMs),
+		highMark:     highMark,
+		lowMark:      lowMark,
 		stepDown:     pressureStepDown,
 		stepUp:       pressureStepUp,
 		minLimit:     pressureMinLimit,

--- a/internal/db/pressure.go
+++ b/internal/db/pressure.go
@@ -1,0 +1,145 @@
+package db
+
+import (
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/rs/zerolog/log"
+)
+
+// Default tuning constants for the pressure controller.
+// Override via GNH_PRESSURE_HIGH_MARK_MS and GNH_PRESSURE_LOW_MARK_MS.
+const (
+	pressureHighMarkDefaultMs = 300.0           // EMA above this → shed load
+	pressureLowMarkDefaultMs  = 50.0            // EMA below this → restore capacity
+	pressureEMAAlpha          = 0.15            // smoothing factor (lower = smoother)
+	pressureStep              = int32(5)        // slots to add/remove per adjustment
+	pressureMinLimit          = int32(10)       // never drop below this
+	pressureCooldown          = 15 * time.Second // min gap between adjustments
+	pressureWarmupSamples     = 5               // samples before acting
+)
+
+// PressureController adaptively adjusts the queue semaphore's effective limit
+// based on observed pool_wait_total per transaction.
+//
+// Signal: every completed Execute / ExecuteWithContext call reports its
+// cumulative pool_wait_total. An exponential moving average of those samples
+// is compared against highMark / lowMark:
+//
+//   - EMA > highMark → reduce effective limit by step (floor: minLimit)
+//   - EMA < lowMark  → restore effective limit by step (ceiling: maxLimit)
+//
+// Adjustments are rate-limited by cooldown to prevent thrashing.
+type PressureController struct {
+	mu         sync.Mutex
+	ema        float64
+	samples    int
+	lastAdjust time.Time
+
+	// limit is read on every hot-path call to ensurePoolCapacity, so it must
+	// be accessed atomically. Writes happen at most once per cooldown period.
+	limit    atomic.Int32
+	maxLimit int32
+
+	// tuning
+	highMark float64
+	lowMark  float64
+	step     int32
+	minLimit int32
+	cooldown time.Duration
+}
+
+// newPressureController creates a controller whose effective limit starts at
+// maxLimit and is adjusted dynamically as pool-wait observations arrive.
+func newPressureController(maxLimit int) *PressureController {
+	pc := &PressureController{
+		maxLimit: int32(maxLimit),
+		highMark: parsePressureFloat("GNH_PRESSURE_HIGH_MARK_MS", pressureHighMarkDefaultMs),
+		lowMark:  parsePressureFloat("GNH_PRESSURE_LOW_MARK_MS", pressureLowMarkDefaultMs),
+		step:     pressureStep,
+		minLimit: pressureMinLimit,
+		cooldown: pressureCooldown,
+	}
+	pc.limit.Store(int32(maxLimit))
+	return pc
+}
+
+// EffectiveLimit returns the current pressure-adjusted concurrency ceiling.
+// This is safe to call from multiple goroutines concurrently.
+func (pc *PressureController) EffectiveLimit() int32 {
+	return pc.limit.Load()
+}
+
+// Record adds a pool_wait observation (cumulative milliseconds for one
+// transaction) and adjusts the effective limit when thresholds are crossed.
+// It is safe to call concurrently.
+func (pc *PressureController) Record(poolWaitMs float64) {
+	pc.mu.Lock()
+	defer pc.mu.Unlock()
+
+	if pc.samples == 0 {
+		pc.ema = poolWaitMs
+	} else {
+		pc.ema = pressureEMAAlpha*poolWaitMs + (1.0-pressureEMAAlpha)*pc.ema
+	}
+	pc.samples++
+
+	if pc.samples < pressureWarmupSamples {
+		return
+	}
+	pc.maybeAdjust()
+}
+
+// EMA returns the current smoothed pool-wait estimate in milliseconds.
+func (pc *PressureController) EMA() float64 {
+	pc.mu.Lock()
+	defer pc.mu.Unlock()
+	return pc.ema
+}
+
+// maybeAdjust checks whether a threshold has been crossed and fires an
+// adjustment if the cooldown period has elapsed. Must be called with mu held.
+func (pc *PressureController) maybeAdjust() {
+	if time.Since(pc.lastAdjust) < pc.cooldown {
+		return
+	}
+
+	current := pc.limit.Load()
+
+	switch {
+	case pc.ema > pc.highMark && current > pc.minLimit:
+		newLimit := max(current-pc.step, pc.minLimit)
+		pc.limit.Store(newLimit)
+		pc.lastAdjust = time.Now()
+		log.Warn().
+			Float64("pool_wait_ema_ms", pc.ema).
+			Int32("limit_before", current).
+			Int32("limit_after", newLimit).
+			Int32("limit_ceiling", pc.maxLimit).
+			Msg("DB pressure high — reducing queue concurrency")
+
+	case pc.ema < pc.lowMark && current < pc.maxLimit:
+		newLimit := min(current+pc.step, pc.maxLimit)
+		pc.limit.Store(newLimit)
+		pc.lastAdjust = time.Now()
+		log.Info().
+			Float64("pool_wait_ema_ms", pc.ema).
+			Int32("limit_before", current).
+			Int32("limit_after", newLimit).
+			Int32("limit_ceiling", pc.maxLimit).
+			Msg("DB pressure eased — restoring queue concurrency")
+	}
+}
+
+func parsePressureFloat(key string, fallback float64) float64 {
+	if raw := strings.TrimSpace(os.Getenv(key)); raw != "" {
+		if v, err := strconv.ParseFloat(raw, 64); err == nil && v > 0 {
+			return v
+		}
+	}
+	return fallback
+}

--- a/internal/db/pressure.go
+++ b/internal/db/pressure.go
@@ -73,7 +73,7 @@ func newPressureController(maxLimit int) *PressureController {
 	// practice, but clamp explicitly to satisfy the linter and be defensive.
 	safeMax := int32(math.MaxInt32)
 	if maxLimit <= math.MaxInt32 {
-		safeMax = int32(maxLimit)
+		safeMax = int32(maxLimit) //nolint:gosec // G115: bounds-checked immediately above
 	}
 	initial := pressureInitialLimit
 	if safeMax < initial {

--- a/internal/db/pressure.go
+++ b/internal/db/pressure.go
@@ -164,8 +164,10 @@ func (pc *PressureController) maybeAdjust() {
 		if newLimit == pc.minLimit {
 			log.Error().
 				Float64("pool_wait_ema_ms", pc.ema).
-				Int32("limit", newLimit).
-				Int32("limit_ceiling", pc.maxLimit).
+				Float64("ema_high_mark_ms", pc.highMark).
+				Int32("concurrency_slots", newLimit).
+				Int32("concurrency_floor", pc.minLimit).
+				Int32("concurrency_ceiling", pc.maxLimit).
 				Msg("DB pressure at floor — queue concurrency fully shed, Supabase severely overloaded")
 		}
 
@@ -185,8 +187,10 @@ func (pc *PressureController) maybeAdjust() {
 		if newLimit == pc.maxLimit {
 			log.Info().
 				Float64("pool_wait_ema_ms", pc.ema).
-				Int32("limit", newLimit).
-				Int32("limit_ceiling", pc.maxLimit).
+				Float64("ema_low_mark_ms", pc.lowMark).
+				Int32("concurrency_slots", newLimit).
+				Int32("concurrency_floor", pc.minLimit).
+				Int32("concurrency_ceiling", pc.maxLimit).
 				Msg("DB pressure cleared — queue concurrency fully restored")
 		}
 	}

--- a/internal/db/pressure.go
+++ b/internal/db/pressure.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"math"
 	"os"
 	"strconv"
 	"strings"
@@ -68,12 +69,18 @@ type PressureController struct {
 // newPressureController creates a controller that starts at pressureInitialLimit
 // (clamped to maxLimit) and adjusts dynamically as pool-wait observations arrive.
 func newPressureController(maxLimit int) *PressureController {
+	// Guard against int32 overflow — maxLimit is always a small pool size in
+	// practice, but clamp explicitly to satisfy the linter and be defensive.
+	safeMax := int32(math.MaxInt32)
+	if maxLimit <= math.MaxInt32 {
+		safeMax = int32(maxLimit)
+	}
 	initial := pressureInitialLimit
-	if int32(maxLimit) < initial {
-		initial = int32(maxLimit)
+	if safeMax < initial {
+		initial = safeMax
 	}
 	pc := &PressureController{
-		maxLimit:     int32(maxLimit),
+		maxLimit:     safeMax,
 		highMark:     parsePressureFloat("GNH_PRESSURE_HIGH_MARK_MS", pressureHighMarkDefaultMs),
 		lowMark:      parsePressureFloat("GNH_PRESSURE_LOW_MARK_MS", pressureLowMarkDefaultMs),
 		stepDown:     pressureStepDown,

--- a/internal/db/pressure.go
+++ b/internal/db/pressure.go
@@ -96,13 +96,24 @@ func newPressureController(maxLimit int) *PressureController {
 		highMark = pressureHighMarkDefaultMs
 	}
 
+	// If the pool is configured smaller than the default floor, clamp the floor
+	// to maxLimit to avoid an unresolvable inconsistency where we can never shed.
+	minLimit := pressureMinLimit
+	if safeMax < minLimit {
+		log.Warn().
+			Int32("max_limit", safeMax).
+			Int32("min_limit_default", minLimit).
+			Msg("DB_QUEUE_MAX_CONCURRENCY smaller than pressure floor — clamping floor to max")
+		minLimit = safeMax
+	}
+
 	pc := &PressureController{
 		maxLimit:     safeMax,
 		highMark:     highMark,
 		lowMark:      lowMark,
 		stepDown:     pressureStepDown,
 		stepUp:       pressureStepUp,
-		minLimit:     pressureMinLimit,
+		minLimit:     minLimit,
 		cooldownDown: pressureCooldownDown,
 		cooldownUp:   pressureCooldownUp,
 	}
@@ -175,10 +186,10 @@ func (pc *PressureController) maybeAdjust() {
 				scope.SetTag("event_type", "db_pressure")
 				scope.SetTag("state", "floor")
 				scope.SetContext("db_pressure", map[string]any{
-					"pool_wait_ema_ms":  pc.ema,
-					"ema_high_mark_ms":  pc.highMark,
-					"concurrency_slots": newLimit,
-					"concurrency_floor": pc.minLimit,
+					"pool_wait_ema_ms":    pc.ema,
+					"ema_high_mark_ms":    pc.highMark,
+					"concurrency_slots":   newLimit,
+					"concurrency_floor":   pc.minLimit,
 					"concurrency_ceiling": pc.maxLimit,
 				})
 				sentry.CaptureMessage("DB pressure at floor — queue concurrency fully shed")
@@ -215,6 +226,11 @@ func parsePressureFloat(key string, fallback float64) float64 {
 		if v, err := strconv.ParseFloat(raw, 64); err == nil && v > 0 {
 			return v
 		}
+		log.Debug().
+			Str("key", key).
+			Str("value", raw).
+			Float64("fallback", fallback).
+			Msg("Invalid pressure config value — using default")
 	}
 	return fallback
 }

--- a/internal/db/pressure_test.go
+++ b/internal/db/pressure_test.go
@@ -1,0 +1,144 @@
+package db
+
+import (
+	"testing"
+	"time"
+)
+
+// newTestPressureController returns a controller with shortened cooldown for
+// testing. maxLimit is set to 50 to give room in both directions.
+func newTestPressureController(maxLimit int) *PressureController {
+	pc := newPressureController(maxLimit)
+	pc.cooldown = 0 // no cooldown in tests
+	return pc
+}
+
+func TestPressureController_StartsAtMaxLimit(t *testing.T) {
+	pc := newTestPressureController(50)
+	if got := pc.EffectiveLimit(); got != 50 {
+		t.Fatalf("expected initial limit 50, got %d", got)
+	}
+}
+
+func TestPressureController_ReducesOnHighPressure(t *testing.T) {
+	pc := newTestPressureController(50)
+	pc.highMark = 300
+
+	// Warm up past minimum samples, then drive EMA above highMark.
+	for range pressureWarmupSamples {
+		pc.Record(400)
+	}
+
+	limit := pc.EffectiveLimit()
+	if limit >= 50 {
+		t.Fatalf("expected limit to decrease from 50, got %d", limit)
+	}
+}
+
+func TestPressureController_RestoresOnLowPressure(t *testing.T) {
+	pc := newTestPressureController(50)
+	pc.highMark = 300
+	pc.lowMark = 50
+
+	// Drive limit down.
+	for range pressureWarmupSamples * 3 {
+		pc.Record(500)
+	}
+	reduced := pc.EffectiveLimit()
+	if reduced >= 50 {
+		t.Fatalf("expected limit to decrease, got %d", reduced)
+	}
+
+	// Now drive EMA down — need enough samples to shift the smoothed value.
+	for range 50 {
+		pc.Record(0)
+	}
+
+	restored := pc.EffectiveLimit()
+	if restored <= reduced {
+		t.Fatalf("expected limit to recover above %d, got %d", reduced, restored)
+	}
+}
+
+func TestPressureController_NeverDropsBelowMinLimit(t *testing.T) {
+	pc := newTestPressureController(50)
+	pc.highMark = 1 // trigger on any non-zero wait
+
+	for range 1000 {
+		pc.Record(9999)
+	}
+
+	if got := pc.EffectiveLimit(); got < pressureMinLimit {
+		t.Fatalf("limit %d dropped below minimum %d", got, pressureMinLimit)
+	}
+}
+
+func TestPressureController_NeverExceedsMaxLimit(t *testing.T) {
+	pc := newTestPressureController(50)
+	pc.lowMark = 9999 // always below lowMark → always restore
+
+	for range 1000 {
+		pc.Record(0)
+	}
+
+	if got := pc.EffectiveLimit(); got > 50 {
+		t.Fatalf("limit %d exceeded max 50", got)
+	}
+}
+
+func TestPressureController_CooldownPreventsRapidAdjustment(t *testing.T) {
+	pc := newPressureController(50) // real cooldown
+	pc.cooldown = 10 * time.Second
+	pc.highMark = 300
+
+	// Warm up.
+	for range pressureWarmupSamples {
+		pc.Record(400)
+	}
+	afterFirst := pc.EffectiveLimit()
+
+	// Second batch of high-pressure samples — cooldown should block another adjustment.
+	for range pressureWarmupSamples {
+		pc.Record(400)
+	}
+	afterSecond := pc.EffectiveLimit()
+
+	if afterFirst != afterSecond {
+		t.Fatalf("cooldown not respected: limit changed from %d to %d", afterFirst, afterSecond)
+	}
+}
+
+func TestPressureController_WarmupSamplesRequired(t *testing.T) {
+	pc := newTestPressureController(50)
+	pc.highMark = 1
+
+	// Feed fewer than warmupSamples — should not adjust yet.
+	for range pressureWarmupSamples - 1 {
+		pc.Record(9999)
+	}
+
+	if got := pc.EffectiveLimit(); got != 50 {
+		t.Fatalf("adjusted before warmup complete: limit = %d", got)
+	}
+}
+
+func TestPressureController_EMAIsSmoothed(t *testing.T) {
+	pc := newTestPressureController(50)
+
+	// Seed EMA with a stable value.
+	for range 20 {
+		pc.Record(100)
+	}
+	baseline := pc.EMA()
+
+	// Single spike — EMA should move but not jump to 9999.
+	pc.Record(9999)
+	spiked := pc.EMA()
+
+	if spiked >= 9999 {
+		t.Fatalf("EMA not smoothed: jumped to %f on single spike", spiked)
+	}
+	if spiked <= baseline {
+		t.Fatalf("EMA did not respond to spike: %f → %f", baseline, spiked)
+	}
+}

--- a/internal/db/pressure_test.go
+++ b/internal/db/pressure_test.go
@@ -5,52 +5,76 @@ import (
 	"time"
 )
 
-// newTestPressureController returns a controller with shortened cooldown for
-// testing. maxLimit is set to 50 to give room in both directions.
+// newTestPressureController returns a controller with zero cooldowns for fast
+// testing. maxLimit is set to 88 to match production hard cap.
 func newTestPressureController(maxLimit int) *PressureController {
 	pc := newPressureController(maxLimit)
-	pc.cooldown = 0 // no cooldown in tests
+	pc.cooldownDown = 0
+	pc.cooldownUp = 0
 	return pc
 }
 
-func TestPressureController_StartsAtMaxLimit(t *testing.T) {
-	pc := newTestPressureController(50)
-	if got := pc.EffectiveLimit(); got != 50 {
-		t.Fatalf("expected initial limit 50, got %d", got)
+func TestPressureController_StartsAtInitialLimit(t *testing.T) {
+	pc := newTestPressureController(88)
+	want := pressureInitialLimit
+	if got := pc.EffectiveLimit(); got != want {
+		t.Fatalf("expected initial limit %d, got %d", want, got)
+	}
+}
+
+func TestPressureController_InitialLimitClampedToMax(t *testing.T) {
+	// When hard cap is below the default initial limit, clamp to hard cap.
+	pc := newTestPressureController(20)
+	if got := pc.EffectiveLimit(); got != 20 {
+		t.Fatalf("expected clamped initial limit 20, got %d", got)
 	}
 }
 
 func TestPressureController_ReducesOnHighPressure(t *testing.T) {
-	pc := newTestPressureController(50)
-	pc.highMark = 300
+	pc := newTestPressureController(88)
+	pc.highMark = 500
 
-	// Warm up past minimum samples, then drive EMA above highMark.
 	for range pressureWarmupSamples {
-		pc.Record(400)
+		pc.Record(600)
 	}
 
-	limit := pc.EffectiveLimit()
-	if limit >= 50 {
-		t.Fatalf("expected limit to decrease from 50, got %d", limit)
+	if got := pc.EffectiveLimit(); got >= int32(pressureInitialLimit) {
+		t.Fatalf("expected limit to decrease from %d, got %d", pressureInitialLimit, got)
+	}
+}
+
+func TestPressureController_ReducesByStepDown(t *testing.T) {
+	pc := newTestPressureController(88)
+	pc.highMark = 500
+
+	before := pc.EffectiveLimit()
+	for range pressureWarmupSamples {
+		pc.Record(600)
+	}
+	after := pc.EffectiveLimit()
+
+	if before-after != pressureStepDown {
+		t.Fatalf("expected reduction of %d, got %d (before=%d after=%d)",
+			pressureStepDown, before-after, before, after)
 	}
 }
 
 func TestPressureController_RestoresOnLowPressure(t *testing.T) {
-	pc := newTestPressureController(50)
-	pc.highMark = 300
-	pc.lowMark = 50
+	pc := newTestPressureController(88)
+	pc.highMark = 500
+	pc.lowMark = 100
 
 	// Drive limit down.
-	for range pressureWarmupSamples * 3 {
-		pc.Record(500)
+	for range pressureWarmupSamples * 5 {
+		pc.Record(800)
 	}
 	reduced := pc.EffectiveLimit()
-	if reduced >= 50 {
+	if reduced >= pressureInitialLimit {
 		t.Fatalf("expected limit to decrease, got %d", reduced)
 	}
 
-	// Now drive EMA down — need enough samples to shift the smoothed value.
-	for range 50 {
+	// Drive EMA below lowMark.
+	for range 60 {
 		pc.Record(0)
 	}
 
@@ -60,9 +84,30 @@ func TestPressureController_RestoresOnLowPressure(t *testing.T) {
 	}
 }
 
+func TestPressureController_RestoresByStepUp(t *testing.T) {
+	pc := newTestPressureController(88)
+	pc.highMark = 500
+	pc.lowMark = 100
+
+	// Settle the EMA below lowMark from the start.
+	for range pressureWarmupSamples {
+		pc.Record(0)
+	}
+	before := pc.EffectiveLimit()
+
+	// One more sample to trigger a restore.
+	pc.Record(0)
+	after := pc.EffectiveLimit()
+
+	if after-before != pressureStepUp {
+		t.Fatalf("expected restore of %d, got %d (before=%d after=%d)",
+			pressureStepUp, after-before, before, after)
+	}
+}
+
 func TestPressureController_NeverDropsBelowMinLimit(t *testing.T) {
-	pc := newTestPressureController(50)
-	pc.highMark = 1 // trigger on any non-zero wait
+	pc := newTestPressureController(88)
+	pc.highMark = 1
 
 	for range 1000 {
 		pc.Record(9999)
@@ -74,64 +119,99 @@ func TestPressureController_NeverDropsBelowMinLimit(t *testing.T) {
 }
 
 func TestPressureController_NeverExceedsMaxLimit(t *testing.T) {
-	pc := newTestPressureController(50)
-	pc.lowMark = 9999 // always below lowMark → always restore
+	pc := newTestPressureController(88)
+	pc.lowMark = 9999
 
 	for range 1000 {
 		pc.Record(0)
 	}
 
-	if got := pc.EffectiveLimit(); got > 50 {
-		t.Fatalf("limit %d exceeded max 50", got)
+	if got := pc.EffectiveLimit(); got > 88 {
+		t.Fatalf("limit %d exceeded max 88", got)
 	}
 }
 
-func TestPressureController_CooldownPreventsRapidAdjustment(t *testing.T) {
-	pc := newPressureController(50) // real cooldown
-	pc.cooldown = 10 * time.Second
-	pc.highMark = 300
+func TestPressureController_ShedCooldownPreventsRapidReduction(t *testing.T) {
+	pc := newPressureController(88) // real cooldowns
+	pc.cooldownDown = 10 * time.Second
+	pc.highMark = 500
 
-	// Warm up.
 	for range pressureWarmupSamples {
-		pc.Record(400)
+		pc.Record(600)
 	}
 	afterFirst := pc.EffectiveLimit()
 
-	// Second batch of high-pressure samples — cooldown should block another adjustment.
+	// More high-pressure samples — cooldown should block a second reduction.
 	for range pressureWarmupSamples {
-		pc.Record(400)
+		pc.Record(600)
 	}
 	afterSecond := pc.EffectiveLimit()
 
 	if afterFirst != afterSecond {
-		t.Fatalf("cooldown not respected: limit changed from %d to %d", afterFirst, afterSecond)
+		t.Fatalf("shed cooldown not respected: limit changed from %d to %d", afterFirst, afterSecond)
+	}
+}
+
+func TestPressureController_RestoreCooldownPreventsRapidIncrease(t *testing.T) {
+	pc := newPressureController(88)
+	pc.cooldownUp = 30 * time.Second
+	pc.cooldownDown = 0
+	pc.lowMark = 100
+
+	for range pressureWarmupSamples {
+		pc.Record(0)
+	}
+	afterFirst := pc.EffectiveLimit()
+
+	for range pressureWarmupSamples {
+		pc.Record(0)
+	}
+	afterSecond := pc.EffectiveLimit()
+
+	if afterFirst != afterSecond {
+		t.Fatalf("restore cooldown not respected: limit changed from %d to %d", afterFirst, afterSecond)
+	}
+}
+
+func TestPressureController_HoldsInDeadband(t *testing.T) {
+	pc := newTestPressureController(88)
+	pc.highMark = 500
+	pc.lowMark = 100
+
+	initial := pc.EffectiveLimit()
+
+	// EMA in the deadband (between 100 and 500) — limit must not change.
+	for range 50 {
+		pc.Record(250)
+	}
+
+	if got := pc.EffectiveLimit(); got != initial {
+		t.Fatalf("limit changed in deadband: %d → %d", initial, got)
 	}
 }
 
 func TestPressureController_WarmupSamplesRequired(t *testing.T) {
-	pc := newTestPressureController(50)
+	pc := newTestPressureController(88)
 	pc.highMark = 1
 
-	// Feed fewer than warmupSamples — should not adjust yet.
+	initial := pc.EffectiveLimit()
 	for range pressureWarmupSamples - 1 {
 		pc.Record(9999)
 	}
 
-	if got := pc.EffectiveLimit(); got != 50 {
+	if got := pc.EffectiveLimit(); got != initial {
 		t.Fatalf("adjusted before warmup complete: limit = %d", got)
 	}
 }
 
 func TestPressureController_EMAIsSmoothed(t *testing.T) {
-	pc := newTestPressureController(50)
+	pc := newTestPressureController(88)
 
-	// Seed EMA with a stable value.
 	for range 20 {
 		pc.Record(100)
 	}
 	baseline := pc.EMA()
 
-	// Single spike — EMA should move but not jump to 9999.
 	pc.Record(9999)
 	spiked := pc.EMA()
 
@@ -140,5 +220,23 @@ func TestPressureController_EMAIsSmoothed(t *testing.T) {
 	}
 	if spiked <= baseline {
 		t.Fatalf("EMA did not respond to spike: %f → %f", baseline, spiked)
+	}
+}
+
+func TestPressureController_AsymmetricSteps(t *testing.T) {
+	pc := newTestPressureController(88)
+
+	// Verify stepDown > stepUp (shed faster than restore).
+	if pc.stepDown <= pc.stepUp {
+		t.Fatalf("expected stepDown (%d) > stepUp (%d)", pc.stepDown, pc.stepUp)
+	}
+}
+
+func TestPressureController_AsymmetricCooldowns(t *testing.T) {
+	pc := newPressureController(88)
+
+	// Verify cooldownUp > cooldownDown (restore more slowly than shedding).
+	if pc.cooldownUp <= pc.cooldownDown {
+		t.Fatalf("expected cooldownUp (%v) > cooldownDown (%v)", pc.cooldownUp, pc.cooldownDown)
 	}
 }

--- a/internal/db/queue.go
+++ b/internal/db/queue.go
@@ -788,7 +788,7 @@ func (q *DbQueue) ensurePoolCapacity(ctx context.Context) (func(), error) {
 		// The check is intentionally non-blocking: a small overshoot is acceptable
 		// because the channel hard cap still holds.
 		if q.pressure != nil {
-			if int32(len(q.poolSemaphore)) >= q.pressure.EffectiveLimit() {
+			if len(q.poolSemaphore) >= int(q.pressure.EffectiveLimit()) {
 				log.Debug().
 					Int32("soft_limit", q.pressure.EffectiveLimit()).
 					Int("in_flight", len(q.poolSemaphore)).

--- a/internal/db/queue.go
+++ b/internal/db/queue.go
@@ -288,8 +288,12 @@ func (q *DbQueue) Execute(ctx context.Context, fn func(*sql.Tx) error) error {
 				Msg("Database transaction finished with no rows")
 			return execErr
 		}
-		// Don't log concurrency blocking as error - it's normal backoff behaviour
+		// Don't log concurrency blocking as error - it's normal backoff behaviour.
+		// Still record pool wait so the pressure controller sees the signal.
 		if errors.Is(execErr, ErrConcurrencyBlocked) {
+			if q.pressure != nil {
+				q.pressure.Record(float64(poolWaitTotal.Milliseconds()))
+			}
 			return execErr
 		}
 
@@ -425,8 +429,12 @@ func (q *DbQueue) ExecuteWithContext(ctx context.Context, fn func(context.Contex
 				Msg("Database transaction finished with no rows")
 			return execErr
 		}
-		// Don't log concurrency blocking as error - it's normal backoff behaviour
+		// Don't log concurrency blocking as error - it's normal backoff behaviour.
+		// Still record pool wait so the pressure controller sees the signal.
 		if errors.Is(execErr, ErrConcurrencyBlocked) {
+			if q.pressure != nil {
+				q.pressure.Record(float64(poolWaitTotal.Milliseconds()))
+			}
 			return execErr
 		}
 

--- a/internal/db/queue.go
+++ b/internal/db/queue.go
@@ -50,6 +50,9 @@ type DbQueue struct {
 	rng                 *rand.Rand
 	// concurrencyOverride is a callback to get effective concurrency overrides from domain limiter
 	concurrencyOverride ConcurrencyOverrideFunc
+	// pressure adaptively adjusts the effective semaphore limit based on
+	// observed pool_wait_total, preventing Supabase from being overwhelmed.
+	pressure *PressureController
 }
 
 // ErrPoolSaturated is returned when the database connection pool cannot provide
@@ -140,6 +143,7 @@ func NewDbQueue(db *DB) *DbQueue {
 		retryBaseDelay:      baseDelay,
 		retryMaxDelay:       maxDelay,
 		rng:                 nil, // Initialised on first use in randInt63n
+		pressure:            newPressureController(maxConcurrent),
 	}
 }
 
@@ -253,6 +257,10 @@ func (q *DbQueue) Execute(ctx context.Context, fn func(*sql.Tx) error) error {
 
 		if execErr == nil {
 			totalDuration := time.Since(totalStart)
+			// Feed pool wait into the adaptive pressure controller.
+			if q.pressure != nil {
+				q.pressure.Record(float64(poolWaitTotal.Milliseconds()))
+			}
 			// Log if transaction was slow (>5s) to help diagnose performance issues
 			if totalDuration > 5*time.Second {
 				log.Warn().
@@ -268,6 +276,9 @@ func (q *DbQueue) Execute(ctx context.Context, fn func(*sql.Tx) error) error {
 		lastErr = execErr
 		if errors.Is(execErr, sql.ErrNoRows) {
 			totalDuration := time.Since(totalStart)
+			if q.pressure != nil {
+				q.pressure.Record(float64(poolWaitTotal.Milliseconds()))
+			}
 			log.Debug().
 				Err(execErr).
 				Dur("total_duration", totalDuration).
@@ -286,6 +297,9 @@ func (q *DbQueue) Execute(ctx context.Context, fn func(*sql.Tx) error) error {
 
 		if !q.shouldRetry(execErr) || attempt == maxAttempts-1 {
 			totalDuration := time.Since(totalStart)
+			if q.pressure != nil {
+				q.pressure.Record(float64(poolWaitTotal.Milliseconds()))
+			}
 			log.Error().
 				Err(execErr).
 				Str("error_class", errorClass).
@@ -380,6 +394,10 @@ func (q *DbQueue) ExecuteWithContext(ctx context.Context, fn func(context.Contex
 
 		if execErr == nil {
 			totalDuration := time.Since(totalStart)
+			// Feed pool wait into the adaptive pressure controller.
+			if q.pressure != nil {
+				q.pressure.Record(float64(poolWaitTotal.Milliseconds()))
+			}
 			// Log if transaction was slow (>5s) to help diagnose performance issues
 			if totalDuration > 5*time.Second {
 				log.Warn().
@@ -395,6 +413,9 @@ func (q *DbQueue) ExecuteWithContext(ctx context.Context, fn func(context.Contex
 		lastErr = execErr
 		if errors.Is(execErr, sql.ErrNoRows) {
 			totalDuration := time.Since(totalStart)
+			if q.pressure != nil {
+				q.pressure.Record(float64(poolWaitTotal.Milliseconds()))
+			}
 			log.Debug().
 				Err(execErr).
 				Dur("total_duration", totalDuration).
@@ -413,6 +434,9 @@ func (q *DbQueue) ExecuteWithContext(ctx context.Context, fn func(context.Contex
 
 		if !q.shouldRetry(execErr) || attempt == maxAttempts-1 {
 			totalDuration := time.Since(totalStart)
+			if q.pressure != nil {
+				q.pressure.Record(float64(poolWaitTotal.Milliseconds()))
+			}
 			log.Error().
 				Err(execErr).
 				Str("error_class", errorClass).
@@ -759,6 +783,22 @@ func (q *DbQueue) ensurePoolCapacity(ctx context.Context) (func(), error) {
 
 	release := noop
 	if q.poolSemaphore != nil {
+		// Enforce the pressure-adjusted soft limit before blocking on the channel.
+		// len(poolSemaphore) == current in-flight count (send=acquire, recv=release).
+		// The check is intentionally non-blocking: a small overshoot is acceptable
+		// because the channel hard cap still holds.
+		if q.pressure != nil {
+			if int32(len(q.poolSemaphore)) >= q.pressure.EffectiveLimit() {
+				log.Debug().
+					Int32("soft_limit", q.pressure.EffectiveLimit()).
+					Int("in_flight", len(q.poolSemaphore)).
+					Float64("pool_wait_ema_ms", q.pressure.EMA()).
+					Msg("DB pressure soft limit reached — shedding request")
+				observability.RecordDBPoolRejection(ctx)
+				return noop, ErrPoolSaturated
+			}
+		}
+
 		select {
 		case q.poolSemaphore <- struct{}{}:
 			release = func() { <-q.poolSemaphore }


### PR DESCRIPTION
## Summary

- Adds `PressureController` (`internal/db/pressure.go`) that tracks an EMA of `pool_wait_total` per transaction and adjusts the queue semaphore's effective (soft) limit automatically
- When EMA exceeds 300ms → reduce limit by 5 slots (floor: 10); when EMA drops below 50ms → restore by 5 slots (ceiling: hard cap)
- Soft limit check is a non-blocking `len(ch)` test before the semaphore acquire — zero overhead on the happy path
- Both `Execute` and `ExecuteWithContext` report pool wait to the controller after every terminal transaction path
- 15s cooldown between adjustments prevents thrashing
- 7 unit tests, no DB required

## Why

This morning's load test showed `pool_wait_total` hitting 7–8s per transaction when Supabase was overwhelmed. The pressure controller would have shed load automatically rather than cascading into connection timeouts.

## Test plan

- [x] `go test ./internal/db/ -run TestPressureController` — all pass
- [x] `go build ./...` — clean
- [ ] Deploy and run a load test; watch for "DB pressure high — reducing queue concurrency" log lines and confirm Supabase CPU stays below 80%

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adaptive concurrency manager added to dynamically adjust DB queue concurrency and proactively reject requests when the soft capacity is exceeded to avoid blocking; includes signalling for observability.

* **Documentation**
  * Architecture docs updated to describe the dual‑limit semaphore model, adaptive pressure controller, tuning variables and revised DB capacity values.

* **Tests**
  * Added unit tests covering warm‑up, scaling down/up, cooldowns, bounds and EMA behaviour.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->