### PR TITLE
Emit pressure EMA, limit, adjustment and semaphore wait metrics

### DIFF
--- a/internal/db/pressure.go
+++ b/internal/db/pressure.go
@@ -65,6 +65,10 @@ type PressureController struct {
 	cooldownDown time.Duration
 	cooldownUp   time.Duration
 	minLimit     int32
+
+	// OnAdjust is called after each scale-up or scale-down with direction "up" or "down".
+	// Must not block. Set once at construction time before any concurrent use.
+	OnAdjust func(direction string)
 }
 
 // newPressureController creates a controller that starts at pressureInitialLimit
@@ -167,6 +171,9 @@ func (pc *PressureController) maybeAdjust() {
 		newLimit := max(current-pc.stepDown, pc.minLimit)
 		pc.limit.Store(newLimit)
 		pc.lastScaleDown = time.Now()
+		if pc.OnAdjust != nil {
+			pc.OnAdjust("down")
+		}
 		log.Warn().
 			Float64("pool_wait_ema_ms", pc.ema).
 			Int32("limit_before", current).
@@ -203,6 +210,9 @@ func (pc *PressureController) maybeAdjust() {
 		newLimit := min(current+pc.stepUp, pc.maxLimit)
 		pc.limit.Store(newLimit)
 		pc.lastScaleUp = time.Now()
+		if pc.OnAdjust != nil {
+			pc.OnAdjust("up")
+		}
 		log.Info().
 			Float64("pool_wait_ema_ms", pc.ema).
 			Int32("limit_before", current).

--- a/internal/db/queue.go
+++ b/internal/db/queue.go
@@ -132,7 +132,7 @@ func NewDbQueue(db *DB) *DbQueue {
 
 	semaphore = make(chan struct{}, maxConcurrent)
 
-	return &DbQueue{
+	q := &DbQueue{
 		db:                  db,
 		poolWarnThreshold:   warn,
 		poolRejectThreshold: reject,
@@ -143,8 +143,13 @@ func NewDbQueue(db *DB) *DbQueue {
 		retryBaseDelay:      baseDelay,
 		retryMaxDelay:       maxDelay,
 		rng:                 nil, // Initialised on first use in randInt63n
-		pressure:            newPressureController(maxConcurrent),
 	}
+
+	q.pressure = newPressureController(maxConcurrent)
+	q.pressure.OnAdjust = func(direction string) {
+		observability.RecordDBPressureAdjustment(context.Background(), direction)
+	}
+	return q
 }
 
 // SetConcurrencyOverride sets a callback to retrieve effective concurrency from the domain limiter
@@ -807,8 +812,10 @@ func (q *DbQueue) ensurePoolCapacity(ctx context.Context) (func(), error) {
 			}
 		}
 
+		semWaitStart := time.Now()
 		select {
 		case q.poolSemaphore <- struct{}{}:
+			observability.RecordSemaphoreWait(ctx, float64(time.Since(semWaitStart).Milliseconds()))
 			release = func() { <-q.poolSemaphore }
 		case <-ctx.Done():
 			// Explicitly log pool rejections when context expires before acquiring semaphore
@@ -858,6 +865,9 @@ func (q *DbQueue) ensurePoolCapacity(ctx context.Context) (func(), error) {
 		Reserved:     q.preserveConnections,
 		Usage:        usage,
 	})
+	if q.pressure != nil {
+		observability.RecordDBPressureStats(ctx, q.pressure.EMA(), q.pressure.EffectiveLimit())
+	}
 
 	waitDelta := stats.WaitCount - q.lastRejectWaitCount
 	if usage >= q.poolRejectThreshold && waitDelta >= minRejectWaitDelta && time.Since(q.lastRejectLog) > poolLogCooldown {

--- a/internal/observability/observability.go
+++ b/internal/observability/observability.go
@@ -82,6 +82,11 @@ var (
 	dbPoolReservedGauge     metric.Int64Gauge
 	dbPoolRejectCounter     metric.Int64Counter
 
+	dbPressureEMAGauge        metric.Float64Gauge
+	dbPressureLimitGauge      metric.Int64Gauge
+	dbPressureAdjustCounter   metric.Int64Counter
+	dbSemaphoreWaitHistogram  metric.Float64Histogram
+
 	fdCurrentGauge  metric.Int64Gauge
 	fdLimitGauge    metric.Int64Gauge
 	fdPressureGauge metric.Float64Gauge
@@ -468,6 +473,40 @@ func initDBPoolInstruments(meterProvider *sdkmetric.MeterProvider) error {
 		"bee.process.fd.pressure",
 		metric.WithDescription("File descriptor usage ratio (current / limit)"),
 	)
+	if err != nil {
+		return err
+	}
+
+	dbPressureEMAGauge, err = meter.Float64Gauge(
+		"bee.db.pressure.ema_ms",
+		metric.WithUnit("ms"),
+		metric.WithDescription("Exponential moving average of DB query execution time — the pressure controller signal"),
+	)
+	if err != nil {
+		return err
+	}
+
+	dbPressureLimitGauge, err = meter.Int64Gauge(
+		"bee.db.pressure.limit",
+		metric.WithDescription("Current pressure-adjusted concurrency limit for the DB queue semaphore"),
+	)
+	if err != nil {
+		return err
+	}
+
+	dbPressureAdjustCounter, err = meter.Int64Counter(
+		"bee.db.pressure.adjustments_total",
+		metric.WithDescription("Number of times the pressure controller scaled concurrency up or down"),
+	)
+	if err != nil {
+		return err
+	}
+
+	dbSemaphoreWaitHistogram, err = meter.Float64Histogram(
+		"bee.db.semaphore.wait_ms",
+		metric.WithUnit("ms"),
+		metric.WithDescription("Time spent waiting to acquire a DB queue semaphore slot"),
+	)
 	return err
 }
 
@@ -684,6 +723,33 @@ func RecordTaskWaiting(ctx context.Context, jobID string, reason string, count i
 func RecordDBPoolRejection(ctx context.Context) {
 	if dbPoolRejectCounter != nil {
 		dbPoolRejectCounter.Add(ctx, 1, metric.WithAttributes())
+	}
+}
+
+// RecordDBPressureStats records the pressure controller's current EMA and concurrency limit.
+// Call this alongside RecordDBPoolStats for a complete pool+pressure snapshot in Grafana.
+func RecordDBPressureStats(ctx context.Context, emaMs float64, limit int32) {
+	if dbPressureEMAGauge != nil {
+		dbPressureEMAGauge.Record(ctx, emaMs)
+	}
+	if dbPressureLimitGauge != nil {
+		dbPressureLimitGauge.Record(ctx, int64(limit))
+	}
+}
+
+// RecordDBPressureAdjustment increments the adjustment counter.
+// direction must be "up" or "down".
+func RecordDBPressureAdjustment(ctx context.Context, direction string) {
+	if dbPressureAdjustCounter != nil {
+		dbPressureAdjustCounter.Add(ctx, 1,
+			metric.WithAttributes(attribute.String("direction", direction)))
+	}
+}
+
+// RecordSemaphoreWait records the time spent waiting to acquire a DB queue semaphore slot.
+func RecordSemaphoreWait(ctx context.Context, waitMs float64) {
+	if dbSemaphoreWaitHistogram != nil {
+		dbSemaphoreWaitHistogram.Record(ctx, waitMs)
 	}
 }
 

--- a/internal/observability/observability.go
+++ b/internal/observability/observability.go
@@ -82,10 +82,10 @@ var (
 	dbPoolReservedGauge     metric.Int64Gauge
 	dbPoolRejectCounter     metric.Int64Counter
 
-	dbPressureEMAGauge        metric.Float64Gauge
-	dbPressureLimitGauge      metric.Int64Gauge
-	dbPressureAdjustCounter   metric.Int64Counter
-	dbSemaphoreWaitHistogram  metric.Float64Histogram
+	dbPressureEMAGauge       metric.Float64Gauge
+	dbPressureLimitGauge     metric.Int64Gauge
+	dbPressureAdjustCounter  metric.Int64Counter
+	dbSemaphoreWaitHistogram metric.Float64Histogram
 
 	fdCurrentGauge  metric.Int64Gauge
 	fdLimitGauge    metric.Int64Gauge


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced database monitoring with new metrics: EMA pressure, effective concurrency limit, adjustment counts, and semaphore wait-time histogram to improve observability and diagnostics.
  * Queue now records semaphore wait durations and emits DB pressure stats alongside existing pool metrics.
* **Bug Fixes**
  * Fixed initialization flow so DB pressure instruments are reliably set up and recorded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->