### PR TITLE
Add Redis broker and worker service

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,6 +37,18 @@ GOOGLE_CLIENT_SECRET=your_google_client_secret
 SENTRY_DSN=your_sentry_dsn
 OTEL_EXPORTER_OTLP_HEADERS=your_otlp_auth_header
 
+# ── Redis Broker (worker service) ──────────────────────────────────
+# REDIS_URL is required for the worker binary (cmd/worker).
+# Local dev: run a Redis container or use REDIS_URL=redis://localhost:6379
+REDIS_URL=redis://default:password@your-redis-host:6379
+REDIS_POOL_SIZE=200
+REDIS_TLS_ENABLED=true
+REDIS_DISPATCH_INTERVAL_MS=100
+REDIS_DISPATCH_BATCH_SIZE=50
+REDIS_CONSUMER_BLOCK_MS=2000
+REDIS_AUTOCLAIM_INTERVAL_S=30
+REDIS_COUNTER_SYNC_INTERVAL_S=5
+
 # ── Worker Pool Scaling ────────────────────────────────────────────
 GNH_WORKER_IDLE_THRESHOLD=10
 GNH_WORKER_SCALE_COOLDOWN_SECONDS=15

--- a/.fly/review_apps.toml
+++ b/.fly/review_apps.toml
@@ -45,6 +45,15 @@ ARCHIVE_INTERVAL = "1m"
 ARCHIVE_BATCH_SIZE = "100"
 ARCHIVE_CONCURRENCY = "5"
 
+# Redis broker — REDIS_URL is set via flyctl secrets in CI
+REDIS_POOL_SIZE = "50"
+REDIS_TLS_ENABLED = "true"
+REDIS_DISPATCH_INTERVAL_MS = "200"
+REDIS_DISPATCH_BATCH_SIZE = "20"
+REDIS_CONSUMER_BLOCK_MS = "2000"
+REDIS_AUTOCLAIM_INTERVAL_S = "30"
+REDIS_COUNTER_SYNC_INTERVAL_S = "5"
+
 # Performance settings (preview has own DB now, can align closer to prod)
 WORKER_CONCURRENCY = "5"                    # Reduced for preview capacity
 DB_MAX_OPEN_CONNS = "40"                   # Supabase preview pool size

--- a/.github/workflows/review-apps.yml
+++ b/.github/workflows/review-apps.yml
@@ -194,6 +194,39 @@ jobs:
           SUPABASE_ACCESS_TOKEN: ${{ env.SUPABASE_ACCESS_TOKEN }}
           BRANCH_SUPABASE_URL: ${{ steps.supabase.outputs.branch_supabase_url }}
 
+      - name: Provision Upstash Redis
+        id: redis
+        run: |
+          REDIS_NAME="hover-redis-pr-${PR_NUMBER}"
+
+          # Create if it doesn't already exist
+          if ! flyctl redis list | grep -q "$REDIS_NAME"; then
+            echo "Creating Upstash Redis: $REDIS_NAME"
+            flyctl redis create \
+              --name "$REDIS_NAME" \
+              --region syd \
+              --no-replicas \
+              --disable-eviction \
+              --org personal
+          else
+            echo "Upstash Redis already exists: $REDIS_NAME"
+          fi
+
+          # Extract private URL from status output
+          REDIS_URL=$(flyctl redis status "$REDIS_NAME" 2>/dev/null | grep -i "private url" | sed 's/.*= *//')
+
+          if [ -z "$REDIS_URL" ]; then
+            echo "⚠️ Could not extract Redis URL — worker will use DB queue fallback"
+            echo "redis_url=" >> "$GITHUB_OUTPUT"
+          else
+            echo "::add-mask::$REDIS_URL"
+            echo "redis_url=$REDIS_URL" >> "$GITHUB_OUTPUT"
+            echo "✅ Redis provisioned: $REDIS_NAME"
+          fi
+        env:
+          FLY_API_TOKEN: ${{ env.FLY_API_TOKEN }}
+          PR_NUMBER: ${{ github.event.number }}
+
       - name: Build Docker image locally
         run: docker build -t hover-pr-${{ github.event.number }} .
 
@@ -259,12 +292,20 @@ jobs:
           echo "Setting test database connection and auth secrets for review app..."
           # Non-secret config (OAuth client IDs, auth URLs) is in review_apps.toml [env].
           # Only set actual secrets and per-PR dynamic values here.
+          # Build optional Redis secret flag
+          REDIS_FLAGS=()
+          if [ -n "$REVIEW_REDIS_URL" ]; then
+            REDIS_FLAGS+=(REDIS_URL="$REVIEW_REDIS_URL")
+            echo "🔴 Setting REDIS_URL for review app worker"
+          fi
+
           if [ -n "$DIRECT_URL" ]; then
             echo "📡 Setting DATABASE_DIRECT_URL for real-time notifications"
             flyctl secrets set \
               DATABASE_URL="$DB_URL" \
               DATABASE_DIRECT_URL="$DIRECT_URL" \
               "${SUPABASE_URL_FLAGS[@]}" \
+              "${REDIS_FLAGS[@]}" \
               SUPABASE_JWT_SECRET="$JWT_SECRET" \
               SUPABASE_SERVICE_ROLE_KEY="$SERVICE_ROLE_KEY" \
               SENTRY_DSN="$SENTRY_DSN" \
@@ -284,6 +325,7 @@ jobs:
             flyctl secrets set \
               DATABASE_URL="$DB_URL" \
               "${SUPABASE_URL_FLAGS[@]}" \
+              "${REDIS_FLAGS[@]}" \
               SUPABASE_JWT_SECRET="$JWT_SECRET" \
               SUPABASE_SERVICE_ROLE_KEY="$SERVICE_ROLE_KEY" \
               SENTRY_DSN="$SENTRY_DSN" \
@@ -310,6 +352,7 @@ jobs:
             --image hover-pr-${{ github.event.number }}
         env:
           FLY_API_TOKEN: ${{ env.FLY_API_TOKEN }}
+          REVIEW_REDIS_URL: ${{ steps.redis.outputs.redis_url }}
 
       - name: Comment PR with app URL
         uses: actions/github-script@v8
@@ -347,7 +390,18 @@ jobs:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           FLY_API_TOKEN: op://Good Native/hover-fly/FLY_API_TOKEN
 
+      - name: Destroy Upstash Redis
+        run: |
+          REDIS_NAME="hover-redis-pr-${PR_NUMBER}"
+          flyctl redis destroy "$REDIS_NAME" --yes 2>/dev/null || echo "Redis instance may not exist: $REDIS_NAME"
+        env:
+          FLY_API_TOKEN: ${{ env.FLY_API_TOKEN }}
+          PR_NUMBER: ${{ github.event.number }}
+
       - name: Destroy Review App
         run: |
-          APP_NAME="hover-pr-${{ github.event.number }}"
-          flyctl apps destroy $APP_NAME --yes || echo "App may not exist"
+          APP_NAME="hover-pr-${PR_NUMBER}"
+          flyctl apps destroy "$APP_NAME" --yes || echo "App may not exist"
+        env:
+          FLY_API_TOKEN: ${{ env.FLY_API_TOKEN }}
+          PR_NUMBER: ${{ github.event.number }}

--- a/.github/workflows/review-apps.yml
+++ b/.github/workflows/review-apps.yml
@@ -199,8 +199,10 @@ jobs:
         run: |
           REDIS_NAME="hover-redis-pr-${PR_NUMBER}"
 
-          # Create if it doesn't already exist
-          if ! flyctl redis list | grep -q "$REDIS_NAME"; then
+          # Exact-match by name using JSON output
+          EXISTS=$(flyctl redis list --json | jq -e --arg name "$REDIS_NAME" 'map(select(.name == $name)) | length > 0' 2>/dev/null || echo "false")
+
+          if [ "$EXISTS" != "true" ]; then
             echo "Creating Upstash Redis: $REDIS_NAME"
             flyctl redis create \
               --name "$REDIS_NAME" \
@@ -212,11 +214,19 @@ jobs:
             echo "Upstash Redis already exists: $REDIS_NAME"
           fi
 
-          # Extract private URL from status output
-          REDIS_URL=$(flyctl redis status "$REDIS_NAME" 2>/dev/null | grep -i "private url" | sed 's/.*= *//')
+          # Poll for private URL (may take a moment after creation)
+          REDIS_URL=""
+          for i in 1 2 3 4 5 6; do
+            REDIS_URL=$(flyctl redis status "$REDIS_NAME" 2>/dev/null | grep -i "private url" | sed 's/.*= *//')
+            if [ -n "$REDIS_URL" ]; then
+              break
+            fi
+            echo "Waiting for Redis private URL (attempt $i/6)..."
+            sleep 5
+          done
 
           if [ -z "$REDIS_URL" ]; then
-            echo "⚠️ Could not extract Redis URL — worker will use DB queue fallback"
+            echo "⚠️ Could not extract Redis URL after 6 attempts — worker will use DB queue fallback"
             echo "redis_url=" >> "$GITHUB_OUTPUT"
           else
             echo "::add-mask::$REDIS_URL"

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,11 @@ RUN go mod download
 # Copy source code
 COPY . .
 
-# Build the application
+# Build the API application
 RUN CGO_ENABLED=0 GOOS=linux go build -o main ./cmd/app/main.go
+
+# Build the worker binary
+RUN CGO_ENABLED=0 GOOS=linux go build -o worker ./cmd/worker/main.go
 
 # Final stage
 FROM alpine:3.19
@@ -26,8 +29,9 @@ WORKDIR /app
 # Install ca-certificates for HTTPS
 RUN apk --no-cache add ca-certificates
 
-# Copy binary from builder
+# Copy binaries from builder
 COPY --from=builder /app/main .
+COPY --from=builder /app/worker .
 
 # Copy static files
 COPY --from=builder /app/dashboard.html .

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -5,7 +5,6 @@ package main
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 	"os"
 	"os/signal"
@@ -76,6 +75,8 @@ func main() {
 	}
 	defer func() {
 		log.Info().Msg("closing database connection")
+		// Allow in-flight batch manager flushes and counter syncs to complete
+		// before tearing down the connection pool.
 		time.Sleep(1 * time.Second)
 		_ = pgDB.Close()
 	}()
@@ -234,5 +235,4 @@ func parseOTLPHeaders(raw string) map[string]string {
 var (
 	_ broker.JobLister          = (*jobs.StreamWorkerPool)(nil)
 	_ broker.ConcurrencyChecker = (*jobs.StreamWorkerPool)(nil)
-	_                           = (*sql.DB)(nil) // unused import guard
 )

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -1,0 +1,238 @@
+// cmd/worker is the dedicated crawl worker service. It consumes
+// tasks from Redis Streams, executes crawls, and persists results
+// to Postgres via the batch manager.
+package main
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"os/signal"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/Harvey-AU/hover/internal/broker"
+	"github.com/Harvey-AU/hover/internal/crawler"
+	"github.com/Harvey-AU/hover/internal/db"
+	"github.com/Harvey-AU/hover/internal/jobs"
+	"github.com/Harvey-AU/hover/internal/observability"
+	"github.com/getsentry/sentry-go"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+)
+
+func main() {
+	// --- logging ---
+	zerolog.TimeFieldFormat = zerolog.TimeFormatUnix
+	if os.Getenv("APP_ENV") == "development" {
+		log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr})
+	}
+
+	log.Info().Msg("hover worker starting")
+
+	// --- sentry ---
+	if dsn := os.Getenv("SENTRY_DSN"); dsn != "" {
+		if err := sentry.Init(sentry.ClientOptions{
+			Dsn:         dsn,
+			Environment: os.Getenv("APP_ENV"),
+		}); err != nil {
+			log.Warn().Err(err).Msg("failed to initialise Sentry")
+		} else {
+			defer sentry.Flush(2 * time.Second)
+		}
+	}
+
+	// --- observability ---
+	if os.Getenv("OBSERVABILITY_ENABLED") == "true" {
+		providers, err := observability.Init(context.Background(), observability.Config{
+			Enabled:      true,
+			ServiceName:  "hover-worker",
+			Environment:  os.Getenv("APP_ENV"),
+			OTLPEndpoint: strings.TrimSpace(os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT")),
+			OTLPHeaders:  parseOTLPHeaders(os.Getenv("OTEL_EXPORTER_OTLP_HEADERS")),
+		})
+		if err != nil {
+			log.Warn().Err(err).Msg("failed to initialise observability")
+		} else {
+			defer func() {
+				ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+				defer cancel()
+				_ = providers.Shutdown(ctx)
+			}()
+		}
+	}
+
+	// --- postgres ---
+	dbCtx, dbCancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer dbCancel()
+
+	pgDB, err := db.WaitForDatabase(dbCtx, 5*time.Minute)
+	if err != nil {
+		sentry.CaptureException(err)
+		log.Fatal().Err(err).Msg("failed to connect to PostgreSQL")
+	}
+	defer func() {
+		log.Info().Msg("closing database connection")
+		time.Sleep(1 * time.Second)
+		_ = pgDB.Close()
+	}()
+
+	queueDB := pgDB
+	if queueURL := strings.TrimSpace(os.Getenv("DATABASE_QUEUE_URL")); queueURL != "" {
+		queueCtx, queueCancel := context.WithTimeout(context.Background(), 5*time.Minute)
+		defer queueCancel()
+		qConn, err := db.InitFromURLWithSuffixRetry(queueCtx, queueURL, os.Getenv("APP_ENV"), "queue")
+		if err != nil {
+			sentry.CaptureException(err)
+			log.Fatal().Err(err).Msg("failed to connect to queue PostgreSQL")
+		}
+		defer func() {
+			time.Sleep(500 * time.Millisecond)
+			_ = qConn.Close()
+		}()
+		queueDB = qConn
+	}
+
+	dbQueue := db.NewDbQueue(queueDB)
+
+	// --- redis ---
+	redisCfg := broker.ConfigFromEnv()
+	redisClient, err := broker.NewClient(redisCfg, log.Logger)
+	if err != nil {
+		log.Fatal().Err(err).Msg("failed to create Redis client")
+	}
+	defer redisClient.Close()
+
+	if err := redisClient.Ping(context.Background()); err != nil {
+		log.Fatal().Err(err).Msg("failed to ping Redis")
+	}
+	log.Info().Msg("connected to Redis")
+
+	// --- broker components ---
+	scheduler := broker.NewScheduler(redisClient, log.Logger)
+	pacerCfg := broker.DefaultPacerConfig()
+	pacer := broker.NewDomainPacer(redisClient, pacerCfg, log.Logger)
+	counters := broker.NewRunningCounters(redisClient, log.Logger)
+
+	machineName := os.Getenv("FLY_MACHINE_ID")
+	if machineName == "" {
+		machineName, _ = os.Hostname()
+	}
+
+	numWorkers := envInt("WORKER_COUNT", 30)
+	consumerOpts := broker.DefaultConsumerOpts(fmt.Sprintf("worker-%s", machineName))
+	consumer := broker.NewConsumer(redisClient, consumerOpts, log.Logger)
+
+	// --- crawler ---
+	crawlerCfg := crawler.DefaultConfig()
+	cr := crawler.New(crawlerCfg)
+
+	// --- executor ---
+	executorCfg := jobs.DefaultExecutorConfig()
+	executor := jobs.NewTaskExecutor(cr, executorCfg)
+
+	// --- batch manager ---
+	batchManager := db.NewBatchManager(dbQueue)
+	defer batchManager.Stop()
+
+	// --- stream worker pool ---
+	swpOpts := jobs.StreamWorkerOpts{
+		NumWorkers:      numWorkers,
+		ReclaimInterval: 30 * time.Second,
+	}
+
+	swp := jobs.NewStreamWorkerPool(jobs.StreamWorkerDeps{
+		Consumer:     consumer,
+		Scheduler:    scheduler,
+		Counters:     counters,
+		Pacer:        pacer,
+		Executor:     executor,
+		BatchManager: batchManager,
+		DBQueue:      dbQueue,
+		Logger:       log.Logger,
+	}, swpOpts)
+
+	// --- dispatcher ---
+	dispatcherOpts := broker.DefaultDispatcherOpts()
+	dispatcher := broker.NewDispatcher(
+		redisClient, scheduler, pacer, counters,
+		swp, // implements broker.JobLister
+		swp, // implements broker.ConcurrencyChecker
+		dispatcherOpts,
+		log.Logger,
+	)
+
+	// --- running counter DB sync ---
+	syncInterval := time.Duration(envInt("REDIS_COUNTER_SYNC_INTERVAL_S", 5)) * time.Second
+	syncFn := broker.DefaultDBSyncFunc(pgDB.GetDB())
+
+	// --- start everything ---
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	swp.Start(ctx)
+	go dispatcher.Run(ctx)
+	go counters.StartDBSync(ctx, syncInterval, syncFn)
+
+	log.Info().
+		Int("workers", numWorkers).
+		Str("machine", machineName).
+		Msg("hover worker ready")
+
+	// --- graceful shutdown ---
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	sig := <-sigCh
+	log.Info().Str("signal", sig.String()).Msg("shutdown signal received")
+
+	cancel() // stop dispatcher, counter sync, and all workers
+
+	// Wait for workers to drain (with timeout).
+	done := make(chan struct{})
+	go func() {
+		swp.Stop()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		log.Info().Msg("all workers stopped cleanly")
+	case <-time.After(3 * time.Minute):
+		log.Warn().Msg("shutdown timed out after 3 minutes")
+	}
+}
+
+// --- helpers ---
+
+func envInt(key string, def int) int {
+	v := os.Getenv(key)
+	if v == "" {
+		return def
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil {
+		return def
+	}
+	return n
+}
+
+func parseOTLPHeaders(raw string) map[string]string {
+	headers := make(map[string]string)
+	for _, pair := range strings.Split(raw, ",") {
+		parts := strings.SplitN(strings.TrimSpace(pair), "=", 2)
+		if len(parts) == 2 {
+			headers[strings.TrimSpace(parts[0])] = strings.TrimSpace(parts[1])
+		}
+	}
+	return headers
+}
+
+// Compile-time interface checks.
+var (
+	_ broker.JobLister        = (*jobs.StreamWorkerPool)(nil)
+	_ broker.ConcurrencyChecker = (*jobs.StreamWorkerPool)(nil)
+	_ = (*sql.DB)(nil) // unused import guard
+)

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -232,7 +232,7 @@ func parseOTLPHeaders(raw string) map[string]string {
 
 // Compile-time interface checks.
 var (
-	_ broker.JobLister        = (*jobs.StreamWorkerPool)(nil)
+	_ broker.JobLister          = (*jobs.StreamWorkerPool)(nil)
 	_ broker.ConcurrencyChecker = (*jobs.StreamWorkerPool)(nil)
-	_ = (*sql.DB)(nil) // unused import guard
+	_                           = (*sql.DB)(nil) // unused import guard
 )

--- a/dev.sh
+++ b/dev.sh
@@ -64,6 +64,16 @@ else
         .air.toml
 fi
 
+# Start local Redis for the broker (used by worker service)
+echo "Starting local Redis..."
+if docker ps --format '{{.Names}}' | grep -q '^hover-redis$'; then
+    echo "ℹ️  Redis container already running"
+else
+    docker run -d --name hover-redis -p 6379:6379 redis:7-alpine >/dev/null 2>&1 \
+        || docker start hover-redis >/dev/null 2>&1
+    echo "✅ Redis started on localhost:6379"
+fi
+
 # Start Supabase (will be no-op if already running)
 echo "Starting local Supabase..."
 supabase start
@@ -94,6 +104,15 @@ SUPABASE_URL=${API_URL}
 SUPABASE_AUTH_URL=${API_URL}
 SUPABASE_PUBLISHABLE_KEY=${PUBLISHABLE_KEY}
 SUPABASE_SERVICE_ROLE_KEY=${SERVICE_ROLE_KEY}
+
+# Redis broker (local Docker container started by dev.sh)
+REDIS_URL=redis://localhost:6379
+REDIS_TLS_ENABLED=false
+
+# Pressure controller — match production thresholds so local dev
+# sheds load at the same latency marks as prod (defaults are 500/100).
+GNH_PRESSURE_HIGH_MARK_MS=80
+GNH_PRESSURE_LOW_MARK_MS=40
 EOF
 )
     echo "✅ .env.local created"

--- a/dev.sh
+++ b/dev.sh
@@ -117,7 +117,28 @@ EOF
 )
     echo "✅ .env.local created"
 else
-    echo "ℹ️  .env.local already exists — skipping generation"
+    echo "ℹ️  .env.local already exists — checking for missing Redis vars"
+    # Append Redis vars if missing from an older .env.local
+    if ! grep -q '^REDIS_URL=' .env.local 2>/dev/null; then
+        (umask 077; cat >> .env.local <<'REDIS_EOF'
+
+# Redis broker (local Docker container started by dev.sh)
+REDIS_URL=redis://localhost:6379
+REDIS_TLS_ENABLED=false
+REDIS_EOF
+)
+        echo "  ✅ Appended REDIS_URL to .env.local"
+    fi
+    if ! grep -q '^GNH_PRESSURE_HIGH_MARK_MS=' .env.local 2>/dev/null; then
+        (umask 077; cat >> .env.local <<'PRESSURE_EOF'
+
+# Pressure controller — match production thresholds
+GNH_PRESSURE_HIGH_MARK_MS=80
+GNH_PRESSURE_LOW_MARK_MS=40
+PRESSURE_EOF
+)
+        echo "  ✅ Appended pressure thresholds to .env.local"
+    fi
 fi
 
 # Start Air with hot reloading and migration watching

--- a/fly.worker.toml
+++ b/fly.worker.toml
@@ -1,0 +1,44 @@
+# fly.worker.toml — Fly.io configuration for the hover worker service.
+# The worker consumes tasks from Redis Streams, executes crawls,
+# and persists results to Postgres.
+
+app = 'hover-worker'
+primary_region = 'syd'
+
+[build]
+
+[env]
+  APP_ENV = "production"
+  WORKER_COUNT = "30"
+  WORKER_CONCURRENCY = "20"
+  GNH_MAX_WORKERS = "130"
+  DB_MAX_OPEN_CONNS = "60"
+  DB_MAX_IDLE_CONNS = "15"
+  REDIS_POOL_SIZE = "200"
+  REDIS_DISPATCH_INTERVAL_MS = "100"
+  REDIS_DISPATCH_BATCH_SIZE = "50"
+  REDIS_CONSUMER_BLOCK_MS = "2000"
+  REDIS_AUTOCLAIM_INTERVAL_S = "30"
+  REDIS_COUNTER_SYNC_INTERVAL_S = "5"
+  GNH_BATCH_CHANNEL_SIZE = "5000"
+  GNH_HTML_PERSIST_WORKERS = "32"
+  GNH_HTML_PERSIST_QUEUE_SIZE = "2048"
+  LOG_LEVEL = "debug"
+  OBSERVABILITY_ENABLED = "true"
+  ARCHIVE_PROVIDER = "r2"
+  ARCHIVE_BUCKET = "native-hover-archive"
+  ARCHIVE_RETENTION_JOBS = "3"
+  ARCHIVE_INTERVAL = "1m"
+  ARCHIVE_BATCH_SIZE = "100"
+  ARCHIVE_CONCURRENCY = "5"
+
+[deploy]
+  strategy = "immediate"
+
+[processes]
+  worker = "./worker"
+
+[[vm]]
+  memory = '4gb'
+  cpu_kind = 'performance'
+  cpus = 2

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/MicahParks/keyfunc/v3 v3.7.0
 	github.com/PuerkitoBio/goquery v1.10.3
+	github.com/alicebob/miniredis/v2 v2.37.0
 	github.com/aws/aws-sdk-go-v2 v1.41.5
 	github.com/aws/aws-sdk-go-v2/config v1.32.14
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.14
@@ -20,6 +21,7 @@ require (
 	github.com/lib/pq v1.10.9
 	github.com/projectdiscovery/wappalyzergo v0.2.61
 	github.com/prometheus/client_golang v1.23.2
+	github.com/redis/go-redis/v9 v9.18.0
 	github.com/rs/zerolog v1.34.0
 	github.com/slack-go/slack v0.17.3
 	github.com/stretchr/testify v1.11.1
@@ -63,6 +65,7 @@ require (
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
+	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
@@ -88,9 +91,11 @@ require (
 	github.com/saintfish/chardet v0.0.0-20230101081208-5e3ef4b5456d // indirect
 	github.com/stretchr/objx v0.5.3 // indirect
 	github.com/temoto/robotstxt v1.1.2 // indirect
+	github.com/yuin/gopher-lua v1.1.1 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.43.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
+	go.uber.org/atomic v1.11.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.4 // indirect
 	golang.org/x/crypto v0.49.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/MicahParks/keyfunc/v3 v3.7.0 h1:pdafUNyq+p3ZlvjJX1HWFP7MA3+cLpDtg69U3
 github.com/MicahParks/keyfunc/v3 v3.7.0/go.mod h1:z66bkCviwqfg2YUp+Jcc/xRE9IXLcMq6DrgV/+Htru0=
 github.com/PuerkitoBio/goquery v1.10.3 h1:pFYcNSqHxBD06Fpj/KsbStFRsgRATgnf3LeXiUkhzPo=
 github.com/PuerkitoBio/goquery v1.10.3/go.mod h1:tMUX0zDMHXYlAQk6p35XxQMqMweEKB7iK7iLNd4RH4Y=
+github.com/alicebob/miniredis/v2 v2.37.0 h1:RheObYW32G1aiJIj81XVt78ZHJpHonHLHW7OLIshq68=
+github.com/alicebob/miniredis/v2 v2.37.0/go.mod h1:TcL7YfarKPGDAthEtl5NBeHZfeUQj6OXMm/+iu5cLMM=
 github.com/andybalholm/cascadia v1.3.3 h1:AG2YHrzJIm4BZ19iwJ/DAua6Btl3IwJX+VI4kktS1LM=
 github.com/andybalholm/cascadia v1.3.3/go.mod h1:xNd9bqTn98Ln4DwST8/nG+H0yuB8Hmgu1YHNnWw0GeA=
 github.com/antchfx/htmlquery v1.3.4 h1:Isd0srPkni2iNTWCwVj/72t7uCphFeor5Q8nCzj1jdQ=
@@ -61,6 +63,10 @@ github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6r
 github.com/bits-and-blooms/bitset v1.20.0/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
 github.com/bits-and-blooms/bitset v1.24.3 h1:Bte86SlO3lwPQqww+7BE9ZuUCKIjfqnG5jtEyqA9y9Y=
 github.com/bits-and-blooms/bitset v1.24.3/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
+github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=
+github.com/bsm/ginkgo/v2 v2.12.0/go.mod h1:SwYbGRRDovPVboqFv0tPTcG1sN61LM1Z4ARdbAV9g4c=
+github.com/bsm/gomega v1.27.10 h1:yeMWxP2pV2fG3FgAODIY8EiRE3dy0aeFYt4l7wh6yKA=
+github.com/bsm/gomega v1.27.10/go.mod h1:JyEr/xRbxbtgWNi8tIEVPUYZ5Dzef52k01W3YH0H+O0=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
@@ -69,6 +75,8 @@ github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSV
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/getsentry/sentry-go v0.36.2 h1:uhuxRPTrUy0dnSzTd0LrYXlBYygLkKY0hhlG5LXarzM=
@@ -125,6 +133,8 @@ github.com/kennygrant/sanitize v1.2.4/go.mod h1:LGsjYYtgxbetdg5owWB2mpgUL6e2nfw2
 github.com/kisielk/sqlstruct v0.0.0-20201105191214-5f3e10d3ab46/go.mod h1:yyMNCyc/Ib3bDTKd379tNMpB/7/H5TjM2Y9QJ5THLbE=
 github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zttxdo=
 github.com/klauspost/compress v1.18.0/go.mod h1:2Pp+KzxcywXVXMr50+X0Q/Lsb43OQHYWRCY2AiWywWQ=
+github.com/klauspost/cpuid/v2 v2.0.9 h1:lgaqFMSdTdQYdZ04uHyN2d/eKdOMyi2YLSvlQIBFYa4=
+github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
@@ -163,6 +173,8 @@ github.com/prometheus/otlptranslator v1.0.0 h1:s0LJW/iN9dkIH+EnhiD3BlkkP5QVIUVEo
 github.com/prometheus/otlptranslator v1.0.0/go.mod h1:vRYWnXvI6aWGpsdY/mOT/cbeVRBlPWtBNDb7kGR3uKM=
 github.com/prometheus/procfs v0.20.1 h1:XwbrGOIplXW/AU3YhIhLODXMJYyC1isLFfYCsTEycfc=
 github.com/prometheus/procfs v0.20.1/go.mod h1:o9EMBZGRyvDrSPH1RqdxhojkuXstoe4UlK79eF5TGGo=
+github.com/redis/go-redis/v9 v9.18.0 h1:pMkxYPkEbMPwRdenAzUNyFNrDgHx9U+DrBabWNfSRQs=
+github.com/redis/go-redis/v9 v9.18.0/go.mod h1:k3ufPphLU5YXwNTUcCRXGxUoF1fqxnhFQmscfkCoDA0=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/rs/xid v1.6.0/go.mod h1:7XoLgs4eV+QndskICGsho+ADou8ySMSjJKDIan90Nz0=
@@ -182,6 +194,10 @@ github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD
 github.com/temoto/robotstxt v1.1.2 h1:W2pOjSJ6SWvldyEuiFXNxz3xZ8aiWX5LbfDiOFd7Fxg=
 github.com/temoto/robotstxt v1.1.2/go.mod h1:+1AmkuG3IYkh1kv0d2qEB9Le88ehNO0zwOr3ujewlOo=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
+github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=
+github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
+github.com/zeebo/xxh3 v1.0.2 h1:xZmwmqxHZA8AI603jOQ0tMqmBr9lPeFwGg6d+xy9DC0=
+github.com/zeebo/xxh3 v1.0.2/go.mod h1:5NWz9Sef7zIDm2JHfFlcQvNekmcEl9ekUZQQKCYaDcA=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.63.0 h1:RbKq8BG0FI8OiXhBfcRtqqHcZcka+gU3cskNuf05R18=
@@ -206,6 +222,8 @@ go.opentelemetry.io/otel/trace v1.43.0 h1:BkNrHpup+4k4w+ZZ86CZoHHEkohws8AY+WTX09
 go.opentelemetry.io/otel/trace v1.43.0/go.mod h1:/QJhyVBUUswCphDVxq+8mld+AvhXZLhe+8WVFxiFff0=
 go.opentelemetry.io/proto/otlp v1.10.0 h1:IQRWgT5srOCYfiWnpqUYz9CVmbO8bFmKcwYxpuCSL2g=
 go.opentelemetry.io/proto/otlp v1.10.0/go.mod h1:/CV4QoCR/S9yaPj8utp3lvQPoqMtxXdzn7ozvvozVqk=
+go.uber.org/atomic v1.11.0 h1:ZvwS0R+56ePWxUNi+Atn9dWONBPp/AUETXlHW0DxSjE=
+go.uber.org/atomic v1.11.0/go.mod h1:LUxbIzbOniOlMKjJjyPfpl4v+PKK2cNJn91OQbhoJI0=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.yaml.in/yaml/v2 v2.4.4 h1:tuyd0P+2Ont/d6e2rl3be67goVK4R6deVxCUX5vyPaQ=

--- a/internal/broker/consumer.go
+++ b/internal/broker/consumer.go
@@ -263,6 +263,13 @@ func parseStreamMessage(xMsg redis.XMessage) (StreamMessage, error) {
 		return v
 	}
 
+	// Validate required string fields.
+	for _, key := range []string{"task_id", "job_id", "host", "path"} {
+		if get(key) == "" {
+			return StreamMessage{}, fmt.Errorf("missing required field: %s", key)
+		}
+	}
+
 	pageID, err := strconv.Atoi(get("page_id"))
 	if err != nil {
 		return StreamMessage{}, fmt.Errorf("bad page_id: %w", err)

--- a/internal/broker/consumer.go
+++ b/internal/broker/consumer.go
@@ -1,0 +1,291 @@
+package broker
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+	"github.com/rs/zerolog"
+)
+
+// StreamMessage is a parsed task envelope read from a Redis Stream.
+type StreamMessage struct {
+	// MessageID is the Redis stream entry ID (e.g. "1234567890-0").
+	MessageID string
+
+	TaskID     string
+	JobID      string
+	PageID     int
+	Host       string
+	Path       string
+	Priority   float64
+	RetryCount int
+	SourceType string
+	SourceURL  string
+}
+
+// ConsumerOpts controls stream reading behaviour.
+type ConsumerOpts struct {
+	// ConsumerName uniquely identifies this consumer within the group.
+	// Typically "worker-{machineID}-{goroutineID}".
+	ConsumerName string
+
+	// BlockTimeout is the XREADGROUP BLOCK duration. Default 2s.
+	BlockTimeout time.Duration
+
+	// Count is the max messages per XREADGROUP call. Default 1.
+	Count int64
+
+	// ClaimInterval is how often the XAUTOCLAIM sweep runs. Default 30s.
+	ClaimInterval time.Duration
+
+	// MinIdleTime is the XAUTOCLAIM min-idle-time. Messages pending
+	// longer than this are reclaimed. Default 3min (TaskStaleTimeout).
+	MinIdleTime time.Duration
+
+	// MaxDeliveries is the maximum number of times a message can be
+	// delivered before it is treated as a permanent failure. Default 3.
+	MaxDeliveries int64
+}
+
+// DefaultConsumerOpts returns production defaults.
+func DefaultConsumerOpts(consumerName string) ConsumerOpts {
+	return ConsumerOpts{
+		ConsumerName:  consumerName,
+		BlockTimeout:  time.Duration(envInt("REDIS_CONSUMER_BLOCK_MS", 2000)) * time.Millisecond,
+		Count:         1,
+		ClaimInterval: time.Duration(envInt("REDIS_AUTOCLAIM_INTERVAL_S", 30)) * time.Second,
+		MinIdleTime:   3 * time.Minute,
+		MaxDeliveries: 3,
+	}
+}
+
+// Consumer reads from one or more job streams via XREADGROUP and
+// reclaims stale messages via XAUTOCLAIM.
+type Consumer struct {
+	client *Client
+	opts   ConsumerOpts
+	logger zerolog.Logger
+}
+
+// NewConsumer creates a Consumer.
+func NewConsumer(client *Client, opts ConsumerOpts, logger zerolog.Logger) *Consumer {
+	return &Consumer{
+		client: client,
+		opts:   opts,
+		logger: logger.With().Str("component", "consumer").Str("consumer", opts.ConsumerName).Logger(),
+	}
+}
+
+// Read fetches new messages from the given job's stream. It blocks
+// for up to opts.BlockTimeout if no messages are available.
+// Returns nil (not error) when no messages are ready.
+func (c *Consumer) Read(ctx context.Context, jobID string) ([]StreamMessage, error) {
+	streamKey := StreamKey(jobID)
+	groupName := ConsumerGroup(jobID)
+
+	streams, err := c.client.rdb.XReadGroup(ctx, &redis.XReadGroupArgs{
+		Group:    groupName,
+		Consumer: c.opts.ConsumerName,
+		Streams:  []string{streamKey, ">"},
+		Count:    c.opts.Count,
+		Block:    c.opts.BlockTimeout,
+	}).Result()
+	if err == redis.Nil {
+		return nil, nil
+	}
+	if err != nil {
+		// Stream or consumer group doesn't exist yet — not an error,
+		// the dispatcher creates both lazily on first XADD.
+		if isNoGroupErr(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("broker: XREADGROUP %s: %w", jobID, err)
+	}
+
+	var msgs []StreamMessage
+	for _, stream := range streams {
+		for _, xMsg := range stream.Messages {
+			msg, err := parseStreamMessage(xMsg)
+			if err != nil {
+				c.logger.Warn().Err(err).Str("message_id", xMsg.ID).Msg("skipping malformed stream message")
+				// ACK to prevent infinite redelivery of bad messages.
+				_ = c.Ack(ctx, jobID, xMsg.ID)
+				continue
+			}
+			msgs = append(msgs, msg)
+		}
+	}
+	return msgs, nil
+}
+
+// ReadNonBlocking is like Read but returns immediately if no messages
+// are available. Useful for round-robin scanning across multiple jobs.
+func (c *Consumer) ReadNonBlocking(ctx context.Context, jobID string) ([]StreamMessage, error) {
+	streamKey := StreamKey(jobID)
+	groupName := ConsumerGroup(jobID)
+
+	streams, err := c.client.rdb.XReadGroup(ctx, &redis.XReadGroupArgs{
+		Group:    groupName,
+		Consumer: c.opts.ConsumerName,
+		Streams:  []string{streamKey, ">"},
+		Count:    c.opts.Count,
+		Block:    0, // non-blocking
+	}).Result()
+	if err == redis.Nil {
+		return nil, nil
+	}
+	if err != nil {
+		if isNoGroupErr(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("broker: XREADGROUP (non-blocking) %s: %w", jobID, err)
+	}
+
+	var msgs []StreamMessage
+	for _, stream := range streams {
+		for _, xMsg := range stream.Messages {
+			msg, err := parseStreamMessage(xMsg)
+			if err != nil {
+				c.logger.Warn().Err(err).Str("message_id", xMsg.ID).Msg("skipping malformed stream message")
+				_ = c.Ack(ctx, jobID, xMsg.ID)
+				continue
+			}
+			msgs = append(msgs, msg)
+		}
+	}
+	return msgs, nil
+}
+
+// Ack acknowledges one or more messages, removing them from the
+// pending entries list (PEL).
+func (c *Consumer) Ack(ctx context.Context, jobID string, messageIDs ...string) error {
+	if len(messageIDs) == 0 {
+		return nil
+	}
+	streamKey := StreamKey(jobID)
+	groupName := ConsumerGroup(jobID)
+	return c.client.rdb.XAck(ctx, streamKey, groupName, messageIDs...).Err()
+}
+
+// ReclaimStale uses XAUTOCLAIM to take ownership of messages that
+// have been pending longer than MinIdleTime. Returns the reclaimed
+// messages. Messages that have been delivered more than MaxDeliveries
+// times are returned separately as dead-letter candidates.
+func (c *Consumer) ReclaimStale(ctx context.Context, jobID string) (reclaimed []StreamMessage, deadLetter []StreamMessage, err error) {
+	streamKey := StreamKey(jobID)
+	groupName := ConsumerGroup(jobID)
+
+	// Stream may not exist yet if no tasks have been dispatched.
+	msgs, start, err := c.client.rdb.XAutoClaim(ctx, &redis.XAutoClaimArgs{
+		Stream:   streamKey,
+		Group:    groupName,
+		Consumer: c.opts.ConsumerName,
+		MinIdle:  c.opts.MinIdleTime,
+		Start:    "0-0",
+		Count:    10,
+	}).Result()
+	if err != nil {
+		if isNoGroupErr(err) {
+			return nil, nil, nil
+		}
+		return nil, nil, fmt.Errorf("broker: XAUTOCLAIM %s: %w", jobID, err)
+	}
+
+	_ = start // next cursor, unused for now — single pass per tick
+
+	for _, xMsg := range msgs {
+		msg, parseErr := parseStreamMessage(xMsg)
+		if parseErr != nil {
+			c.logger.Warn().Err(parseErr).Str("message_id", xMsg.ID).Msg("dead-lettering unparseable reclaimed message")
+			_ = c.Ack(ctx, jobID, xMsg.ID)
+			continue
+		}
+
+		// Check delivery count via XPENDING for this message.
+		deliveries, err := c.getDeliveryCount(ctx, streamKey, groupName, xMsg.ID)
+		if err != nil {
+			c.logger.Warn().Err(err).Str("message_id", xMsg.ID).Msg("failed to check delivery count")
+			// Treat as reclaimable to avoid losing work.
+			reclaimed = append(reclaimed, msg)
+			continue
+		}
+
+		if deliveries >= c.opts.MaxDeliveries {
+			deadLetter = append(deadLetter, msg)
+		} else {
+			reclaimed = append(reclaimed, msg)
+		}
+	}
+
+	return reclaimed, deadLetter, nil
+}
+
+// getDeliveryCount returns how many times a specific message has been
+// delivered to consumers.
+func (c *Consumer) getDeliveryCount(ctx context.Context, streamKey, groupName, messageID string) (int64, error) {
+	// XPENDING with a specific range of just this message ID.
+	pending, err := c.client.rdb.XPendingExt(ctx, &redis.XPendingExtArgs{
+		Stream: streamKey,
+		Group:  groupName,
+		Start:  messageID,
+		End:    messageID,
+		Count:  1,
+	}).Result()
+	if err != nil {
+		return 0, err
+	}
+	if len(pending) == 0 {
+		return 0, nil
+	}
+	return pending[0].RetryCount, nil
+}
+
+// isNoGroupErr returns true when Redis reports that the stream or
+// consumer group doesn't exist. This is expected before the
+// dispatcher first XADDs to a job's stream.
+func isNoGroupErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	s := err.Error()
+	return strings.Contains(s, "NOGROUP") || strings.Contains(s, "no such key")
+}
+
+// --- parsing ---
+
+func parseStreamMessage(xMsg redis.XMessage) (StreamMessage, error) {
+	get := func(key string) string {
+		v, _ := xMsg.Values[key].(string)
+		return v
+	}
+
+	pageID, err := strconv.Atoi(get("page_id"))
+	if err != nil {
+		return StreamMessage{}, fmt.Errorf("bad page_id: %w", err)
+	}
+	priority, err := strconv.ParseFloat(get("priority"), 64)
+	if err != nil {
+		return StreamMessage{}, fmt.Errorf("bad priority: %w", err)
+	}
+	retryCount, err := strconv.Atoi(get("retry_count"))
+	if err != nil {
+		return StreamMessage{}, fmt.Errorf("bad retry_count: %w", err)
+	}
+
+	return StreamMessage{
+		MessageID:  xMsg.ID,
+		TaskID:     get("task_id"),
+		JobID:      get("job_id"),
+		PageID:     pageID,
+		Host:       get("host"),
+		Path:       get("path"),
+		Priority:   priority,
+		RetryCount: retryCount,
+		SourceType: get("source_type"),
+		SourceURL:  get("source_url"),
+	}, nil
+}

--- a/internal/broker/counters.go
+++ b/internal/broker/counters.go
@@ -1,0 +1,167 @@
+package broker
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+	"github.com/rs/zerolog"
+)
+
+// RunningCounters tracks how many tasks are currently in-flight per
+// job using a single Redis HASH. This replaces the in-memory atomic
+// counters and async DB flush loops in the old worker pool.
+type RunningCounters struct {
+	client *Client
+	logger zerolog.Logger
+}
+
+// NewRunningCounters creates a RunningCounters.
+func NewRunningCounters(client *Client, logger zerolog.Logger) *RunningCounters {
+	return &RunningCounters{
+		client: client,
+		logger: logger.With().Str("component", "counters").Logger(),
+	}
+}
+
+// Increment atomically bumps the running count for a job.
+// Returns the new count.
+func (rc *RunningCounters) Increment(ctx context.Context, jobID string) (int64, error) {
+	return rc.client.rdb.HIncrBy(ctx, RunningCountersKey, jobID, 1).Result()
+}
+
+// Decrement atomically reduces the running count for a job.
+// Returns the new count. Cleans up zero entries.
+func (rc *RunningCounters) Decrement(ctx context.Context, jobID string) (int64, error) {
+	val, err := rc.client.rdb.HIncrBy(ctx, RunningCountersKey, jobID, -1).Result()
+	if err != nil {
+		return 0, err
+	}
+	if val <= 0 {
+		// Remove zero/negative entries to keep the hash clean.
+		rc.client.rdb.HDel(ctx, RunningCountersKey, jobID)
+		return 0, nil
+	}
+	return val, nil
+}
+
+// Get returns the current running count for a single job.
+func (rc *RunningCounters) Get(ctx context.Context, jobID string) (int64, error) {
+	val, err := rc.client.rdb.HGet(ctx, RunningCountersKey, jobID).Int64()
+	if err == redis.Nil {
+		return 0, nil
+	}
+	return val, err
+}
+
+// GetAll returns the running counts for all jobs.
+func (rc *RunningCounters) GetAll(ctx context.Context) (map[string]int64, error) {
+	result, err := rc.client.rdb.HGetAll(ctx, RunningCountersKey).Result()
+	if err != nil {
+		return nil, err
+	}
+
+	counts := make(map[string]int64, len(result))
+	for jobID, v := range result {
+		n, _ := strconv.ParseInt(v, 10, 64)
+		counts[jobID] = n
+	}
+	return counts, nil
+}
+
+// Reconcile sets the running counters from an authoritative source
+// (typically a Postgres query on startup). This overwrites any
+// stale state in Redis.
+func (rc *RunningCounters) Reconcile(ctx context.Context, counts map[string]int64) error {
+	if len(counts) == 0 {
+		// No running tasks — clear the hash.
+		return rc.client.rdb.Del(ctx, RunningCountersKey).Err()
+	}
+
+	pipe := rc.client.rdb.Pipeline()
+	// Delete existing hash and rebuild.
+	pipe.Del(ctx, RunningCountersKey)
+	fields := make([]interface{}, 0, len(counts)*2)
+	for jobID, count := range counts {
+		if count > 0 {
+			fields = append(fields, jobID, strconv.FormatInt(count, 10))
+		}
+	}
+	if len(fields) > 0 {
+		pipe.HSet(ctx, RunningCountersKey, fields...)
+	}
+
+	_, err := pipe.Exec(ctx)
+	return err
+}
+
+// RemoveJob clears the running counter for a specific job
+// (e.g. on job completion/cancellation).
+func (rc *RunningCounters) RemoveJob(ctx context.Context, jobID string) error {
+	return rc.client.rdb.HDel(ctx, RunningCountersKey, jobID).Err()
+}
+
+// --- Periodic DB sync ---
+
+// DBSyncFunc is called periodically to write running counters back
+// to Postgres for API visibility. The function receives a map of
+// jobID -> count.
+type DBSyncFunc func(ctx context.Context, counts map[string]int64) error
+
+// StartDBSync runs a background loop that periodically reads all
+// running counters from Redis and calls syncFn to persist them to
+// Postgres. Blocks until ctx is cancelled.
+func (rc *RunningCounters) StartDBSync(ctx context.Context, interval time.Duration, syncFn DBSyncFunc) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			counts, err := rc.GetAll(ctx)
+			if err != nil {
+				rc.logger.Error().Err(err).Msg("failed to read running counters for DB sync")
+				continue
+			}
+			if err := syncFn(ctx, counts); err != nil {
+				rc.logger.Error().Err(err).Msg("failed to sync running counters to DB")
+			}
+		}
+	}
+}
+
+// DefaultDBSyncFunc returns a DBSyncFunc that updates the jobs table
+// running_tasks column using the provided *sql.DB.
+func DefaultDBSyncFunc(sqlDB *sql.DB) DBSyncFunc {
+	return func(ctx context.Context, counts map[string]int64) error {
+		if len(counts) == 0 {
+			return nil
+		}
+
+		tx, err := sqlDB.BeginTx(ctx, nil)
+		if err != nil {
+			return fmt.Errorf("begin tx: %w", err)
+		}
+		defer tx.Rollback()
+
+		stmt, err := tx.PrepareContext(ctx,
+			`UPDATE jobs SET running_tasks = $1 WHERE id = $2 AND status IN ('running', 'pending')`)
+		if err != nil {
+			return fmt.Errorf("prepare stmt: %w", err)
+		}
+		defer stmt.Close()
+
+		for jobID, count := range counts {
+			if _, err := stmt.ExecContext(ctx, count, jobID); err != nil {
+				return fmt.Errorf("update job %s: %w", jobID, err)
+			}
+		}
+
+		return tx.Commit()
+	}
+}

--- a/internal/broker/counters_test.go
+++ b/internal/broker/counters_test.go
@@ -42,9 +42,12 @@ func TestRunningCounters_GetAll(t *testing.T) {
 	rc := NewRunningCounters(client, zerolog.Nop())
 	ctx := context.Background()
 
-	_, _ = rc.Increment(ctx, "j1")
-	_, _ = rc.Increment(ctx, "j1")
-	_, _ = rc.Increment(ctx, "j2")
+	_, err := rc.Increment(ctx, "j1")
+	require.NoError(t, err)
+	_, err = rc.Increment(ctx, "j1")
+	require.NoError(t, err)
+	_, err = rc.Increment(ctx, "j2")
+	require.NoError(t, err)
 
 	counts, err := rc.GetAll(ctx)
 	require.NoError(t, err)
@@ -58,10 +61,11 @@ func TestRunningCounters_Reconcile(t *testing.T) {
 	ctx := context.Background()
 
 	// Start with some stale data.
-	_, _ = rc.Increment(ctx, "stale-job")
+	_, err := rc.Increment(ctx, "stale-job")
+	require.NoError(t, err)
 
 	// Reconcile with authoritative counts.
-	err := rc.Reconcile(ctx, map[string]int64{
+	err = rc.Reconcile(ctx, map[string]int64{
 		"j1": 5,
 		"j2": 3,
 	})

--- a/internal/broker/counters_test.go
+++ b/internal/broker/counters_test.go
@@ -1,0 +1,79 @@
+package broker
+
+import (
+	"context"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunningCounters_IncrementDecrement(t *testing.T) {
+	client, _ := newTestClient(t)
+	rc := NewRunningCounters(client, zerolog.Nop())
+	ctx := context.Background()
+
+	val, err := rc.Increment(ctx, "job-1")
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), val)
+
+	val, err = rc.Increment(ctx, "job-1")
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), val)
+
+	val, err = rc.Decrement(ctx, "job-1")
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), val)
+
+	// Decrement to zero should clean up.
+	val, err = rc.Decrement(ctx, "job-1")
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), val)
+
+	// Get after cleanup should return 0.
+	val, err = rc.Get(ctx, "job-1")
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), val)
+}
+
+func TestRunningCounters_GetAll(t *testing.T) {
+	client, _ := newTestClient(t)
+	rc := NewRunningCounters(client, zerolog.Nop())
+	ctx := context.Background()
+
+	_, _ = rc.Increment(ctx, "j1")
+	_, _ = rc.Increment(ctx, "j1")
+	_, _ = rc.Increment(ctx, "j2")
+
+	counts, err := rc.GetAll(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), counts["j1"])
+	assert.Equal(t, int64(1), counts["j2"])
+}
+
+func TestRunningCounters_Reconcile(t *testing.T) {
+	client, _ := newTestClient(t)
+	rc := NewRunningCounters(client, zerolog.Nop())
+	ctx := context.Background()
+
+	// Start with some stale data.
+	_, _ = rc.Increment(ctx, "stale-job")
+
+	// Reconcile with authoritative counts.
+	err := rc.Reconcile(ctx, map[string]int64{
+		"j1": 5,
+		"j2": 3,
+	})
+	require.NoError(t, err)
+
+	// Stale job should be gone.
+	val, err := rc.Get(ctx, "stale-job")
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), val)
+
+	// New values should be set.
+	val, err = rc.Get(ctx, "j1")
+	require.NoError(t, err)
+	assert.Equal(t, int64(5), val)
+}

--- a/internal/broker/dispatcher.go
+++ b/internal/broker/dispatcher.go
@@ -1,0 +1,251 @@
+package broker
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+	"github.com/rs/zerolog"
+)
+
+// DispatcherOpts controls the dispatcher's scan behaviour.
+type DispatcherOpts struct {
+	// ScanInterval is how often the dispatcher sweeps all active job
+	// ZSETs for due items. Default 100ms.
+	ScanInterval time.Duration
+
+	// BatchSize is the maximum number of ZSET entries fetched per job
+	// per scan tick. Default 50.
+	BatchSize int64
+}
+
+// DefaultDispatcherOpts returns production defaults, optionally
+// overridden by environment variables.
+func DefaultDispatcherOpts() DispatcherOpts {
+	interval := time.Duration(envInt("REDIS_DISPATCH_INTERVAL_MS", 100)) * time.Millisecond
+	batch := int64(envInt("REDIS_DISPATCH_BATCH_SIZE", 50))
+	return DispatcherOpts{
+		ScanInterval: interval,
+		BatchSize:    batch,
+	}
+}
+
+// JobLister returns the set of active job IDs the dispatcher should
+// scan. Implementations typically query Postgres.
+type JobLister interface {
+	ActiveJobIDs(ctx context.Context) ([]string, error)
+}
+
+// ConcurrencyChecker determines whether a job has capacity for more
+// in-flight tasks.
+type ConcurrencyChecker interface {
+	// CanDispatch returns true if the job has room for another task.
+	CanDispatch(ctx context.Context, jobID string) (bool, error)
+}
+
+// Dispatcher is a long-running goroutine that moves due items from
+// per-job Redis ZSETs into per-job Redis Streams.
+type Dispatcher struct {
+	scheduler  *Scheduler
+	pacer      *DomainPacer
+	counters   *RunningCounters
+	client     *Client
+	jobLister  JobLister
+	concCheck  ConcurrencyChecker
+	opts       DispatcherOpts
+	logger     zerolog.Logger
+}
+
+// NewDispatcher creates a Dispatcher.
+func NewDispatcher(
+	client *Client,
+	scheduler *Scheduler,
+	pacer *DomainPacer,
+	counters *RunningCounters,
+	jobLister JobLister,
+	concCheck ConcurrencyChecker,
+	opts DispatcherOpts,
+	logger zerolog.Logger,
+) *Dispatcher {
+	return &Dispatcher{
+		scheduler: scheduler,
+		pacer:     pacer,
+		counters:  counters,
+		client:    client,
+		jobLister: jobLister,
+		concCheck: concCheck,
+		opts:      opts,
+		logger:    logger.With().Str("component", "dispatcher").Logger(),
+	}
+}
+
+// Run is the dispatcher's main loop. It blocks until ctx is
+// cancelled. Start it as a goroutine.
+func (d *Dispatcher) Run(ctx context.Context) {
+	ticker := time.NewTicker(d.opts.ScanInterval)
+	defer ticker.Stop()
+
+	d.logger.Info().
+		Dur("interval", d.opts.ScanInterval).
+		Int64("batch", d.opts.BatchSize).
+		Msg("dispatcher started")
+
+	for {
+		select {
+		case <-ctx.Done():
+			d.logger.Info().Msg("dispatcher stopping")
+			return
+		case <-ticker.C:
+			d.tick(ctx)
+		}
+	}
+}
+
+func (d *Dispatcher) tick(ctx context.Context) {
+	jobIDs, err := d.jobLister.ActiveJobIDs(ctx)
+	if err != nil {
+		d.logger.Error().Err(err).Msg("failed to list active jobs")
+		return
+	}
+
+	now := time.Now()
+	for _, jobID := range jobIDs {
+		if ctx.Err() != nil {
+			return
+		}
+		dispatched, err := d.dispatchJob(ctx, jobID, now)
+		if err != nil {
+			d.logger.Error().Err(err).Str("job_id", jobID).Msg("dispatch error")
+		}
+		if dispatched > 0 {
+			d.logger.Debug().Str("job_id", jobID).Int("dispatched", dispatched).Msg("dispatched tasks")
+		}
+	}
+}
+
+// dispatchJob moves due items from the job's ZSET to its Stream.
+// Returns the number of tasks successfully dispatched.
+func (d *Dispatcher) dispatchJob(ctx context.Context, jobID string, now time.Time) (int, error) {
+	entries, err := d.scheduler.DueItems(ctx, jobID, now, d.opts.BatchSize)
+	if err != nil {
+		return 0, err
+	}
+	if len(entries) == 0 {
+		return 0, nil
+	}
+
+	dispatched := 0
+	for i := range entries {
+		entry := &entries[i]
+
+		// Check job-level concurrency.
+		canDispatch, err := d.concCheck.CanDispatch(ctx, jobID)
+		if err != nil {
+			d.logger.Warn().Err(err).Str("job_id", jobID).Msg("concurrency check failed, skipping batch")
+			break
+		}
+		if !canDispatch {
+			// Job at capacity — remaining items stay in ZSET.
+			break
+		}
+
+		// Check domain pacing.
+		domain := entry.Host
+		paceResult, err := d.pacer.TryAcquire(ctx, domain)
+		if err != nil {
+			d.logger.Warn().Err(err).Str("domain", domain).Msg("pacer check failed")
+			continue
+		}
+		if !paceResult.Acquired {
+			// Domain in delay window — reschedule with estimated wait.
+			newRunAt := now.Add(paceResult.RetryAfter)
+			if err := d.scheduler.Reschedule(ctx, jobID, entry.Member(), newRunAt); err != nil {
+				d.logger.Warn().Err(err).Str("task_id", entry.TaskID).Msg("reschedule failed")
+			}
+			continue
+		}
+
+		// Publish to stream.
+		if err := d.publishToStream(ctx, entry); err != nil {
+			// Release the domain permit since we didn't actually start work.
+			_ = d.pacer.Release(ctx, domain, jobID, false, false)
+			d.logger.Warn().Err(err).Str("task_id", entry.TaskID).Msg("stream publish failed")
+			continue
+		}
+
+		// Increment running counter.
+		if _, err := d.counters.Increment(ctx, jobID); err != nil {
+			d.logger.Warn().Err(err).Str("job_id", jobID).Msg("counter increment failed")
+		}
+
+		// Increment domain inflight counter.
+		if err := d.pacer.IncrementInflight(ctx, domain, jobID); err != nil {
+			d.logger.Warn().Err(err).Str("domain", domain).Msg("inflight increment failed")
+		}
+
+		// Remove from ZSET.
+		if err := d.scheduler.Remove(ctx, jobID, entry.Member()); err != nil {
+			d.logger.Warn().Err(err).Str("task_id", entry.TaskID).Msg("ZREM failed after dispatch")
+		}
+
+		dispatched++
+	}
+
+	return dispatched, nil
+}
+
+// publishToStream XADDs the task envelope to the job's stream,
+// creating the stream and consumer group lazily if needed.
+func (d *Dispatcher) publishToStream(ctx context.Context, entry *ScheduleEntry) error {
+	streamKey := StreamKey(entry.JobID)
+	groupName := ConsumerGroup(entry.JobID)
+
+	// Ensure consumer group exists (idempotent).
+	d.ensureConsumerGroup(ctx, streamKey, groupName)
+
+	args := &redis.XAddArgs{
+		Stream: streamKey,
+		Values: map[string]interface{}{
+			"task_id":     entry.TaskID,
+			"job_id":      entry.JobID,
+			"page_id":     strconv.Itoa(entry.PageID),
+			"host":        entry.Host,
+			"path":        entry.Path,
+			"priority":    fmt.Sprintf("%.4f", entry.Priority),
+			"retry_count": strconv.Itoa(entry.RetryCount),
+			"source_type": entry.SourceType,
+			"source_url":  entry.SourceURL,
+		},
+	}
+
+	return d.client.rdb.XAdd(ctx, args).Err()
+}
+
+// ensureConsumerGroup creates the consumer group if it doesn't exist.
+// Errors are logged but not propagated — the group may already exist.
+func (d *Dispatcher) ensureConsumerGroup(ctx context.Context, streamKey, groupName string) {
+	err := d.client.rdb.XGroupCreateMkStream(ctx, streamKey, groupName, "0").Err()
+	if err != nil && !isGroupExistsErr(err) {
+		d.logger.Warn().Err(err).Str("stream", streamKey).Msg("failed to create consumer group")
+	}
+}
+
+func isGroupExistsErr(err error) bool {
+	return err != nil && err.Error() == "BUSYGROUP Consumer Group name already exists"
+}
+
+// envDuration reads a duration-in-milliseconds from the environment.
+func envDuration(key string, defMS int) time.Duration {
+	v := os.Getenv(key)
+	if v == "" {
+		return time.Duration(defMS) * time.Millisecond
+	}
+	ms, err := strconv.Atoi(v)
+	if err != nil {
+		return time.Duration(defMS) * time.Millisecond
+	}
+	return time.Duration(ms) * time.Millisecond
+}

--- a/internal/broker/dispatcher.go
+++ b/internal/broker/dispatcher.go
@@ -49,14 +49,14 @@ type ConcurrencyChecker interface {
 // Dispatcher is a long-running goroutine that moves due items from
 // per-job Redis ZSETs into per-job Redis Streams.
 type Dispatcher struct {
-	scheduler  *Scheduler
-	pacer      *DomainPacer
-	counters   *RunningCounters
-	client     *Client
-	jobLister  JobLister
-	concCheck  ConcurrencyChecker
-	opts       DispatcherOpts
-	logger     zerolog.Logger
+	scheduler *Scheduler
+	pacer     *DomainPacer
+	counters  *RunningCounters
+	client    *Client
+	jobLister JobLister
+	concCheck ConcurrencyChecker
+	opts      DispatcherOpts
+	logger    zerolog.Logger
 }
 
 // NewDispatcher creates a Dispatcher.

--- a/internal/broker/dispatcher.go
+++ b/internal/broker/dispatcher.go
@@ -3,8 +3,8 @@ package broker
 import (
 	"context"
 	"fmt"
-	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/redis/go-redis/v9"
@@ -168,11 +168,10 @@ func (d *Dispatcher) dispatchJob(ctx context.Context, jobID string, now time.Tim
 			continue
 		}
 
-		// Publish to stream.
-		if err := d.publishToStream(ctx, entry); err != nil {
-			// Release the domain permit since we didn't actually start work.
+		// Publish to stream and remove from ZSET atomically via pipeline.
+		if err := d.publishAndRemove(ctx, entry); err != nil {
 			_ = d.pacer.Release(ctx, domain, jobID, false, false)
-			d.logger.Warn().Err(err).Str("task_id", entry.TaskID).Msg("stream publish failed")
+			d.logger.Warn().Err(err).Str("task_id", entry.TaskID).Msg("stream publish+remove failed")
 			continue
 		}
 
@@ -186,27 +185,24 @@ func (d *Dispatcher) dispatchJob(ctx context.Context, jobID string, now time.Tim
 			d.logger.Warn().Err(err).Str("domain", domain).Msg("inflight increment failed")
 		}
 
-		// Remove from ZSET.
-		if err := d.scheduler.Remove(ctx, jobID, entry.Member()); err != nil {
-			d.logger.Warn().Err(err).Str("task_id", entry.TaskID).Msg("ZREM failed after dispatch")
-		}
-
 		dispatched++
 	}
 
 	return dispatched, nil
 }
 
-// publishToStream XADDs the task envelope to the job's stream,
-// creating the stream and consumer group lazily if needed.
-func (d *Dispatcher) publishToStream(ctx context.Context, entry *ScheduleEntry) error {
+// publishAndRemove atomically XADDs the task to the job's stream
+// and ZREMs it from the schedule ZSET in a single Redis pipeline,
+// preventing double-dispatch if either operation were to fail alone.
+func (d *Dispatcher) publishAndRemove(ctx context.Context, entry *ScheduleEntry) error {
 	streamKey := StreamKey(entry.JobID)
 	groupName := ConsumerGroup(entry.JobID)
 
 	// Ensure consumer group exists (idempotent).
 	d.ensureConsumerGroup(ctx, streamKey, groupName)
 
-	args := &redis.XAddArgs{
+	pipe := d.client.rdb.TxPipeline()
+	pipe.XAdd(ctx, &redis.XAddArgs{
 		Stream: streamKey,
 		Values: map[string]interface{}{
 			"task_id":     entry.TaskID,
@@ -219,9 +215,11 @@ func (d *Dispatcher) publishToStream(ctx context.Context, entry *ScheduleEntry) 
 			"source_type": entry.SourceType,
 			"source_url":  entry.SourceURL,
 		},
-	}
+	})
+	pipe.ZRem(ctx, ScheduleKey(entry.JobID), entry.Member())
 
-	return d.client.rdb.XAdd(ctx, args).Err()
+	_, err := pipe.Exec(ctx)
+	return err
 }
 
 // ensureConsumerGroup creates the consumer group if it doesn't exist.
@@ -234,18 +232,8 @@ func (d *Dispatcher) ensureConsumerGroup(ctx context.Context, streamKey, groupNa
 }
 
 func isGroupExistsErr(err error) bool {
-	return err != nil && err.Error() == "BUSYGROUP Consumer Group name already exists"
-}
-
-// envDuration reads a duration-in-milliseconds from the environment.
-func envDuration(key string, defMS int) time.Duration {
-	v := os.Getenv(key)
-	if v == "" {
-		return time.Duration(defMS) * time.Millisecond
+	if err == nil {
+		return false
 	}
-	ms, err := strconv.Atoi(v)
-	if err != nil {
-		return time.Duration(defMS) * time.Millisecond
-	}
-	return time.Duration(ms) * time.Millisecond
+	return strings.Contains(err.Error(), "BUSYGROUP")
 }

--- a/internal/broker/keys.go
+++ b/internal/broker/keys.go
@@ -47,4 +47,3 @@ func FormatScheduleEntry(taskID, jobID string, pageID int, host, path string, pr
 	return fmt.Sprintf("%s|%s|%d|%s|%s|%.4f|%d|%s|%s",
 		taskID, jobID, pageID, host, path, priority, retryCount, sourceType, sourceURL)
 }
-// Trigger CI

--- a/internal/broker/keys.go
+++ b/internal/broker/keys.go
@@ -47,3 +47,4 @@ func FormatScheduleEntry(taskID, jobID string, pageID int, host, path string, pr
 	return fmt.Sprintf("%s|%s|%d|%s|%s|%.4f|%d|%s|%s",
 		taskID, jobID, pageID, host, path, priority, retryCount, sourceType, sourceURL)
 }
+// Trigger CI

--- a/internal/broker/keys.go
+++ b/internal/broker/keys.go
@@ -1,0 +1,49 @@
+// Package broker provides Redis-backed task scheduling, dispatch, and
+// coordination primitives for the hover crawl execution pipeline.
+package broker
+
+import "fmt"
+
+// Redis key prefixes and patterns. Every key used by the broker is
+// defined here so naming stays consistent and grep-able.
+
+const keyPrefix = "hover:"
+
+// Schedule keys — sorted sets keyed by job, scored by earliest
+// runnable unix-millisecond timestamp.
+func ScheduleKey(jobID string) string { return keyPrefix + "sched:" + jobID }
+
+// Stream keys — per-job streams that hold ready-to-run task envelopes.
+func StreamKey(jobID string) string { return keyPrefix + "stream:" + jobID }
+
+// ConsumerGroup returns the consumer group name for a job stream.
+func ConsumerGroup(jobID string) string { return keyPrefix + "cg:" + jobID }
+
+// RunningCountersKey is a single hash whose fields are job IDs and
+// values are the number of tasks currently in-flight.
+const RunningCountersKey = keyPrefix + "running"
+
+// Domain pacing keys.
+
+// DomainGateKey is a short-lived string used as a time gate.
+// SET NX PX {delay_ms} prevents dispatching to the same domain
+// faster than its configured rate.
+func DomainGateKey(domain string) string { return keyPrefix + "dom:gate:" + domain }
+
+// DomainConfigKey is a hash storing adaptive delay state:
+// base_delay_ms, adaptive_delay_ms, floor_ms, success_streak, error_streak.
+func DomainConfigKey(domain string) string { return keyPrefix + "dom:cfg:" + domain }
+
+// DomainInflightKey is a hash whose fields are job IDs and values
+// are the number of inflight tasks for that domain+job pair.
+func DomainInflightKey(domain string) string { return keyPrefix + "dom:flight:" + domain }
+
+// ScheduleEntry is the member value stored inside the schedule ZSET.
+// It is serialised as a compact pipe-delimited string to avoid JSON
+// overhead on the hot scheduling path.
+//
+// Format: taskID|jobID|pageID|host|path|priority|retryCount|sourceType|sourceURL
+func FormatScheduleEntry(taskID, jobID string, pageID int, host, path string, priority float64, retryCount int, sourceType, sourceURL string) string {
+	return fmt.Sprintf("%s|%s|%d|%s|%s|%.4f|%d|%s|%s",
+		taskID, jobID, pageID, host, path, priority, retryCount, sourceType, sourceURL)
+}

--- a/internal/broker/pacer.go
+++ b/internal/broker/pacer.go
@@ -23,19 +23,14 @@ type PacerConfig struct {
 
 	// MaxDelayMS caps the adaptive delay. Default 60_000 (60s).
 	MaxDelayMS int
-
-	// RobotsDelayMultiplier scales the robots.txt Crawl-Delay.
-	// Default 0.5 (a 2s robots delay becomes 1s).
-	RobotsDelayMultiplier float64
 }
 
 // DefaultPacerConfig returns production defaults.
 func DefaultPacerConfig() PacerConfig {
 	return PacerConfig{
-		SuccessThreshold:      5,
-		DelayStepMS:           envInt("GNH_RATE_LIMIT_DELAY_STEP_MS", 500),
-		MaxDelayMS:            envInt("GNH_RATE_LIMIT_MAX_DELAY_SECONDS", 60) * 1000,
-		RobotsDelayMultiplier: 0.5,
+		SuccessThreshold: 5,
+		DelayStepMS:      envInt("GNH_RATE_LIMIT_DELAY_STEP_MS", 500),
+		MaxDelayMS:       envInt("GNH_RATE_LIMIT_MAX_DELAY_MS", 60000),
 	}
 }
 

--- a/internal/broker/pacer.go
+++ b/internal/broker/pacer.go
@@ -1,0 +1,214 @@
+package broker
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+	"github.com/rs/zerolog"
+)
+
+// PacerConfig holds the tuning knobs for domain pacing, mirroring
+// the constants from the current in-memory DomainLimiter.
+type PacerConfig struct {
+	// SuccessThreshold is the number of consecutive successes before
+	// the adaptive delay decreases. Default 5.
+	SuccessThreshold int
+
+	// DelayStepMS is the amount (milliseconds) the adaptive delay
+	// changes per adjustment. Default 500.
+	DelayStepMS int
+
+	// MaxDelayMS caps the adaptive delay. Default 60_000 (60s).
+	MaxDelayMS int
+
+	// RobotsDelayMultiplier scales the robots.txt Crawl-Delay.
+	// Default 0.5 (a 2s robots delay becomes 1s).
+	RobotsDelayMultiplier float64
+}
+
+// DefaultPacerConfig returns production defaults.
+func DefaultPacerConfig() PacerConfig {
+	return PacerConfig{
+		SuccessThreshold:      5,
+		DelayStepMS:           envInt("GNH_RATE_LIMIT_DELAY_STEP_MS", 500),
+		MaxDelayMS:            envInt("GNH_RATE_LIMIT_MAX_DELAY_SECONDS", 60) * 1000,
+		RobotsDelayMultiplier: 0.5,
+	}
+}
+
+// PaceResult is returned by TryAcquire.
+type PaceResult struct {
+	// Acquired is true if the domain time-gate was successfully set.
+	Acquired bool
+
+	// RetryAfter is how long the caller should wait before retrying.
+	// Only meaningful when Acquired is false.
+	RetryAfter time.Duration
+}
+
+// DomainPacer coordinates per-domain request rate across all worker
+// instances using Redis-backed time gates and adaptive delay state.
+type DomainPacer struct {
+	client *Client
+	cfg    PacerConfig
+	logger zerolog.Logger
+}
+
+// NewDomainPacer creates a DomainPacer.
+func NewDomainPacer(client *Client, cfg PacerConfig, logger zerolog.Logger) *DomainPacer {
+	return &DomainPacer{
+		client: client,
+		cfg:    cfg,
+		logger: logger.With().Str("component", "pacer").Logger(),
+	}
+}
+
+// Seed initialises the domain config hash with base delay values
+// (typically from robots.txt and Postgres domain record). Safe to
+// call multiple times — uses HSETNX so existing values are preserved.
+func (p *DomainPacer) Seed(ctx context.Context, domain string, baseDelayMS, adaptiveDelayMS, floorMS int) error {
+	key := DomainConfigKey(domain)
+	pipe := p.client.rdb.Pipeline()
+
+	pipe.HSetNX(ctx, key, "base_delay_ms", strconv.Itoa(baseDelayMS))
+	pipe.HSetNX(ctx, key, "adaptive_delay_ms", strconv.Itoa(adaptiveDelayMS))
+	pipe.HSetNX(ctx, key, "floor_ms", strconv.Itoa(floorMS))
+	pipe.HSetNX(ctx, key, "success_streak", "0")
+	pipe.HSetNX(ctx, key, "error_streak", "0")
+	pipe.Expire(ctx, key, 24*time.Hour)
+
+	_, err := pipe.Exec(ctx)
+	if err != nil {
+		return fmt.Errorf("broker: seed domain %s: %w", domain, err)
+	}
+	return nil
+}
+
+// TryAcquire attempts to set the domain time-gate. If the gate is
+// already held (domain was recently accessed), it returns the
+// remaining wait time. This is non-blocking.
+func (p *DomainPacer) TryAcquire(ctx context.Context, domain string) (PaceResult, error) {
+	delayMS, err := p.effectiveDelayMS(ctx, domain)
+	if err != nil {
+		return PaceResult{}, err
+	}
+
+	// A zero delay means no pacing — always acquire.
+	if delayMS <= 0 {
+		return PaceResult{Acquired: true}, nil
+	}
+
+	gateKey := DomainGateKey(domain)
+
+	// SET NX PX: only succeeds if key doesn't exist.
+	ok, err := p.client.rdb.SetNX(ctx, gateKey, "1", time.Duration(delayMS)*time.Millisecond).Result()
+	if err != nil {
+		return PaceResult{}, fmt.Errorf("broker: gate SET NX %s: %w", domain, err)
+	}
+
+	if ok {
+		return PaceResult{Acquired: true}, nil
+	}
+
+	// Gate exists — get remaining TTL.
+	ttl, err := p.client.rdb.PTTL(ctx, gateKey).Result()
+	if err != nil || ttl <= 0 {
+		// Key expired between SET NX and PTTL — treat as a short retry.
+		return PaceResult{Acquired: false, RetryAfter: time.Duration(delayMS) * time.Millisecond}, nil
+	}
+
+	return PaceResult{Acquired: false, RetryAfter: ttl}, nil
+}
+
+// Release is called after a crawl completes. It updates the adaptive
+// delay state based on the outcome.
+func (p *DomainPacer) Release(ctx context.Context, domain, jobID string, success, rateLimited bool) error {
+	cfgKey := DomainConfigKey(domain)
+
+	if success {
+		_, err := adaptiveDelayOnSuccessScript.Run(ctx, p.client.rdb,
+			[]string{cfgKey},
+			p.cfg.SuccessThreshold,
+			p.cfg.DelayStepMS,
+		).Result()
+		if err != nil {
+			return fmt.Errorf("broker: release success %s: %w", domain, err)
+		}
+	} else if rateLimited {
+		_, err := adaptiveDelayOnErrorScript.Run(ctx, p.client.rdb,
+			[]string{cfgKey},
+			p.cfg.DelayStepMS,
+			p.cfg.MaxDelayMS,
+		).Result()
+		if err != nil {
+			return fmt.Errorf("broker: release rate-limited %s: %w", domain, err)
+		}
+	}
+
+	// Decrement inflight.
+	return p.DecrementInflight(ctx, domain, jobID)
+}
+
+// IncrementInflight bumps the per-domain per-job inflight counter.
+func (p *DomainPacer) IncrementInflight(ctx context.Context, domain, jobID string) error {
+	key := DomainInflightKey(domain)
+	return p.client.rdb.HIncrBy(ctx, key, jobID, 1).Err()
+}
+
+// DecrementInflight reduces the per-domain per-job inflight counter.
+func (p *DomainPacer) DecrementInflight(ctx context.Context, domain, jobID string) error {
+	key := DomainInflightKey(domain)
+	val, err := p.client.rdb.HIncrBy(ctx, key, jobID, -1).Result()
+	if err != nil {
+		return err
+	}
+	// Clean up zero/negative entries.
+	if val <= 0 {
+		p.client.rdb.HDel(ctx, key, jobID)
+	}
+	return nil
+}
+
+// GetInflight returns the current inflight count for a domain+job.
+func (p *DomainPacer) GetInflight(ctx context.Context, domain, jobID string) (int64, error) {
+	val, err := p.client.rdb.HGet(ctx, DomainInflightKey(domain), jobID).Int64()
+	if err == redis.Nil {
+		return 0, nil
+	}
+	return val, err
+}
+
+// effectiveDelayMS returns the current effective delay for a domain,
+// combining base delay and adaptive delay.
+func (p *DomainPacer) effectiveDelayMS(ctx context.Context, domain string) (int, error) {
+	cfgKey := DomainConfigKey(domain)
+
+	vals, err := p.client.rdb.HMGet(ctx, cfgKey, "base_delay_ms", "adaptive_delay_ms").Result()
+	if err != nil {
+		return 0, fmt.Errorf("broker: effective delay %s: %w", domain, err)
+	}
+
+	baseMS := intFromHMGet(vals, 0)
+	adaptiveMS := intFromHMGet(vals, 1)
+
+	// Take the larger of base and adaptive.
+	if adaptiveMS > baseMS {
+		return adaptiveMS, nil
+	}
+	return baseMS, nil
+}
+
+func intFromHMGet(vals []interface{}, idx int) int {
+	if idx >= len(vals) || vals[idx] == nil {
+		return 0
+	}
+	s, ok := vals[idx].(string)
+	if !ok {
+		return 0
+	}
+	n, _ := strconv.Atoi(s)
+	return n
+}

--- a/internal/broker/pacer_lua.go
+++ b/internal/broker/pacer_lua.go
@@ -1,0 +1,65 @@
+package broker
+
+import "github.com/redis/go-redis/v9"
+
+// Lua scripts for atomic domain pacing operations. Using scripts
+// avoids race conditions between read-modify-write cycles that would
+// occur with separate GET/SET calls across multiple workers.
+
+// adaptiveDelayOnSuccessScript atomically:
+// 1. Increments success_streak
+// 2. Resets error_streak to 0
+// 3. If success_streak >= threshold, decreases adaptive_delay_ms by step (min = floor)
+//
+// KEYS[1] = hover:dom:cfg:{domain}
+// ARGV[1] = success threshold (e.g. 5)
+// ARGV[2] = step down ms (e.g. 500)
+//
+// Returns the new adaptive_delay_ms.
+var adaptiveDelayOnSuccessScript = redis.NewScript(`
+local key = KEYS[1]
+local threshold = tonumber(ARGV[1])
+local step = tonumber(ARGV[2])
+
+redis.call('HINCRBY', key, 'success_streak', 1)
+redis.call('HSET', key, 'error_streak', '0')
+
+local streak = tonumber(redis.call('HGET', key, 'success_streak') or '0')
+local delay = tonumber(redis.call('HGET', key, 'adaptive_delay_ms') or '0')
+local floor = tonumber(redis.call('HGET', key, 'floor_ms') or '0')
+
+if streak >= threshold and delay > floor then
+    delay = math.max(floor, delay - step)
+    redis.call('HSET', key, 'adaptive_delay_ms', tostring(delay))
+    redis.call('HSET', key, 'success_streak', '0')
+end
+
+redis.call('EXPIRE', key, 86400)
+return delay
+`)
+
+// adaptiveDelayOnErrorScript atomically:
+// 1. Increments error_streak
+// 2. Resets success_streak to 0
+// 3. Increases adaptive_delay_ms by step (capped at max)
+//
+// KEYS[1] = hover:dom:cfg:{domain}
+// ARGV[1] = step up ms (e.g. 500)
+// ARGV[2] = max delay ms (e.g. 60000)
+//
+// Returns the new adaptive_delay_ms.
+var adaptiveDelayOnErrorScript = redis.NewScript(`
+local key = KEYS[1]
+local step = tonumber(ARGV[1])
+local maxDelay = tonumber(ARGV[2])
+
+redis.call('HINCRBY', key, 'error_streak', 1)
+redis.call('HSET', key, 'success_streak', '0')
+
+local delay = tonumber(redis.call('HGET', key, 'adaptive_delay_ms') or '0')
+delay = math.min(maxDelay, delay + step)
+redis.call('HSET', key, 'adaptive_delay_ms', tostring(delay))
+
+redis.call('EXPIRE', key, 86400)
+return delay
+`)

--- a/internal/broker/pacer_test.go
+++ b/internal/broker/pacer_test.go
@@ -1,0 +1,132 @@
+package broker
+
+import (
+	"context"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDomainPacer_Seed(t *testing.T) {
+	client, _ := newTestClient(t)
+	pacer := NewDomainPacer(client, DefaultPacerConfig(), zerolog.Nop())
+	ctx := context.Background()
+
+	err := pacer.Seed(ctx, "example.com", 100, 200, 50)
+	require.NoError(t, err)
+
+	// Verify hash was set.
+	key := DomainConfigKey("example.com")
+	base, err := client.rdb.HGet(ctx, key, "base_delay_ms").Result()
+	require.NoError(t, err)
+	assert.Equal(t, "100", base)
+
+	adaptive, err := client.rdb.HGet(ctx, key, "adaptive_delay_ms").Result()
+	require.NoError(t, err)
+	assert.Equal(t, "200", adaptive)
+}
+
+func TestDomainPacer_Seed_Idempotent(t *testing.T) {
+	client, _ := newTestClient(t)
+	pacer := NewDomainPacer(client, DefaultPacerConfig(), zerolog.Nop())
+	ctx := context.Background()
+
+	require.NoError(t, pacer.Seed(ctx, "example.com", 100, 200, 50))
+	require.NoError(t, pacer.Seed(ctx, "example.com", 999, 999, 999))
+
+	// First seed wins (HSETNX).
+	key := DomainConfigKey("example.com")
+	base, err := client.rdb.HGet(ctx, key, "base_delay_ms").Result()
+	require.NoError(t, err)
+	assert.Equal(t, "100", base)
+}
+
+func TestDomainPacer_TryAcquire_NoDelay(t *testing.T) {
+	client, _ := newTestClient(t)
+	pacer := NewDomainPacer(client, DefaultPacerConfig(), zerolog.Nop())
+	ctx := context.Background()
+
+	// No domain config seeded — delay is 0, always acquires.
+	result, err := pacer.TryAcquire(ctx, "no-config.com")
+	require.NoError(t, err)
+	assert.True(t, result.Acquired)
+}
+
+func TestDomainPacer_TryAcquire_WithDelay(t *testing.T) {
+	client, mr := newTestClient(t)
+	pacer := NewDomainPacer(client, DefaultPacerConfig(), zerolog.Nop())
+	ctx := context.Background()
+
+	require.NoError(t, pacer.Seed(ctx, "slow.com", 1000, 0, 0))
+
+	// First acquire should succeed.
+	r1, err := pacer.TryAcquire(ctx, "slow.com")
+	require.NoError(t, err)
+	assert.True(t, r1.Acquired)
+
+	// Second acquire should fail (gate held).
+	r2, err := pacer.TryAcquire(ctx, "slow.com")
+	require.NoError(t, err)
+	assert.False(t, r2.Acquired)
+	assert.True(t, r2.RetryAfter > 0)
+
+	// Fast-forward past the delay.
+	mr.FastForward(r2.RetryAfter)
+
+	// Third acquire should succeed.
+	r3, err := pacer.TryAcquire(ctx, "slow.com")
+	require.NoError(t, err)
+	assert.True(t, r3.Acquired)
+}
+
+func TestDomainPacer_Inflight(t *testing.T) {
+	client, _ := newTestClient(t)
+	pacer := NewDomainPacer(client, DefaultPacerConfig(), zerolog.Nop())
+	ctx := context.Background()
+
+	require.NoError(t, pacer.IncrementInflight(ctx, "example.com", "job-1"))
+	require.NoError(t, pacer.IncrementInflight(ctx, "example.com", "job-1"))
+
+	count, err := pacer.GetInflight(ctx, "example.com", "job-1")
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), count)
+
+	require.NoError(t, pacer.DecrementInflight(ctx, "example.com", "job-1"))
+
+	count, err = pacer.GetInflight(ctx, "example.com", "job-1")
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), count)
+}
+
+func TestDomainPacer_Release_AdaptiveDelay(t *testing.T) {
+	client, _ := newTestClient(t)
+	cfg := DefaultPacerConfig()
+	cfg.SuccessThreshold = 2
+	cfg.DelayStepMS = 100
+	pacer := NewDomainPacer(client, cfg, zerolog.Nop())
+	ctx := context.Background()
+
+	// Seed with an adaptive delay.
+	require.NoError(t, pacer.Seed(ctx, "test.com", 50, 300, 50))
+	require.NoError(t, pacer.IncrementInflight(ctx, "test.com", "j1"))
+
+	// Two successes should reduce the adaptive delay.
+	require.NoError(t, pacer.Release(ctx, "test.com", "j1", true, false))
+	require.NoError(t, pacer.IncrementInflight(ctx, "test.com", "j1"))
+	require.NoError(t, pacer.Release(ctx, "test.com", "j1", true, false))
+
+	key := DomainConfigKey("test.com")
+	adaptive, err := client.rdb.HGet(ctx, key, "adaptive_delay_ms").Result()
+	require.NoError(t, err)
+	assert.Equal(t, "200", adaptive) // 300 - 100
+
+	// A rate-limit error should increase it.
+	require.NoError(t, pacer.IncrementInflight(ctx, "test.com", "j1"))
+	require.NoError(t, pacer.Release(ctx, "test.com", "j1", false, true))
+
+	adaptive, err = client.rdb.HGet(ctx, key, "adaptive_delay_ms").Result()
+	require.NoError(t, err)
+	assert.Equal(t, "300", adaptive) // 200 + 100
+}

--- a/internal/broker/redis.go
+++ b/internal/broker/redis.go
@@ -1,0 +1,118 @@
+package broker
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+	"github.com/rs/zerolog"
+)
+
+// Config holds Redis connection parameters, typically loaded from
+// environment variables.
+type Config struct {
+	URL        string
+	PoolSize   int
+	TLSEnabled bool
+
+	ReadTimeout  time.Duration
+	WriteTimeout time.Duration
+	MaxRetries   int
+}
+
+// ConfigFromEnv builds a Config from the process environment.
+func ConfigFromEnv() Config {
+	poolSize := envInt("REDIS_POOL_SIZE", 200)
+	tlsEnabled := envBool("REDIS_TLS_ENABLED", true)
+
+	return Config{
+		URL:          os.Getenv("REDIS_URL"),
+		PoolSize:     poolSize,
+		TLSEnabled:   tlsEnabled,
+		ReadTimeout:  3 * time.Second,
+		WriteTimeout: 3 * time.Second,
+		MaxRetries:   3,
+	}
+}
+
+// Client wraps a go-redis client with convenience helpers.
+type Client struct {
+	rdb    *redis.Client
+	logger zerolog.Logger
+}
+
+// NewClient parses cfg.URL and returns a connected Client.
+func NewClient(cfg Config, logger zerolog.Logger) (*Client, error) {
+	if cfg.URL == "" {
+		return nil, fmt.Errorf("broker: REDIS_URL is required")
+	}
+
+	opts, err := redis.ParseURL(cfg.URL)
+	if err != nil {
+		return nil, fmt.Errorf("broker: parse REDIS_URL: %w", err)
+	}
+
+	opts.PoolSize = cfg.PoolSize
+	opts.ReadTimeout = cfg.ReadTimeout
+	opts.WriteTimeout = cfg.WriteTimeout
+	opts.MaxRetries = cfg.MaxRetries
+
+	if cfg.TLSEnabled && opts.TLSConfig == nil {
+		opts.TLSConfig = &tls.Config{MinVersion: tls.VersionTLS12}
+	}
+	if !cfg.TLSEnabled {
+		opts.TLSConfig = nil
+	}
+
+	rdb := redis.NewClient(opts)
+
+	c := &Client{
+		rdb:    rdb,
+		logger: logger.With().Str("component", "broker").Logger(),
+	}
+	return c, nil
+}
+
+// Ping verifies the connection is alive.
+func (c *Client) Ping(ctx context.Context) error {
+	return c.rdb.Ping(ctx).Err()
+}
+
+// Close releases the underlying connection pool.
+func (c *Client) Close() error {
+	return c.rdb.Close()
+}
+
+// RDB exposes the raw go-redis client for packages that need direct
+// access (e.g. Lua scripts, pipelines).
+func (c *Client) RDB() *redis.Client { return c.rdb }
+
+// --- env helpers ---
+
+func envInt(key string, def int) int {
+	v := os.Getenv(key)
+	if v == "" {
+		return def
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil {
+		return def
+	}
+	return n
+}
+
+func envBool(key string, def bool) bool {
+	v := os.Getenv(key)
+	if v == "" {
+		return def
+	}
+	b, err := strconv.ParseBool(v)
+	if err != nil {
+		return def
+	}
+	return b
+}

--- a/internal/broker/redis.go
+++ b/internal/broker/redis.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/redis/go-redis/v9"
 	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
 )
 
 // Config holds Redis connection parameters, typically loaded from
@@ -100,6 +101,8 @@ func envInt(key string, def int) int {
 	}
 	n, err := strconv.Atoi(v)
 	if err != nil {
+		log.Warn().Str("key", key).Str("value", v).Int("default", def).
+			Msg("invalid integer for env var, using default")
 		return def
 	}
 	return n

--- a/internal/broker/scheduler.go
+++ b/internal/broker/scheduler.go
@@ -1,0 +1,197 @@
+package broker
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+	"github.com/rs/zerolog"
+)
+
+// ScheduleEntry contains the data needed to schedule a task into
+// the Redis ZSET. The entry is stored as a pipe-delimited member
+// string; the score is the earliest unix-millisecond timestamp at
+// which the task may run.
+type ScheduleEntry struct {
+	TaskID     string
+	JobID      string
+	PageID     int
+	Host       string
+	Path       string
+	Priority   float64
+	RetryCount int
+	SourceType string
+	SourceURL  string
+	RunAt      time.Time
+}
+
+// Member returns the pipe-delimited string stored in the ZSET.
+func (e ScheduleEntry) Member() string {
+	return FormatScheduleEntry(
+		e.TaskID, e.JobID, e.PageID,
+		e.Host, e.Path, e.Priority,
+		e.RetryCount, e.SourceType, e.SourceURL,
+	)
+}
+
+// Score returns the ZSET score (unix milliseconds).
+func (e ScheduleEntry) Score() float64 {
+	return float64(e.RunAt.UnixMilli())
+}
+
+// ParseScheduleEntry reconstructs a ScheduleEntry from its
+// pipe-delimited ZSET member string plus the score.
+func ParseScheduleEntry(member string, score float64) (ScheduleEntry, error) {
+	parts := strings.SplitN(member, "|", 9)
+	if len(parts) != 9 {
+		return ScheduleEntry{}, fmt.Errorf("broker: malformed schedule entry: %q", member)
+	}
+
+	pageID, err := strconv.Atoi(parts[2])
+	if err != nil {
+		return ScheduleEntry{}, fmt.Errorf("broker: bad page_id in entry: %w", err)
+	}
+	priority, err := strconv.ParseFloat(parts[5], 64)
+	if err != nil {
+		return ScheduleEntry{}, fmt.Errorf("broker: bad priority in entry: %w", err)
+	}
+	retryCount, err := strconv.Atoi(parts[6])
+	if err != nil {
+		return ScheduleEntry{}, fmt.Errorf("broker: bad retry_count in entry: %w", err)
+	}
+
+	return ScheduleEntry{
+		TaskID:     parts[0],
+		JobID:      parts[1],
+		PageID:     pageID,
+		Host:       parts[3],
+		Path:       parts[4],
+		Priority:   priority,
+		RetryCount: retryCount,
+		SourceType: parts[7],
+		SourceURL:  parts[8],
+		RunAt:      time.UnixMilli(int64(score)),
+	}, nil
+}
+
+// Scheduler manages delayed task scheduling via Redis sorted sets.
+type Scheduler struct {
+	client *Client
+	logger zerolog.Logger
+}
+
+// NewScheduler creates a Scheduler.
+func NewScheduler(client *Client, logger zerolog.Logger) *Scheduler {
+	return &Scheduler{
+		client: client,
+		logger: logger.With().Str("component", "scheduler").Logger(),
+	}
+}
+
+// Schedule adds a single task to the job's ZSET.
+func (s *Scheduler) Schedule(ctx context.Context, entry ScheduleEntry) error {
+	key := ScheduleKey(entry.JobID)
+	z := redis.Z{Score: entry.Score(), Member: entry.Member()}
+
+	if err := s.client.rdb.ZAdd(ctx, key, z).Err(); err != nil {
+		return fmt.Errorf("broker: schedule task %s: %w", entry.TaskID, err)
+	}
+	return nil
+}
+
+// ScheduleBatch adds multiple tasks to their respective job ZSETs
+// using a pipeline for efficiency.
+func (s *Scheduler) ScheduleBatch(ctx context.Context, entries []ScheduleEntry) error {
+	if len(entries) == 0 {
+		return nil
+	}
+
+	pipe := s.client.rdb.Pipeline()
+	for i := range entries {
+		key := ScheduleKey(entries[i].JobID)
+		z := redis.Z{Score: entries[i].Score(), Member: entries[i].Member()}
+		pipe.ZAdd(ctx, key, z)
+	}
+
+	cmds, err := pipe.Exec(ctx)
+	if err != nil {
+		return fmt.Errorf("broker: schedule batch (%d entries): %w", len(entries), err)
+	}
+
+	var errs int
+	for _, cmd := range cmds {
+		if cmd.Err() != nil {
+			errs++
+		}
+	}
+	if errs > 0 {
+		s.logger.Warn().Int("failed", errs).Int("total", len(entries)).Msg("partial schedule batch failure")
+	}
+	return nil
+}
+
+// Remove deletes a task from the job's ZSET (e.g. on cancellation).
+func (s *Scheduler) Remove(ctx context.Context, jobID, member string) error {
+	return s.client.rdb.ZRem(ctx, ScheduleKey(jobID), member).Err()
+}
+
+// DueItems returns up to limit entries whose score is <= now from the
+// given job's ZSET. Items are returned but not removed — the caller
+// is responsible for ZREM after successful dispatch.
+func (s *Scheduler) DueItems(ctx context.Context, jobID string, now time.Time, limit int64) ([]ScheduleEntry, error) {
+	key := ScheduleKey(jobID)
+	nowMS := fmt.Sprintf("%d", now.UnixMilli())
+
+	results, err := s.client.rdb.ZRangeByScoreWithScores(ctx, key, &redis.ZRangeBy{
+		Min:   "-inf",
+		Max:   nowMS,
+		Count: limit,
+	}).Result()
+	if err != nil {
+		return nil, fmt.Errorf("broker: due items for job %s: %w", jobID, err)
+	}
+
+	entries := make([]ScheduleEntry, 0, len(results))
+	for _, z := range results {
+		member, ok := z.Member.(string)
+		if !ok {
+			s.logger.Warn().Interface("member", z.Member).Msg("skipping non-string ZSET member")
+			continue
+		}
+		entry, err := ParseScheduleEntry(member, z.Score)
+		if err != nil {
+			s.logger.Warn().Err(err).Msg("skipping malformed schedule entry")
+			continue
+		}
+		entries = append(entries, entry)
+	}
+	return entries, nil
+}
+
+// Reschedule updates the score (run-at time) for an existing entry
+// in the ZSET. This is used when the dispatcher cannot dispatch yet
+// (domain pacing, concurrency limit) and needs to push the item back.
+func (s *Scheduler) Reschedule(ctx context.Context, jobID string, member string, newRunAt time.Time) error {
+	key := ScheduleKey(jobID)
+	score := float64(newRunAt.UnixMilli())
+
+	// ZADD XX updates only if the member already exists.
+	return s.client.rdb.ZAddArgs(ctx, key, redis.ZAddArgs{
+		XX:      true,
+		Members: []redis.Z{{Score: score, Member: member}},
+	}).Err()
+}
+
+// PendingCount returns the total number of scheduled items for a job.
+func (s *Scheduler) PendingCount(ctx context.Context, jobID string) (int64, error) {
+	return s.client.rdb.ZCard(ctx, ScheduleKey(jobID)).Result()
+}
+
+// RemoveJobSchedule deletes the entire ZSET for a job
+// (used on job cancellation or completion).
+func (s *Scheduler) RemoveJobSchedule(ctx context.Context, jobID string) error {
+	return s.client.rdb.Del(ctx, ScheduleKey(jobID)).Err()
+}

--- a/internal/broker/scheduler.go
+++ b/internal/broker/scheduler.go
@@ -129,6 +129,7 @@ func (s *Scheduler) ScheduleBatch(ctx context.Context, entries []ScheduleEntry) 
 	}
 	if errs > 0 {
 		s.logger.Warn().Int("failed", errs).Int("total", len(entries)).Msg("partial schedule batch failure")
+		return fmt.Errorf("broker: %d of %d schedule entries failed", errs, len(entries))
 	}
 	return nil
 }

--- a/internal/broker/scheduler_test.go
+++ b/internal/broker/scheduler_test.go
@@ -21,7 +21,7 @@ func newTestClient(t *testing.T) (*Client, *miniredis.Miniredis) {
 }
 
 func TestSchedule_SingleEntry(t *testing.T) {
-	client, mr := newTestClient(t)
+	client, _ := newTestClient(t)
 	s := NewScheduler(client, zerolog.Nop())
 	ctx := context.Background()
 
@@ -43,7 +43,6 @@ func TestSchedule_SingleEntry(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify ZSET has one member via the scheduler's own API.
-	_ = mr
 	count, err := s.PendingCount(ctx, "job-1")
 	require.NoError(t, err)
 	assert.Equal(t, int64(1), count)

--- a/internal/broker/scheduler_test.go
+++ b/internal/broker/scheduler_test.go
@@ -1,0 +1,152 @@
+package broker
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestClient(t *testing.T) (*Client, *miniredis.Miniredis) {
+	t.Helper()
+	mr := miniredis.RunT(t)
+	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { rdb.Close() })
+	return &Client{rdb: rdb, logger: zerolog.Nop()}, mr
+}
+
+func TestSchedule_SingleEntry(t *testing.T) {
+	client, mr := newTestClient(t)
+	s := NewScheduler(client, zerolog.Nop())
+	ctx := context.Background()
+
+	now := time.Now()
+	entry := ScheduleEntry{
+		TaskID:     "task-1",
+		JobID:      "job-1",
+		PageID:     42,
+		Host:       "example.com",
+		Path:       "/page",
+		Priority:   0.8,
+		RetryCount: 0,
+		SourceType: "sitemap",
+		SourceURL:  "https://example.com/sitemap.xml",
+		RunAt:      now,
+	}
+
+	err := s.Schedule(ctx, entry)
+	require.NoError(t, err)
+
+	// Verify ZSET has one member via the scheduler's own API.
+	_ = mr
+	count, err := s.PendingCount(ctx, "job-1")
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), count)
+}
+
+func TestScheduleBatch(t *testing.T) {
+	client, _ := newTestClient(t)
+	s := NewScheduler(client, zerolog.Nop())
+	ctx := context.Background()
+
+	now := time.Now()
+	entries := []ScheduleEntry{
+		{TaskID: "t1", JobID: "j1", PageID: 1, Host: "a.com", Path: "/a", RunAt: now},
+		{TaskID: "t2", JobID: "j1", PageID: 2, Host: "a.com", Path: "/b", RunAt: now.Add(time.Second)},
+		{TaskID: "t3", JobID: "j2", PageID: 3, Host: "b.com", Path: "/c", RunAt: now},
+	}
+
+	err := s.ScheduleBatch(ctx, entries)
+	require.NoError(t, err)
+
+	// j1 should have 2, j2 should have 1.
+	c1, err := s.PendingCount(ctx, "j1")
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), c1)
+
+	c2, err := s.PendingCount(ctx, "j2")
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), c2)
+}
+
+func TestDueItems(t *testing.T) {
+	client, _ := newTestClient(t)
+	s := NewScheduler(client, zerolog.Nop())
+	ctx := context.Background()
+
+	now := time.Now()
+	past := now.Add(-time.Minute)
+	future := now.Add(time.Minute)
+
+	entries := []ScheduleEntry{
+		{TaskID: "past", JobID: "j1", PageID: 1, Host: "a.com", Path: "/p", RunAt: past},
+		{TaskID: "future", JobID: "j1", PageID: 2, Host: "a.com", Path: "/f", RunAt: future},
+	}
+	require.NoError(t, s.ScheduleBatch(ctx, entries))
+
+	due, err := s.DueItems(ctx, "j1", now, 10)
+	require.NoError(t, err)
+	assert.Len(t, due, 1)
+	assert.Equal(t, "past", due[0].TaskID)
+}
+
+func TestReschedule(t *testing.T) {
+	client, _ := newTestClient(t)
+	s := NewScheduler(client, zerolog.Nop())
+	ctx := context.Background()
+
+	now := time.Now()
+	entry := ScheduleEntry{
+		TaskID: "t1", JobID: "j1", PageID: 1, Host: "a.com", Path: "/",
+		RunAt: now,
+	}
+	require.NoError(t, s.Schedule(ctx, entry))
+
+	// Should be due now.
+	due, err := s.DueItems(ctx, "j1", now, 10)
+	require.NoError(t, err)
+	require.Len(t, due, 1)
+
+	// Reschedule to future.
+	future := now.Add(10 * time.Minute)
+	err = s.Reschedule(ctx, "j1", entry.Member(), future)
+	require.NoError(t, err)
+
+	// Should no longer be due.
+	due, err = s.DueItems(ctx, "j1", now, 10)
+	require.NoError(t, err)
+	assert.Len(t, due, 0)
+}
+
+func TestParseScheduleEntry_RoundTrip(t *testing.T) {
+	entry := ScheduleEntry{
+		TaskID:     "abc-123",
+		JobID:      "def-456",
+		PageID:     99,
+		Host:       "example.com",
+		Path:       "/path/to/page",
+		Priority:   0.7500,
+		RetryCount: 2,
+		SourceType: "link",
+		SourceURL:  "https://example.com/source",
+	}
+
+	member := entry.Member()
+	parsed, err := ParseScheduleEntry(member, 1234567890.0)
+	require.NoError(t, err)
+
+	assert.Equal(t, entry.TaskID, parsed.TaskID)
+	assert.Equal(t, entry.JobID, parsed.JobID)
+	assert.Equal(t, entry.PageID, parsed.PageID)
+	assert.Equal(t, entry.Host, parsed.Host)
+	assert.Equal(t, entry.Path, parsed.Path)
+	assert.InDelta(t, entry.Priority, parsed.Priority, 0.001)
+	assert.Equal(t, entry.RetryCount, parsed.RetryCount)
+	assert.Equal(t, entry.SourceType, parsed.SourceType)
+	assert.Equal(t, entry.SourceURL, parsed.SourceURL)
+}

--- a/internal/jobs/executor.go
+++ b/internal/jobs/executor.go
@@ -1,0 +1,610 @@
+package jobs
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"mime"
+	"net/http"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/Harvey-AU/hover/internal/archive"
+	"github.com/Harvey-AU/hover/internal/crawler"
+	"github.com/Harvey-AU/hover/internal/db"
+	"github.com/Harvey-AU/hover/internal/observability"
+	"github.com/Harvey-AU/hover/internal/util"
+	"github.com/rs/zerolog/log"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+)
+
+// RetryDecision describes what should happen after a task error.
+// The caller (stream worker) uses this to decide whether to
+// reschedule via Redis or mark the task as permanently failed.
+type RetryDecision struct {
+	ShouldRetry        bool
+	NextRunAt          time.Time
+	Reason             string // "blocking", "retryable", "domain_delay"
+	IsPermanentFailure bool
+}
+
+// TaskOutcome is the result of executing a single task.
+type TaskOutcome struct {
+	// Task is the populated db.Task with status, metrics, and JSONB
+	// fields set. Ready to be passed to the batch manager.
+	Task *db.Task
+
+	// CrawlResult is the raw crawler output (may be nil on error).
+	CrawlResult *crawler.CrawlResult
+
+	// Retry is set when the task should be rescheduled instead of
+	// permanently completed/failed.
+	Retry *RetryDecision
+
+	// DiscoveredLinks, if non-empty, should be persisted and
+	// scheduled into the ZSET.
+	DiscoveredLinks map[string][]string
+
+	// HTMLUpload, if non-nil, should be uploaded to storage.
+	HTMLUpload *TaskHTMLUpload
+
+	// RateLimited is true when the crawl received a 429/403/503,
+	// used by the caller to update domain pacer state.
+	RateLimited bool
+
+	// Success is true when the crawl completed without error.
+	Success bool
+}
+
+// TaskHTMLUpload holds the data needed to upload HTML to storage.
+type TaskHTMLUpload struct {
+	Bucket              string
+	Path                string
+	ContentType         string
+	UploadContentType   string
+	ContentEncoding     string
+	SizeBytes           int64
+	CompressedSizeBytes int64
+	SHA256              string
+	CapturedAt          time.Time
+	Payload             []byte
+}
+
+// ExecutorConfig holds configuration for the task executor.
+type ExecutorConfig struct {
+	MaxBlockingRetries int
+	MaxTaskRetries     int
+	BaseDelayMS        int
+	MaxDelayMS         int
+}
+
+// DefaultExecutorConfig returns production defaults.
+func DefaultExecutorConfig() ExecutorConfig {
+	return ExecutorConfig{
+		MaxBlockingRetries: 3,
+		MaxTaskRetries:     MaxTaskRetries,
+		BaseDelayMS:        50,
+		MaxDelayMS:         60000,
+	}
+}
+
+// TaskExecutor runs crawl tasks and produces outcomes without
+// side effects on counters, schedulers, or persistence. The caller
+// is responsible for acting on the returned TaskOutcome.
+type TaskExecutor struct {
+	crawler CrawlerInterface
+	cfg     ExecutorConfig
+}
+
+// NewTaskExecutor creates a TaskExecutor.
+func NewTaskExecutor(c CrawlerInterface, cfg ExecutorConfig) *TaskExecutor {
+	return &TaskExecutor{
+		crawler: c,
+		cfg:     cfg,
+	}
+}
+
+// Execute runs a crawl for the given task and returns the outcome.
+// It does NOT modify any external state — all decisions are returned
+// in the TaskOutcome for the caller to act on.
+//
+// The task parameter is a jobs.Task (enriched with job info like
+// DomainName, FindLinks, CrawlDelay). The returned TaskOutcome
+// contains a *db.Task populated for batch persistence.
+func (e *TaskExecutor) Execute(ctx context.Context, task *Task) *TaskOutcome {
+	start := time.Now()
+	status := "success"
+	queueWait := time.Duration(0)
+	if !task.CreatedAt.IsZero() {
+		if !task.StartedAt.IsZero() {
+			queueWait = task.StartedAt.Sub(task.CreatedAt)
+		} else {
+			queueWait = time.Since(task.CreatedAt)
+		}
+	}
+
+	ctx, span := observability.StartWorkerTaskSpan(ctx, observability.WorkerTaskSpanInfo{
+		JobID:     task.JobID,
+		TaskID:    task.ID,
+		Domain:    task.DomainName,
+		Path:      task.Path,
+		FindLinks: task.FindLinks,
+	})
+	defer span.End()
+
+	defer func() {
+		totalDuration := time.Duration(0)
+		if !task.CreatedAt.IsZero() {
+			totalDuration = time.Since(task.CreatedAt)
+		}
+
+		observability.RecordWorkerTask(ctx, observability.WorkerTaskMetrics{
+			JobID:         task.JobID,
+			Status:        status,
+			Duration:      time.Since(start),
+			QueueWait:     queueWait,
+			TotalDuration: totalDuration,
+		})
+	}()
+
+	urlStr := ConstructTaskURL(task.Path, task.Host, task.DomainName)
+
+	log.Debug().Str("url", urlStr).Str("task_id", task.ID).Msg("Starting URL warm")
+
+	result, err := e.crawler.WarmURL(ctx, urlStr, task.FindLinks)
+	if err != nil {
+		status = "error"
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+
+		rateLimited := false
+		if result != nil {
+			switch result.StatusCode {
+			case http.StatusTooManyRequests, http.StatusForbidden, http.StatusServiceUnavailable:
+				rateLimited = true
+			}
+		}
+		if !rateLimited {
+			rateLimited = IsRateLimitError(err)
+		}
+
+		log.Debug().Err(err).
+			Str("task_id", task.ID).
+			Bool("rate_limited", rateLimited).
+			Int("status_code", statusCodeOrZero(result)).
+			Msg("Crawler failed")
+
+		return e.buildErrorOutcome(ctx, task, result, err, rateLimited)
+	}
+
+	if result != nil {
+		span.SetAttributes(
+			attribute.Int("http.status_code", result.StatusCode),
+			attribute.Int("task.links_found", len(result.Links)),
+			attribute.String("task.content_type", result.ContentType),
+		)
+	}
+	span.SetStatus(codes.Ok, "completed")
+
+	log.Debug().
+		Int("status_code", result.StatusCode).
+		Str("task_id", task.ID).
+		Int("links_found", len(result.Links)).
+		Str("content_type", result.ContentType).
+		Msg("Crawler completed")
+
+	return e.buildSuccessOutcome(task, result)
+}
+
+// --- outcome builders ---
+
+// taskToDBTask converts a jobs.Task to a db.Task for persistence.
+func taskToDBTask(t *Task) *db.Task {
+	return &db.Task{
+		ID:            t.ID,
+		JobID:         t.JobID,
+		PageID:        t.PageID,
+		Host:          t.Host,
+		Path:          t.Path,
+		Status:        string(t.Status),
+		CreatedAt:     t.CreatedAt,
+		StartedAt:     t.StartedAt,
+		RetryCount:    t.RetryCount,
+		Error:         t.Error,
+		SourceType:    t.SourceType,
+		SourceURL:     t.SourceURL,
+		PriorityScore: t.PriorityScore,
+	}
+}
+
+func (e *TaskExecutor) buildSuccessOutcome(task *Task, result *crawler.CrawlResult) *TaskOutcome {
+	now := time.Now().UTC()
+
+	dbTask := taskToDBTask(task)
+	dbTask.Status = string(TaskStatusCompleted)
+	dbTask.CompletedAt = now
+	dbTask.StatusCode = result.StatusCode
+	dbTask.ResponseTime = result.ResponseTime
+	dbTask.CacheStatus = result.CacheStatus
+	dbTask.ContentType = result.ContentType
+	dbTask.ContentLength = result.ContentLength
+
+	if util.IsSignificantRedirect(result.URL, result.RedirectURL) {
+		dbTask.RedirectURL = result.RedirectURL
+	}
+
+	// Performance metrics.
+	dbTask.DNSLookupTime = result.Performance.DNSLookupTime
+	dbTask.TCPConnectionTime = result.Performance.TCPConnectionTime
+	dbTask.TLSHandshakeTime = result.Performance.TLSHandshakeTime
+	dbTask.TTFB = result.Performance.TTFB
+	dbTask.ContentTransferTime = result.Performance.ContentTransferTime
+
+	// Second request metrics.
+	dbTask.SecondResponseTime = result.SecondResponseTime
+	dbTask.SecondCacheStatus = result.SecondCacheStatus
+	if result.SecondPerformance != nil {
+		dbTask.SecondContentLength = result.SecondContentLength
+		dbTask.SecondDNSLookupTime = result.SecondPerformance.DNSLookupTime
+		dbTask.SecondTCPConnectionTime = result.SecondPerformance.TCPConnectionTime
+		dbTask.SecondTLSHandshakeTime = result.SecondPerformance.TLSHandshakeTime
+		dbTask.SecondTTFB = result.SecondPerformance.TTFB
+		dbTask.SecondContentTransferTime = result.SecondPerformance.ContentTransferTime
+	}
+
+	// Marshal JSONB fields with safe defaults.
+	populateJSONBFields(dbTask, result)
+
+	outcome := &TaskOutcome{
+		Task:        dbTask,
+		CrawlResult: result,
+		Success:     true,
+	}
+
+	// Discovered links.
+	if len(result.Links) > 0 {
+		outcome.DiscoveredLinks = cloneDiscoveredLinks(result.Links)
+	}
+
+	// HTML upload.
+	if upload, ok := buildHTMLUpload(dbTask, result, now); ok {
+		outcome.HTMLUpload = upload
+		applyHTMLMetadata(dbTask, upload)
+	}
+
+	return outcome
+}
+
+func (e *TaskExecutor) buildErrorOutcome(ctx context.Context, task *Task, result *crawler.CrawlResult, taskErr error, rateLimited bool) *TaskOutcome {
+	now := time.Now().UTC()
+	dbTask := taskToDBTask(task)
+	populateRequestDiagnostics(dbTask, result)
+
+	outcome := &TaskOutcome{
+		Task:        dbTask,
+		CrawlResult: result,
+		RateLimited: rateLimited,
+	}
+
+	if isBlockingError(taskErr) {
+		if dbTask.RetryCount < e.cfg.MaxBlockingRetries {
+			dbTask.RetryCount++
+			dbTask.Error = taskErr.Error()
+			dbTask.Status = string(TaskStatusWaiting)
+			dbTask.StartedAt = time.Time{}
+
+			backoff := e.blockingBackoff(dbTask.RetryCount)
+			outcome.Retry = &RetryDecision{
+				ShouldRetry: true,
+				NextRunAt:   now.Add(backoff),
+				Reason:      "blocking",
+			}
+			observability.RecordWorkerTaskRetry(ctx, dbTask.JobID, "blocking")
+		} else {
+			dbTask.Status = string(TaskStatusFailed)
+			dbTask.CompletedAt = now
+			dbTask.Error = taskErr.Error()
+			outcome.Retry = &RetryDecision{IsPermanentFailure: true}
+			observability.RecordWorkerTaskFailure(ctx, dbTask.JobID, "blocking")
+		}
+	} else if isRetryableError(taskErr) && dbTask.RetryCount < e.cfg.MaxTaskRetries {
+		dbTask.RetryCount++
+		dbTask.Error = taskErr.Error()
+		dbTask.Status = string(TaskStatusWaiting)
+		dbTask.StartedAt = time.Time{}
+
+		backoff := e.retryableBackoff(dbTask.RetryCount)
+		outcome.Retry = &RetryDecision{
+			ShouldRetry: true,
+			NextRunAt:   now.Add(backoff),
+			Reason:      "retryable",
+		}
+		observability.RecordWorkerTaskRetry(ctx, dbTask.JobID, "retryable")
+	} else {
+		dbTask.Status = string(TaskStatusFailed)
+		dbTask.CompletedAt = now
+		dbTask.Error = taskErr.Error()
+		outcome.Retry = &RetryDecision{IsPermanentFailure: true}
+
+		failureReason := "non_retryable"
+		if isRetryableError(taskErr) {
+			failureReason = "retryable_exhausted"
+		} else if isBlockingError(taskErr) {
+			failureReason = "blocking"
+		}
+		observability.RecordWorkerTaskFailure(ctx, dbTask.JobID, failureReason)
+	}
+
+	return outcome
+}
+
+// --- backoff computation ---
+
+func (e *TaskExecutor) blockingBackoff(retryCount int) time.Duration {
+	base := time.Duration(e.cfg.BaseDelayMS) * time.Millisecond
+	delay := base * (1 << retryCount) // exponential
+	max := time.Duration(e.cfg.MaxDelayMS) * time.Millisecond
+	if delay > max {
+		delay = max
+	}
+	return delay
+}
+
+func (e *TaskExecutor) retryableBackoff(retryCount int) time.Duration {
+	delay := time.Duration(retryCount) * time.Second // linear
+	if delay > 30*time.Second {
+		delay = 30 * time.Second
+	}
+	return delay
+}
+
+// --- shared helpers (extracted from worker.go) ---
+
+// ConstructTaskURL builds a full URL from task path, host, and domain.
+// Exported so the stream worker can use it.
+func ConstructTaskURL(path, host, domainName string) string {
+	if strings.HasPrefix(path, "http://") || strings.HasPrefix(path, "https://") {
+		return util.NormaliseURL(path)
+	} else if host != "" {
+		return util.ConstructURL(host, path)
+	} else if domainName != "" {
+		return util.ConstructURL(domainName, path)
+	}
+	return util.NormaliseURL(path)
+}
+
+// Error classification — unchanged from worker.go.
+
+var errStatusCodePattern = regexp.MustCompile(`\b(\d{3})\b`)
+
+func isRetryableError(err error) bool {
+	if err == nil {
+		return false
+	}
+	errorStr := strings.ToLower(err.Error())
+	networkErrors := strings.Contains(errorStr, "timeout") ||
+		strings.Contains(errorStr, "deadline exceeded") ||
+		strings.Contains(errorStr, "connection") ||
+		strings.Contains(errorStr, "network") ||
+		strings.Contains(errorStr, "temporary") ||
+		strings.Contains(errorStr, "reset by peer") ||
+		strings.Contains(errorStr, "broken pipe") ||
+		strings.Contains(errorStr, "unexpected eof")
+	serverErrors := strings.Contains(errorStr, "internal server error") ||
+		strings.Contains(errorStr, "bad gateway") ||
+		strings.Contains(errorStr, "gateway timeout") ||
+		strings.Contains(errorStr, "502") ||
+		strings.Contains(errorStr, "504") ||
+		strings.Contains(errorStr, "500")
+	return networkErrors || serverErrors
+}
+
+func isBlockingError(err error) bool {
+	if err == nil {
+		return false
+	}
+	errorStr := strings.ToLower(err.Error())
+	return strings.Contains(errorStr, "403") ||
+		strings.Contains(errorStr, "forbidden") ||
+		strings.Contains(errorStr, "429") ||
+		strings.Contains(errorStr, "too many requests") ||
+		strings.Contains(errorStr, "rate limit") ||
+		strings.Contains(errorStr, "503") ||
+		strings.Contains(errorStr, "service unavailable")
+}
+
+func isClientOrRedirectError(err error) bool {
+	if err == nil {
+		return false
+	}
+	lower := strings.ToLower(err.Error())
+	if strings.Contains(lower, "crawler error") {
+		keywords := []string{
+			"not found", "bad request", "unauthorized", "forbidden",
+			"gone", "method not allowed", "temporary redirect",
+			"permanent redirect", "moved permanently", "see other",
+		}
+		for _, kw := range keywords {
+			if strings.Contains(lower, kw) {
+				return true
+			}
+		}
+	}
+	matches := errStatusCodePattern.FindAllStringSubmatch(lower, -1)
+	for _, match := range matches {
+		if len(match) < 2 {
+			continue
+		}
+		code, err := strconv.Atoi(match[1])
+		if err != nil {
+			continue
+		}
+		if code >= 400 && code < 500 {
+			return true
+		}
+	}
+	return false
+}
+
+// IsRateLimitError is exported for use by the stream worker when
+// determining whether to update domain pacer state.
+func IsRateLimitErrorCheck(err error) bool {
+	return IsRateLimitError(err)
+}
+
+// --- JSONB helpers ---
+
+func populateJSONBFields(task *db.Task, result *crawler.CrawlResult) {
+	task.Headers = []byte("{}")
+	task.SecondHeaders = []byte("{}")
+	task.CacheCheckAttempts = []byte("[]")
+	task.RequestDiagnostics = []byte("{}")
+
+	if len(result.Headers) > 0 {
+		if b, err := json.Marshal(result.Headers); err == nil && json.Valid(b) {
+			task.Headers = b
+		}
+	}
+	if len(result.SecondHeaders) > 0 {
+		if b, err := json.Marshal(result.SecondHeaders); err == nil && json.Valid(b) {
+			task.SecondHeaders = b
+		}
+	}
+	if len(result.CacheCheckAttempts) > 0 {
+		if b, err := json.Marshal(result.CacheCheckAttempts); err == nil && json.Valid(b) {
+			task.CacheCheckAttempts = b
+		}
+	}
+
+	populateRequestDiagnostics(task, result)
+}
+
+func populateRequestDiagnostics(task *db.Task, result *crawler.CrawlResult) {
+	task.RequestDiagnostics = []byte("{}")
+	if result == nil || result.RequestDiagnostics == nil {
+		return
+	}
+	if b, err := json.Marshal(result.RequestDiagnostics); err == nil && json.Valid(b) {
+		task.RequestDiagnostics = b
+	}
+}
+
+// --- HTML helpers ---
+
+const (
+	htmlStorageBucket   = "task-html"
+	htmlContentEncoding = "gzip"
+)
+
+func buildHTMLUpload(task *db.Task, result *crawler.CrawlResult, capturedAt time.Time) (*TaskHTMLUpload, bool) {
+	if task == nil || result == nil || len(result.Body) == 0 {
+		return nil, false
+	}
+
+	mediaType := canonicalHTMLContentType(result.ContentType)
+	if mediaType != "text/html" && mediaType != "application/xhtml+xml" {
+		return nil, false
+	}
+
+	payload, err := gzipHTML(result.Body)
+	if err != nil {
+		log.Error().Err(err).Str("task_id", task.ID).Msg("Failed to gzip HTML")
+		return nil, false
+	}
+
+	uploadCT := mediaType
+	if uploadCT == "" {
+		uploadCT = "text/html"
+	}
+	checksum := sha256.Sum256(result.Body)
+
+	return &TaskHTMLUpload{
+		Bucket:              htmlStorageBucket,
+		Path:                archive.TaskHTMLObjectPath(task.JobID, task.ID),
+		ContentType:         normalisedHTMLContentType(result.ContentType),
+		UploadContentType:   uploadCT,
+		ContentEncoding:     htmlContentEncoding,
+		SizeBytes:           int64(len(result.Body)),
+		CompressedSizeBytes: int64(len(payload)),
+		SHA256:              hex.EncodeToString(checksum[:]),
+		CapturedAt:          capturedAt,
+		Payload:             payload,
+	}, true
+}
+
+func applyHTMLMetadata(task *db.Task, upload *TaskHTMLUpload) {
+	if task == nil || upload == nil {
+		return
+	}
+	task.HTMLStorageBucket = upload.Bucket
+	task.HTMLStoragePath = upload.Path
+	task.HTMLContentType = upload.ContentType
+	task.HTMLContentEncoding = upload.ContentEncoding
+	task.HTMLSizeBytes = upload.SizeBytes
+	task.HTMLCompressedSizeBytes = upload.CompressedSizeBytes
+	task.HTMLSHA256 = upload.SHA256
+	task.HTMLCapturedAt = upload.CapturedAt
+}
+
+func canonicalHTMLContentType(ct string) string {
+	trimmed := strings.TrimSpace(ct)
+	if trimmed == "" {
+		return ""
+	}
+	mediaType, _, err := mime.ParseMediaType(trimmed)
+	if err != nil {
+		return strings.ToLower(trimmed)
+	}
+	return strings.ToLower(mediaType)
+}
+
+func normalisedHTMLContentType(ct string) string {
+	trimmed := strings.TrimSpace(ct)
+	if trimmed == "" {
+		return "text/html"
+	}
+	return strings.ToLower(trimmed)
+}
+
+func gzipHTML(body []byte) ([]byte, error) {
+	var buf bytes.Buffer
+	w := gzip.NewWriter(&buf)
+	if _, err := w.Write(body); err != nil {
+		return nil, fmt.Errorf("write gzip html: %w", err)
+	}
+	if err := w.Close(); err != nil {
+		return nil, fmt.Errorf("close gzip html: %w", err)
+	}
+	return buf.Bytes(), nil
+}
+
+func cloneDiscoveredLinks(links map[string][]string) map[string][]string {
+	if len(links) == 0 {
+		return nil
+	}
+	cloned := make(map[string][]string, len(links))
+	for cat, vals := range links {
+		cloned[cat] = append([]string(nil), vals...)
+	}
+	return cloned
+}
+
+func statusCodeOrZero(result *crawler.CrawlResult) int {
+	if result != nil {
+		return result.StatusCode
+	}
+	return 0
+}
+
+// Sentinel errors.
+var (
+	ErrDomainDelay = errors.New("domain rate limit delay")
+)

--- a/internal/jobs/executor.go
+++ b/internal/jobs/executor.go
@@ -185,13 +185,20 @@ func (e *TaskExecutor) Execute(ctx context.Context, task *Task) *TaskOutcome {
 		return e.buildErrorOutcome(ctx, task, result, err, rateLimited)
 	}
 
-	if result != nil {
-		span.SetAttributes(
-			attribute.Int("http.status_code", result.StatusCode),
-			attribute.Int("task.links_found", len(result.Links)),
-			attribute.String("task.content_type", result.ContentType),
-		)
+	// Guard against nil result — crawler should always return a result
+	// on success, but defensive check prevents downstream panics.
+	if result == nil {
+		nilErr := fmt.Errorf("crawler returned nil result for %s", urlStr)
+		span.RecordError(nilErr)
+		span.SetStatus(codes.Error, nilErr.Error())
+		return e.buildErrorOutcome(ctx, task, nil, nilErr, false)
 	}
+
+	span.SetAttributes(
+		attribute.Int("http.status_code", result.StatusCode),
+		attribute.Int("task.links_found", len(result.Links)),
+		attribute.String("task.content_type", result.ContentType),
+	)
 	span.SetStatus(codes.Ok, "completed")
 
 	log.Debug().

--- a/internal/jobs/manager.go
+++ b/internal/jobs/manager.go
@@ -18,6 +18,7 @@ import (
 	"github.com/Harvey-AU/hover/internal/util"
 	"github.com/getsentry/sentry-go"
 	"github.com/google/uuid"
+	"github.com/lib/pq"
 	"github.com/rs/zerolog/log"
 )
 
@@ -46,6 +47,25 @@ type JobManagerInterface interface {
 	UpdateJobStatus(ctx context.Context, jobID string, status JobStatus) error
 }
 
+// TaskScheduleCallback is called after tasks are successfully inserted
+// into Postgres. The callback receives the data needed to schedule
+// the tasks into an external broker (e.g. Redis). If nil, no external
+// scheduling occurs (legacy DB-queue mode).
+type TaskScheduleCallback func(ctx context.Context, jobID string, entries []TaskScheduleEntry)
+
+// TaskScheduleEntry carries the minimal data needed to schedule a
+// newly inserted task into the Redis ZSET.
+type TaskScheduleEntry struct {
+	TaskID     string
+	PageID     int
+	Host       string
+	Path       string
+	Status     string // "pending", "waiting", "skipped"
+	Priority   float64
+	SourceType string
+	SourceURL  string
+}
+
 // JobManager handles job creation and lifecycle management
 type JobManager struct {
 	db      *sql.DB
@@ -53,6 +73,10 @@ type JobManager struct {
 	crawler CrawlerInterface
 
 	workerPool *WorkerPool
+
+	// OnTasksEnqueued is called after successful Postgres task insertion.
+	// Set by the worker service to schedule tasks into Redis.
+	OnTasksEnqueued TaskScheduleCallback
 
 	// Map to track which pages have been processed for each job
 	processedPages map[string]struct{} // Key format: "jobID_pageID"
@@ -516,6 +540,11 @@ func (jm *JobManager) EnqueueJobURLs(ctx context.Context, jobID string, pages []
 		for _, page := range filteredPages {
 			jm.markPageProcessed(jobID, page.ID)
 		}
+
+		// Notify external scheduler (Redis) if configured.
+		if jm.OnTasksEnqueued != nil {
+			jm.scheduleEnqueuedTasks(ctx, jobID, filteredPages, sourceType, sourceURL)
+		}
 	} else {
 		log.Error().
 			Err(err).
@@ -525,6 +554,53 @@ func (jm *JobManager) EnqueueJobURLs(ctx context.Context, jobID string, pages []
 	}
 
 	return err
+}
+
+// scheduleEnqueuedTasks queries for tasks just inserted into Postgres
+// and passes them to the OnTasksEnqueued callback for Redis scheduling.
+func (jm *JobManager) scheduleEnqueuedTasks(ctx context.Context, jobID string, pages []db.Page, sourceType, sourceURL string) {
+	if jm.OnTasksEnqueued == nil || len(pages) == 0 {
+		return
+	}
+
+	pageIDs := make([]int, 0, len(pages))
+	for _, p := range pages {
+		if p.ID != 0 {
+			pageIDs = append(pageIDs, p.ID)
+		}
+	}
+	if len(pageIDs) == 0 {
+		return
+	}
+
+	var entries []TaskScheduleEntry
+	err := jm.dbQueue.Execute(ctx, func(tx *sql.Tx) error {
+		rows, err := tx.QueryContext(ctx, `
+			SELECT id, page_id, host, path, status, priority_score, source_type, source_url
+			FROM tasks
+			WHERE job_id = $1 AND page_id = ANY($2) AND status IN ('pending', 'waiting')
+		`, jobID, pq.Array(pageIDs))
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var e TaskScheduleEntry
+			if err := rows.Scan(&e.TaskID, &e.PageID, &e.Host, &e.Path, &e.Status, &e.Priority, &e.SourceType, &e.SourceURL); err != nil {
+				return err
+			}
+			entries = append(entries, e)
+		}
+		return rows.Err()
+	})
+	if err != nil {
+		log.Error().Err(err).Str("job_id", jobID).Msg("failed to query tasks for Redis scheduling")
+		return
+	}
+
+	if len(entries) > 0 {
+		jm.OnTasksEnqueued(ctx, jobID, entries)
+	}
 }
 
 // CancelJob cancels a running job

--- a/internal/jobs/manager.go
+++ b/internal/jobs/manager.go
@@ -314,8 +314,10 @@ func (jm *JobManager) validateRootURLAccess(ctx context.Context, job *Job, norma
 
 // createManualRootTask creates page and task records for the root URL
 func (jm *JobManager) createManualRootTask(ctx context.Context, job *Job, domainID int, rootPath string) error {
+	var taskID string
+	var pageID int
+
 	err := jm.dbQueue.Execute(ctx, func(tx *sql.Tx) error {
-		var pageID int
 		err := tx.QueryRowContext(ctx, `
 				INSERT INTO pages (domain_id, host, path)
 				VALUES ($1, $2, $3)
@@ -338,12 +340,13 @@ func (jm *JobManager) createManualRootTask(ctx context.Context, job *Job, domain
 		}
 
 		// Enqueue the root URL with its page ID
+		taskID = uuid.New().String()
 		_, err = tx.ExecContext(ctx, `
 			INSERT INTO tasks (
 				id, job_id, page_id, host, path, status, created_at, retry_count,
 				source_type, source_url
 			) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
-		`, uuid.New().String(), job.ID, pageID, job.Domain, rootPath, "pending", time.Now().UTC(), 0, "manual", "")
+		`, taskID, job.ID, pageID, job.Domain, rootPath, "pending", time.Now().UTC(), 0, "manual", "")
 
 		if err != nil {
 			return fmt.Errorf("failed to enqueue task for root path: %w", err)
@@ -356,6 +359,19 @@ func (jm *JobManager) createManualRootTask(ctx context.Context, job *Job, domain
 	if err != nil {
 		log.Error().Err(err).Msg("Failed to create and enqueue root URL")
 		return err
+	}
+
+	// Notify Redis broker if configured.
+	if jm.OnTasksEnqueued != nil {
+		jm.OnTasksEnqueued(ctx, job.ID, []TaskScheduleEntry{{
+			TaskID:     taskID,
+			PageID:     pageID,
+			Host:       job.Domain,
+			Path:       rootPath,
+			Status:     "pending",
+			Priority:   0,
+			SourceType: "manual",
+		}})
 	}
 
 	log.Info().
@@ -558,6 +574,13 @@ func (jm *JobManager) EnqueueJobURLs(ctx context.Context, jobID string, pages []
 
 // scheduleEnqueuedTasks queries for tasks just inserted into Postgres
 // and passes them to the OnTasksEnqueued callback for Redis scheduling.
+//
+// NOTE: This re-queries by page_id which could theoretically pick up
+// pre-existing rows on conflict. In practice the ON CONFLICT in
+// EnqueueURLs only updates pending/waiting/skipped tasks (same states
+// we filter here), so the result set matches what was just inserted.
+// A cleaner approach (returning IDs from EnqueueURLs) requires changing
+// the DbQueueProvider interface — deferred to Stage 2.
 func (jm *JobManager) scheduleEnqueuedTasks(ctx context.Context, jobID string, pages []db.Page, sourceType, sourceURL string) {
 	if jm.OnTasksEnqueued == nil || len(pages) == 0 {
 		return

--- a/internal/jobs/process_task_test.go
+++ b/internal/jobs/process_task_test.go
@@ -96,7 +96,7 @@ func TestConstructTaskURL(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := constructTaskURL(tt.path, tt.host, tt.domainName)
+			result := ConstructTaskURL(tt.path, tt.host, tt.domainName)
 			assert.Equal(t, tt.expected, result)
 		})
 	}
@@ -329,21 +329,21 @@ func TestProcessDiscoveredLinks(t *testing.T) {
 func BenchmarkConstructTaskURL(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_ = constructTaskURL("/test/path", "", "example.com")
+		_ = ConstructTaskURL("/test/path", "", "example.com")
 	}
 }
 
 func BenchmarkConstructTaskURLWithFullURL(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_ = constructTaskURL("https://example.com/test/path", "", "example.com")
+		_ = ConstructTaskURL("https://example.com/test/path", "", "example.com")
 	}
 }
 
 func BenchmarkConstructTaskURLWithHostOverride(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_ = constructTaskURL("/test/path", "us.example.com", "example.com")
+		_ = ConstructTaskURL("/test/path", "us.example.com", "example.com")
 	}
 }
 

--- a/internal/jobs/stream_worker.go
+++ b/internal/jobs/stream_worker.go
@@ -1,0 +1,543 @@
+package jobs
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/Harvey-AU/hover/internal/broker"
+	"github.com/Harvey-AU/hover/internal/db"
+	"github.com/Harvey-AU/hover/internal/observability"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	"golang.org/x/sync/singleflight"
+)
+
+// StreamWorkerDeps groups the dependencies for a StreamWorkerPool.
+type StreamWorkerDeps struct {
+	Consumer     *broker.Consumer
+	Scheduler    *broker.Scheduler
+	Counters     *broker.RunningCounters
+	Pacer        *broker.DomainPacer
+	Executor     *TaskExecutor
+	BatchManager *db.BatchManager
+	DBQueue      DbQueueInterface
+	Logger       zerolog.Logger
+}
+
+// StreamWorkerOpts holds tunables for the stream worker pool.
+type StreamWorkerOpts struct {
+	// NumWorkers is the number of consumer goroutines.
+	NumWorkers int
+
+	// ReclaimInterval is how often stale messages are reclaimed.
+	ReclaimInterval time.Duration
+}
+
+// DefaultStreamWorkerOpts returns production defaults.
+func DefaultStreamWorkerOpts() StreamWorkerOpts {
+	return StreamWorkerOpts{
+		NumWorkers:      30,
+		ReclaimInterval: 30 * time.Second,
+	}
+}
+
+// StreamWorkerPool consumes tasks from Redis Streams, executes them
+// via the TaskExecutor, and acts on the returned TaskOutcome
+// (ack, reschedule, persist results).
+type StreamWorkerPool struct {
+	consumer     *broker.Consumer
+	scheduler    *broker.Scheduler
+	counters     *broker.RunningCounters
+	pacer        *broker.DomainPacer
+	executor     *TaskExecutor
+	batchManager *db.BatchManager
+	dbQueue      DbQueueInterface
+	opts         StreamWorkerOpts
+	logger       zerolog.Logger
+
+	// Job info cache.
+	jobInfoCache map[string]*JobInfo
+	jobInfoMutex sync.RWMutex
+	jobInfoGroup singleflight.Group
+
+	// Active job IDs — refreshed periodically for round-robin.
+	activeJobs   []string
+	activeJobsMu sync.RWMutex
+
+	wg     sync.WaitGroup
+	cancel context.CancelFunc
+}
+
+// NewStreamWorkerPool creates a StreamWorkerPool.
+func NewStreamWorkerPool(deps StreamWorkerDeps, opts StreamWorkerOpts) *StreamWorkerPool {
+	return &StreamWorkerPool{
+		consumer:     deps.Consumer,
+		scheduler:    deps.Scheduler,
+		counters:     deps.Counters,
+		pacer:        deps.Pacer,
+		executor:     deps.Executor,
+		batchManager: deps.BatchManager,
+		dbQueue:      deps.DBQueue,
+		opts:         opts,
+		logger:       deps.Logger.With().Str("component", "stream_worker").Logger(),
+		jobInfoCache: make(map[string]*JobInfo),
+	}
+}
+
+// Start launches consumer goroutines and the reclaim loop.
+// Blocks until Stop is called or ctx is cancelled.
+func (swp *StreamWorkerPool) Start(ctx context.Context) {
+	ctx, swp.cancel = context.WithCancel(ctx)
+
+	// Reconcile running counters from Postgres.
+	swp.reconcileCounters(ctx)
+
+	// Refresh active jobs immediately.
+	swp.refreshActiveJobs(ctx)
+
+	// Start consumer goroutines.
+	for i := range swp.opts.NumWorkers {
+		swp.wg.Add(1)
+		go func(id int) {
+			defer swp.wg.Done()
+			swp.workerLoop(ctx, id)
+		}(i)
+	}
+
+	// Start reclaim loop.
+	swp.wg.Add(1)
+	go func() {
+		defer swp.wg.Done()
+		swp.reclaimLoop(ctx)
+	}()
+
+	// Start active jobs refresh loop.
+	swp.wg.Add(1)
+	go func() {
+		defer swp.wg.Done()
+		swp.activeJobsRefreshLoop(ctx)
+	}()
+
+	swp.logger.Info().Int("workers", swp.opts.NumWorkers).Msg("stream worker pool started")
+}
+
+// Stop signals all goroutines to stop and waits for them.
+func (swp *StreamWorkerPool) Stop() {
+	if swp.cancel != nil {
+		swp.cancel()
+	}
+	swp.wg.Wait()
+	swp.logger.Info().Msg("stream worker pool stopped")
+}
+
+// --- consumer loop ---
+
+func (swp *StreamWorkerPool) workerLoop(ctx context.Context, workerID int) {
+	logger := swp.logger.With().Int("worker_id", workerID).Logger()
+	logger.Debug().Msg("worker started")
+
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+
+		// Round-robin across active jobs.
+		jobIDs := swp.getActiveJobs()
+		if len(jobIDs) == 0 {
+			// No active jobs — wait a bit.
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(1 * time.Second):
+				continue
+			}
+		}
+
+		processed := false
+		for _, jobID := range jobIDs {
+			if ctx.Err() != nil {
+				return
+			}
+
+			msgs, err := swp.consumer.ReadNonBlocking(ctx, jobID)
+			if err != nil {
+				logger.Error().Err(err).Str("job_id", jobID).Msg("stream read error")
+				continue
+			}
+
+			for _, msg := range msgs {
+				swp.processMessage(ctx, msg)
+				processed = true
+			}
+		}
+
+		if !processed {
+			// No messages from any stream — block briefly on first stream.
+			if len(jobIDs) > 0 {
+				msgs, err := swp.consumer.Read(ctx, jobIDs[0])
+				if err != nil {
+					logger.Warn().Err(err).Msg("blocking read error")
+				}
+				for _, msg := range msgs {
+					swp.processMessage(ctx, msg)
+				}
+			}
+		}
+	}
+}
+
+func (swp *StreamWorkerPool) processMessage(ctx context.Context, msg broker.StreamMessage) {
+	logger := swp.logger.With().
+		Str("task_id", msg.TaskID).
+		Str("job_id", msg.JobID).
+		Logger()
+
+	// Load job info and build enriched Task.
+	task, err := swp.buildTask(ctx, msg)
+	if err != nil {
+		logger.Error().Err(err).Msg("failed to build task from stream message")
+		// ACK to prevent infinite redelivery of unprocessable messages.
+		_ = swp.consumer.Ack(ctx, msg.JobID, msg.MessageID)
+		_, _ = swp.counters.Decrement(ctx, msg.JobID)
+		return
+	}
+
+	// Execute the crawl.
+	taskCtx, cancel := context.WithTimeout(ctx, 2*time.Minute)
+	outcome := swp.executor.Execute(taskCtx, task)
+	cancel()
+
+	// Act on the outcome.
+	swp.handleOutcome(ctx, msg, outcome)
+}
+
+func (swp *StreamWorkerPool) handleOutcome(ctx context.Context, msg broker.StreamMessage, outcome *TaskOutcome) {
+	// Always ACK the stream message first (remove from PEL).
+	if err := swp.consumer.Ack(ctx, msg.JobID, msg.MessageID); err != nil {
+		swp.logger.Error().Err(err).Str("message_id", msg.MessageID).Msg("failed to ACK")
+	}
+
+	// Decrement running counter.
+	if _, err := swp.counters.Decrement(ctx, msg.JobID); err != nil {
+		swp.logger.Warn().Err(err).Str("job_id", msg.JobID).Msg("counter decrement failed")
+	}
+
+	// Release domain pacer.
+	domain := msg.Host
+	if err := swp.pacer.Release(ctx, domain, msg.JobID, outcome.Success, outcome.RateLimited); err != nil {
+		swp.logger.Warn().Err(err).Str("domain", domain).Msg("pacer release failed")
+	}
+
+	// Queue task update for batch persistence.
+	swp.batchManager.QueueTaskUpdate(outcome.Task)
+
+	// Handle retry if needed.
+	if outcome.Retry != nil && outcome.Retry.ShouldRetry {
+		entry := broker.ScheduleEntry{
+			TaskID:     outcome.Task.ID,
+			JobID:      outcome.Task.JobID,
+			PageID:     outcome.Task.PageID,
+			Host:       msg.Host,
+			Path:       msg.Path,
+			Priority:   msg.Priority,
+			RetryCount: outcome.Task.RetryCount,
+			SourceType: outcome.Task.SourceType,
+			SourceURL:  outcome.Task.SourceURL,
+			RunAt:      outcome.Retry.NextRunAt,
+		}
+		if err := swp.scheduler.Schedule(ctx, entry); err != nil {
+			swp.logger.Error().Err(err).Str("task_id", outcome.Task.ID).Msg("failed to reschedule retry")
+		}
+	}
+
+	// Handle discovered links — enqueue to Postgres then schedule.
+	if len(outcome.DiscoveredLinks) > 0 {
+		swp.handleDiscoveredLinks(ctx, outcome)
+	}
+
+	// Handle HTML upload (TODO: wire to storage client in cmd/worker).
+	if outcome.HTMLUpload != nil {
+		// The HTML upload will be handled by the persistence loop
+		// wired in cmd/worker/main.go via a channel, same pattern
+		// as the current startTaskHTMLPersistenceLoop.
+		// For now, the metadata is already applied to the db.Task
+		// via applyHTMLMetadata in the executor.
+	}
+}
+
+func (swp *StreamWorkerPool) handleDiscoveredLinks(ctx context.Context, outcome *TaskOutcome) {
+	// Discovered link persistence will be wired through the same
+	// channel-based pattern as the current worker pool. The stream
+	// worker's cmd/worker/main.go will set up the persistence loop.
+	//
+	// For now this is a placeholder — the full implementation will
+	// call EnqueueURLs on the dbQueue and then scheduler.ScheduleBatch
+	// for the newly inserted tasks.
+	swp.logger.Debug().
+		Str("task_id", outcome.Task.ID).
+		Int("link_count", len(outcome.DiscoveredLinks)).
+		Msg("discovered links pending persistence")
+}
+
+// --- reclaim loop ---
+
+func (swp *StreamWorkerPool) reclaimLoop(ctx context.Context) {
+	ticker := time.NewTicker(swp.opts.ReclaimInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			swp.reclaimStaleMessages(ctx)
+		}
+	}
+}
+
+func (swp *StreamWorkerPool) reclaimStaleMessages(ctx context.Context) {
+	jobIDs := swp.getActiveJobs()
+	for _, jobID := range jobIDs {
+		reclaimed, deadLetter, err := swp.consumer.ReclaimStale(ctx, jobID)
+		if err != nil {
+			swp.logger.Warn().Err(err).Str("job_id", jobID).Msg("reclaim failed")
+			continue
+		}
+
+		// Re-process reclaimed messages.
+		for _, msg := range reclaimed {
+			swp.logger.Info().Str("task_id", msg.TaskID).Str("message_id", msg.MessageID).Msg("reclaimed stale task")
+			swp.processMessage(ctx, msg)
+		}
+
+		// Dead-letter messages that exceeded max deliveries.
+		for _, msg := range deadLetter {
+			swp.logger.Warn().Str("task_id", msg.TaskID).Int("retry_count", msg.RetryCount).Msg("dead-lettering task after max deliveries")
+			_ = swp.consumer.Ack(ctx, jobID, msg.MessageID)
+			_, decErr := swp.counters.Decrement(ctx, jobID)
+			if decErr != nil {
+				swp.logger.Warn().Err(decErr).Msg("counter decrement on dead-letter failed")
+			}
+
+			// Mark as failed in Postgres.
+			dbTask := &db.Task{
+				ID:          msg.TaskID,
+				JobID:       msg.JobID,
+				Status:      string(TaskStatusFailed),
+				CompletedAt: time.Now().UTC(),
+				Error:       "exceeded maximum delivery attempts",
+				RetryCount:  msg.RetryCount,
+			}
+			swp.batchManager.QueueTaskUpdate(dbTask)
+			observability.RecordWorkerTaskFailure(ctx, jobID, "dead_letter")
+		}
+	}
+}
+
+// --- active jobs ---
+
+func (swp *StreamWorkerPool) activeJobsRefreshLoop(ctx context.Context) {
+	ticker := time.NewTicker(10 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			swp.refreshActiveJobs(ctx)
+		}
+	}
+}
+
+func (swp *StreamWorkerPool) refreshActiveJobs(ctx context.Context) {
+	var jobIDs []string
+	err := swp.dbQueue.ExecuteControl(ctx, func(tx *sql.Tx) error {
+		rows, err := tx.QueryContext(ctx,
+			`SELECT id FROM jobs WHERE status IN ('running', 'pending') ORDER BY created_at DESC LIMIT 200`)
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var id string
+			if err := rows.Scan(&id); err != nil {
+				return err
+			}
+			jobIDs = append(jobIDs, id)
+		}
+		return rows.Err()
+	})
+	if err != nil {
+		swp.logger.Error().Err(err).Msg("failed to refresh active jobs")
+		return
+	}
+
+	swp.activeJobsMu.Lock()
+	swp.activeJobs = jobIDs
+	swp.activeJobsMu.Unlock()
+}
+
+func (swp *StreamWorkerPool) getActiveJobs() []string {
+	swp.activeJobsMu.RLock()
+	defer swp.activeJobsMu.RUnlock()
+	return swp.activeJobs
+}
+
+// ActiveJobIDs implements broker.JobLister for the dispatcher.
+func (swp *StreamWorkerPool) ActiveJobIDs(ctx context.Context) ([]string, error) {
+	return swp.getActiveJobs(), nil
+}
+
+// --- job info ---
+
+func (swp *StreamWorkerPool) buildTask(ctx context.Context, msg broker.StreamMessage) (*Task, error) {
+	info, err := swp.loadJobInfo(ctx, msg.JobID)
+	if err != nil {
+		return nil, fmt.Errorf("load job info for %s: %w", msg.JobID, err)
+	}
+
+	return &Task{
+		ID:                       msg.TaskID,
+		JobID:                    msg.JobID,
+		PageID:                   msg.PageID,
+		Host:                     msg.Host,
+		Path:                     msg.Path,
+		Status:                   TaskStatusRunning,
+		StartedAt:                time.Now().UTC(),
+		RetryCount:               msg.RetryCount,
+		SourceType:               msg.SourceType,
+		SourceURL:                msg.SourceURL,
+		PriorityScore:            msg.Priority,
+		DomainID:                 info.DomainID,
+		DomainName:               info.DomainName,
+		FindLinks:                info.FindLinks,
+		AllowCrossSubdomainLinks: info.AllowCrossSubdomainLinks,
+		CrawlDelay:               info.CrawlDelay,
+		JobConcurrency:           info.Concurrency,
+		AdaptiveDelay:            info.AdaptiveDelay,
+		AdaptiveDelayFloor:       info.AdaptiveDelayFloor,
+	}, nil
+}
+
+func (swp *StreamWorkerPool) loadJobInfo(ctx context.Context, jobID string) (*JobInfo, error) {
+	swp.jobInfoMutex.RLock()
+	if info, ok := swp.jobInfoCache[jobID]; ok {
+		swp.jobInfoMutex.RUnlock()
+		return info, nil
+	}
+	swp.jobInfoMutex.RUnlock()
+
+	val, err, _ := swp.jobInfoGroup.Do(jobID, func() (any, error) {
+		info, fetchErr := swp.fetchJobInfo(ctx, jobID)
+		if fetchErr != nil {
+			return nil, fetchErr
+		}
+
+		swp.jobInfoMutex.Lock()
+		swp.jobInfoCache[jobID] = info
+		swp.jobInfoMutex.Unlock()
+
+		return info, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return val.(*JobInfo), nil
+}
+
+func (swp *StreamWorkerPool) fetchJobInfo(ctx context.Context, jobID string) (*JobInfo, error) {
+	var info JobInfo
+	var crawlDelay, adaptiveDelay, adaptiveFloor sql.NullInt64
+
+	err := swp.dbQueue.Execute(ctx, func(tx *sql.Tx) error {
+		return tx.QueryRowContext(ctx, `
+			SELECT d.id, d.name, d.crawl_delay_seconds, d.adaptive_delay_seconds,
+			       d.adaptive_delay_floor_seconds, j.find_links,
+			       j.allow_cross_subdomain_links, j.concurrency
+			FROM domains d
+			JOIN jobs j ON j.domain_id = d.id
+			WHERE j.id = $1
+		`, jobID).Scan(
+			&info.DomainID, &info.DomainName, &crawlDelay, &adaptiveDelay,
+			&adaptiveFloor, &info.FindLinks, &info.AllowCrossSubdomainLinks,
+			&info.Concurrency,
+		)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if crawlDelay.Valid {
+		info.CrawlDelay = int(crawlDelay.Int64)
+	}
+	if adaptiveDelay.Valid {
+		info.AdaptiveDelay = int(adaptiveDelay.Int64)
+	}
+	if adaptiveFloor.Valid {
+		info.AdaptiveDelayFloor = int(adaptiveFloor.Int64)
+	}
+
+	return &info, nil
+}
+
+// --- counter reconciliation ---
+
+func (swp *StreamWorkerPool) reconcileCounters(ctx context.Context) {
+	counts := make(map[string]int64)
+
+	err := swp.dbQueue.ExecuteControl(ctx, func(tx *sql.Tx) error {
+		rows, err := tx.QueryContext(ctx,
+			`SELECT job_id, COUNT(*) FROM tasks WHERE status = 'running' GROUP BY job_id`)
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var jobID string
+			var count int64
+			if err := rows.Scan(&jobID, &count); err != nil {
+				return err
+			}
+			counts[jobID] = count
+		}
+		return rows.Err()
+	})
+	if err != nil {
+		swp.logger.Error().Err(err).Msg("failed to query running task counts for reconciliation")
+		return
+	}
+
+	if err := swp.counters.Reconcile(ctx, counts); err != nil {
+		swp.logger.Error().Err(err).Msg("failed to reconcile running counters in Redis")
+		return
+	}
+
+	total := int64(0)
+	for _, c := range counts {
+		total += c
+	}
+	log.Info().Int64("total_running", total).Int("jobs", len(counts)).Msg("reconciled running counters")
+}
+
+// --- concurrency checking (for dispatcher) ---
+
+// CanDispatch returns true if the job has capacity for more in-flight
+// tasks. Implements broker.ConcurrencyChecker.
+func (swp *StreamWorkerPool) CanDispatch(ctx context.Context, jobID string) (bool, error) {
+	info, err := swp.loadJobInfo(ctx, jobID)
+	if err != nil {
+		return false, err
+	}
+
+	running, err := swp.counters.Get(ctx, jobID)
+	if err != nil {
+		return false, err
+	}
+
+	return running < int64(info.Concurrency), nil
+}

--- a/internal/jobs/stream_worker.go
+++ b/internal/jobs/stream_worker.go
@@ -11,7 +11,6 @@ import (
 	"github.com/Harvey-AU/hover/internal/db"
 	"github.com/Harvey-AU/hover/internal/observability"
 	"github.com/rs/zerolog"
-	"github.com/rs/zerolog/log"
 	"golang.org/x/sync/singleflight"
 )
 
@@ -44,6 +43,13 @@ func DefaultStreamWorkerOpts() StreamWorkerOpts {
 	}
 }
 
+const jobInfoTTL = 5 * time.Minute
+
+type cachedJobInfo struct {
+	info      *JobInfo
+	expiresAt time.Time
+}
+
 // StreamWorkerPool consumes tasks from Redis Streams, executes them
 // via the TaskExecutor, and acts on the returned TaskOutcome
 // (ack, reschedule, persist results).
@@ -58,8 +64,8 @@ type StreamWorkerPool struct {
 	opts         StreamWorkerOpts
 	logger       zerolog.Logger
 
-	// Job info cache.
-	jobInfoCache map[string]*JobInfo
+	// Job info cache with TTL eviction.
+	jobInfoCache map[string]*cachedJobInfo
 	jobInfoMutex sync.RWMutex
 	jobInfoGroup singleflight.Group
 
@@ -83,7 +89,7 @@ func NewStreamWorkerPool(deps StreamWorkerDeps, opts StreamWorkerOpts) *StreamWo
 		dbQueue:      deps.DBQueue,
 		opts:         opts,
 		logger:       deps.Logger.With().Str("component", "stream_worker").Logger(),
-		jobInfoCache: make(map[string]*JobInfo),
+		jobInfoCache: make(map[string]*cachedJobInfo),
 	}
 }
 
@@ -269,17 +275,15 @@ func (swp *StreamWorkerPool) handleOutcome(ctx context.Context, msg broker.Strea
 }
 
 func (swp *StreamWorkerPool) handleDiscoveredLinks(ctx context.Context, outcome *TaskOutcome) {
-	// Discovered link persistence will be wired through the same
-	// channel-based pattern as the current worker pool. The stream
-	// worker's cmd/worker/main.go will set up the persistence loop.
-	//
-	// For now this is a placeholder — the full implementation will
-	// call EnqueueURLs on the dbQueue and then scheduler.ScheduleBatch
-	// for the newly inserted tasks.
+	// TODO(stage2): Wire discovered link persistence and Redis scheduling.
+	// This requires extracting the link filtering/insertion logic from the
+	// old worker pool's processDiscoveredLinks into a reusable function,
+	// then calling EnqueueURLs + scheduler.ScheduleBatch here.
+	// Tracked as part of Stage 2 implementation.
 	swp.logger.Debug().
 		Str("task_id", outcome.Task.ID).
 		Int("link_count", len(outcome.DiscoveredLinks)).
-		Msg("discovered links pending persistence")
+		Msg("discovered links pending persistence (Stage 2)")
 }
 
 // --- reclaim loop ---
@@ -424,10 +428,12 @@ func (swp *StreamWorkerPool) buildTask(ctx context.Context, msg broker.StreamMes
 }
 
 func (swp *StreamWorkerPool) loadJobInfo(ctx context.Context, jobID string) (*JobInfo, error) {
+	now := time.Now()
+
 	swp.jobInfoMutex.RLock()
-	if info, ok := swp.jobInfoCache[jobID]; ok {
+	if cached, ok := swp.jobInfoCache[jobID]; ok && now.Before(cached.expiresAt) {
 		swp.jobInfoMutex.RUnlock()
-		return info, nil
+		return cached.info, nil
 	}
 	swp.jobInfoMutex.RUnlock()
 
@@ -438,7 +444,10 @@ func (swp *StreamWorkerPool) loadJobInfo(ctx context.Context, jobID string) (*Jo
 		}
 
 		swp.jobInfoMutex.Lock()
-		swp.jobInfoCache[jobID] = info
+		swp.jobInfoCache[jobID] = &cachedJobInfo{
+			info:      info,
+			expiresAt: time.Now().Add(jobInfoTTL),
+		}
 		swp.jobInfoMutex.Unlock()
 
 		return info, nil
@@ -521,7 +530,7 @@ func (swp *StreamWorkerPool) reconcileCounters(ctx context.Context) {
 	for _, c := range counts {
 		total += c
 	}
-	log.Info().Int64("total_running", total).Int("jobs", len(counts)).Msg("reconciled running counters")
+	swp.logger.Info().Int64("total_running", total).Int("jobs", len(counts)).Msg("reconciled running counters")
 }
 
 // --- concurrency checking (for dispatcher) ---

--- a/internal/jobs/worker.go
+++ b/internal/jobs/worker.go
@@ -4216,8 +4216,6 @@ func (wp *WorkerPool) handleTaskError(ctx context.Context, task *db.Task, result
 	return nil
 }
 
-
-
 func (wp *WorkerPool) startTaskHTMLPersistenceLoop(ctx context.Context) {
 	if wp.taskHTMLPersistCh == nil {
 		return

--- a/internal/jobs/worker.go
+++ b/internal/jobs/worker.go
@@ -1,23 +1,17 @@
 package jobs
 
 import (
-	"bytes"
-	"compress/gzip"
 	"context"
-	"crypto/sha256"
 	"database/sql"
-	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"maps"
 	"math"
 	"math/rand"
-	"mime"
 	"net/http"
 	"net/url"
 	"os"
-	"regexp"
 	"runtime/debug"
 	"strconv"
 	"strings"
@@ -76,8 +70,6 @@ const (
 	pendingRebalanceInterval = 5 * time.Minute
 	pendingRebalanceJobLimit = 25
 	pendingUnlimitedCap      = 100
-	taskHTMLStorageBucket    = "task-html"
-	taskHTMLContentEncoding  = "gzip"
 	taskHTMLPersistQueueSize = 64
 	taskHTMLPersistWorkers   = 8
 	maxHTMLPersistWorkers    = 32
@@ -97,19 +89,6 @@ type storageUploader interface {
 	Download(ctx context.Context, bucket, path string) ([]byte, error)
 }
 
-type taskHTMLUpload struct {
-	Bucket              string
-	Path                string
-	ContentType         string
-	UploadContentType   string
-	ContentEncoding     string
-	SizeBytes           int64
-	CompressedSizeBytes int64
-	SHA256              string
-	CapturedAt          time.Time
-	Payload             []byte
-}
-
 type taskHTMLPersistRequest struct {
 	Task        db.Task
 	ContentType string
@@ -122,11 +101,6 @@ type discoveredLinkPersistRequest struct {
 	Links     map[string][]string
 	SourceURL string
 }
-
-// ErrDomainDelay is returned by processTask when the domain rate-limit window
-// has not elapsed. The worker should requeue the task as waiting and immediately
-// pick a different task rather than blocking on the delay.
-var ErrDomainDelay = errors.New("domain rate limit delay")
 
 // domainDelayPause is a short back-off applied after requeueing a domain-delayed
 // task. It prevents a tight DB claim loop when all pending tasks belong to
@@ -3857,32 +3831,6 @@ func (wp *WorkerPool) releaseRunningTaskSlot(jobID string) error {
 }
 
 // processTask processes an individual task
-// constructTaskURL builds a proper URL from task path and domain information
-func constructTaskURL(path, host, domainName string) string {
-	// Check if path is already a full URL
-	if strings.HasPrefix(path, "http://") || strings.HasPrefix(path, "https://") {
-		return util.NormaliseURL(path)
-	} else if host != "" {
-		return util.ConstructURL(host, path)
-	} else if domainName != "" {
-		// Use centralized URL construction
-		return util.ConstructURL(domainName, path)
-	} else {
-		// Fallback case - assume path is a full URL but missing protocol
-		return util.NormaliseURL(path)
-	}
-}
-
-func cloneDiscoveredLinks(links map[string][]string) map[string][]string {
-	if len(links) == 0 {
-		return nil
-	}
-	cloned := make(map[string][]string, len(links))
-	for category, values := range links {
-		cloned[category] = append([]string(nil), values...)
-	}
-	return cloned
-}
 
 func sourceURLForDiscoveredLinks(task *db.Task, result *crawler.CrawlResult, domainName string) string {
 	if result != nil {
@@ -3890,7 +3838,7 @@ func sourceURLForDiscoveredLinks(task *db.Task, result *crawler.CrawlResult, dom
 			return util.NormaliseURL(finalURL)
 		}
 	}
-	return constructTaskURL(task.Path, task.Host, domainName)
+	return ConstructTaskURL(task.Path, task.Host, domainName)
 }
 
 func (wp *WorkerPool) enqueueDiscoveredLinks(task *db.Task, result *crawler.CrawlResult) {
@@ -4180,7 +4128,7 @@ func (wp *WorkerPool) processDiscoveredLinks(ctx context.Context, task *Task, li
 func (wp *WorkerPool) handleTaskError(ctx context.Context, task *db.Task, result *crawler.CrawlResult, taskErr error) error {
 	now := time.Now().UTC()
 	retryReason := "non_retryable"
-	wp.populateRequestDiagnostics(task, result)
+	populateRequestDiagnostics(task, result)
 
 	// Check if this is a blocking error (403/429/503)
 	if isBlockingError(taskErr) {
@@ -4268,115 +4216,7 @@ func (wp *WorkerPool) handleTaskError(ctx context.Context, task *db.Task, result
 	return nil
 }
 
-func (wp *WorkerPool) populateRequestDiagnostics(task *db.Task, result *crawler.CrawlResult) {
-	task.RequestDiagnostics = []byte("{}")
-	if result == nil || result.RequestDiagnostics == nil {
-		return
-	}
 
-	if diagnosticsBytes, err := json.Marshal(result.RequestDiagnostics); err == nil {
-		if json.Valid(diagnosticsBytes) {
-			task.RequestDiagnostics = diagnosticsBytes
-		} else {
-			log.Warn().Str("task_id", task.ID).Msg("Request diagnostics produced invalid JSON, using empty object")
-		}
-	} else {
-		log.Error().Err(err).Str("task_id", task.ID).Interface("request_diagnostics", result.RequestDiagnostics).Msg("Failed to marshal request diagnostics")
-	}
-}
-
-func canonicalTaskHTMLContentType(contentType string) string {
-	trimmed := strings.TrimSpace(contentType)
-	if trimmed == "" {
-		return ""
-	}
-
-	mediaType, _, err := mime.ParseMediaType(trimmed)
-	if err != nil {
-		return strings.ToLower(trimmed)
-	}
-
-	return strings.ToLower(mediaType)
-}
-
-func normalisedTaskHTMLContentType(contentType string) string {
-	trimmed := strings.TrimSpace(contentType)
-	if trimmed == "" {
-		return "text/html"
-	}
-
-	return strings.ToLower(trimmed)
-}
-
-func canStoreTaskHTML(contentType string, body []byte) bool {
-	if len(body) == 0 {
-		return false
-	}
-
-	mediaType := canonicalTaskHTMLContentType(contentType)
-	return mediaType == "text/html" || mediaType == "application/xhtml+xml"
-}
-
-func gzipTaskHTML(body []byte) ([]byte, error) {
-	var buffer bytes.Buffer
-	gzipWriter := gzip.NewWriter(&buffer)
-	if _, err := gzipWriter.Write(body); err != nil {
-		return nil, fmt.Errorf("write gzip html: %w", err)
-	}
-	if err := gzipWriter.Close(); err != nil {
-		return nil, fmt.Errorf("close gzip html: %w", err)
-	}
-	return buffer.Bytes(), nil
-}
-
-func buildTaskHTMLUpload(task *db.Task, result *crawler.CrawlResult, capturedAt time.Time) (*taskHTMLUpload, bool, error) {
-	if task == nil || result == nil {
-		return nil, false, nil
-	}
-	if !canStoreTaskHTML(result.ContentType, result.Body) {
-		return nil, false, nil
-	}
-
-	payload, err := gzipTaskHTML(result.Body)
-	if err != nil {
-		return nil, false, err
-	}
-
-	contentType := normalisedTaskHTMLContentType(result.ContentType)
-	uploadContentType := canonicalTaskHTMLContentType(result.ContentType)
-	if uploadContentType == "" {
-		uploadContentType = "text/html"
-	}
-	checksum := sha256.Sum256(result.Body)
-
-	return &taskHTMLUpload{
-		Bucket:              taskHTMLStorageBucket,
-		Path:                archive.TaskHTMLObjectPath(task.JobID, task.ID),
-		ContentType:         contentType,
-		UploadContentType:   uploadContentType,
-		ContentEncoding:     taskHTMLContentEncoding,
-		SizeBytes:           int64(len(result.Body)),
-		CompressedSizeBytes: int64(len(payload)),
-		SHA256:              hex.EncodeToString(checksum[:]),
-		CapturedAt:          capturedAt,
-		Payload:             payload,
-	}, true, nil
-}
-
-func applyTaskHTMLMetadata(task *db.Task, upload *taskHTMLUpload) {
-	if task == nil || upload == nil {
-		return
-	}
-
-	task.HTMLStorageBucket = upload.Bucket
-	task.HTMLStoragePath = upload.Path
-	task.HTMLContentType = upload.ContentType
-	task.HTMLContentEncoding = upload.ContentEncoding
-	task.HTMLSizeBytes = upload.SizeBytes
-	task.HTMLCompressedSizeBytes = upload.CompressedSizeBytes
-	task.HTMLSHA256 = upload.SHA256
-	task.HTMLCapturedAt = upload.CapturedAt
-}
 
 func (wp *WorkerPool) startTaskHTMLPersistenceLoop(ctx context.Context) {
 	if wp.taskHTMLPersistCh == nil {
@@ -4456,7 +4296,11 @@ func (wp *WorkerPool) persistTaskHTML(ctx context.Context, task *db.Task, result
 	if wp.storageClient == nil || wp.taskHTMLPersistCh == nil || task == nil || result == nil {
 		return
 	}
-	if !canStoreTaskHTML(result.ContentType, result.Body) {
+	if len(result.Body) == 0 {
+		return
+	}
+	mediaType := canonicalHTMLContentType(result.ContentType)
+	if mediaType != "text/html" && mediaType != "application/xhtml+xml" {
 		return
 	}
 
@@ -4501,11 +4345,7 @@ func (wp *WorkerPool) processTaskHTMLPersistence(ctx context.Context, request *t
 	}
 
 	result := &crawler.CrawlResult{ContentType: request.ContentType, Body: request.Body}
-	upload, ok, err := buildTaskHTMLUpload(&request.Task, result, request.CapturedAt)
-	if err != nil {
-		log.Warn().Err(err).Str("task_id", request.Task.ID).Msg("Failed to prepare task HTML for storage")
-		return
-	}
+	upload, ok := buildHTMLUpload(&request.Task, result, request.CapturedAt)
 	if !ok {
 		return
 	}
@@ -4522,7 +4362,7 @@ func (wp *WorkerPool) processTaskHTMLPersistence(ctx context.Context, request *t
 	}
 
 	htmlTask := request.Task
-	applyTaskHTMLMetadata(&htmlTask, upload)
+	applyHTMLMetadata(&htmlTask, upload)
 
 	metadata := db.TaskHTMLMetadata{
 		StorageBucket:       upload.Bucket,
@@ -4538,6 +4378,7 @@ func (wp *WorkerPool) processTaskHTMLPersistence(ctx context.Context, request *t
 	readyCtx, readyCancel := context.WithTimeout(ctx, taskHTMLReadyMaxWait)
 	defer readyCancel()
 	sawNotReady := false
+	var err error
 
 	for {
 		persistCtx, persistCancel := context.WithTimeout(readyCtx, 10*time.Second)
@@ -4667,7 +4508,7 @@ func (wp *WorkerPool) handleTaskSuccess(ctx context.Context, task *db.Task, resu
 		}
 	}
 
-	wp.populateRequestDiagnostics(task, result)
+	populateRequestDiagnostics(task, result)
 
 	// Decrement in-memory counter immediately, then queue async DB decrement.
 	wp.decrementRunningTaskInMem(task.JobID)
@@ -4810,7 +4651,7 @@ func (wp *WorkerPool) processTask(ctx context.Context, task *Task) (*crawler.Cra
 	}()
 
 	// Construct a proper URL for processing
-	urlStr := constructTaskURL(task.Path, task.Host, task.DomainName)
+	urlStr := ConstructTaskURL(task.Path, task.Host, task.DomainName)
 
 	log.Debug().Str("url", urlStr).Str("task_id", task.ID).Msg("Starting URL warm")
 
@@ -4885,96 +4726,6 @@ func (wp *WorkerPool) processTask(ctx context.Context, task *Task) (*crawler.Cra
 		Msg("Crawler completed")
 
 	return result, nil
-}
-
-// isRetryableError checks if an error should trigger a retry
-func isRetryableError(err error) bool {
-	if err == nil {
-		return false
-	}
-
-	errorStr := strings.ToLower(err.Error())
-
-	// Network/timeout errors that should be retried
-	networkErrors := strings.Contains(errorStr, "timeout") ||
-		strings.Contains(errorStr, "deadline exceeded") ||
-		strings.Contains(errorStr, "connection") ||
-		strings.Contains(errorStr, "network") ||
-		strings.Contains(errorStr, "temporary") ||
-		strings.Contains(errorStr, "reset by peer") ||
-		strings.Contains(errorStr, "broken pipe") ||
-		strings.Contains(errorStr, "unexpected eof")
-
-	// Server errors that should be retried (likely due to load/temporary issues)
-	// Note: 503 Service Unavailable is treated as a blocking error (see isBlockingError)
-	serverErrors := strings.Contains(errorStr, "internal server error") ||
-		strings.Contains(errorStr, "bad gateway") ||
-		strings.Contains(errorStr, "gateway timeout") ||
-		strings.Contains(errorStr, "502") ||
-		strings.Contains(errorStr, "504") ||
-		strings.Contains(errorStr, "500")
-
-	return networkErrors || serverErrors
-}
-
-// isBlockingError checks if an error indicates we're being blocked
-func isBlockingError(err error) bool {
-	if err == nil {
-		return false
-	}
-
-	errorStr := strings.ToLower(err.Error())
-
-	// Blocking/rate limit errors that need special handling with exponential backoff
-	return strings.Contains(errorStr, "403") ||
-		strings.Contains(errorStr, "forbidden") ||
-		strings.Contains(errorStr, "429") ||
-		strings.Contains(errorStr, "too many requests") ||
-		strings.Contains(errorStr, "rate limit") ||
-		strings.Contains(errorStr, "503") ||
-		strings.Contains(errorStr, "service unavailable")
-}
-
-var statusCodePattern = regexp.MustCompile(`\b(\d{3})\b`)
-
-func isClientOrRedirectError(err error) bool {
-	if err == nil {
-		return false
-	}
-	lower := strings.ToLower(err.Error())
-	if strings.Contains(lower, "crawler error") {
-		keywords := []string{
-			"not found",
-			"bad request",
-			"unauthorized",
-			"forbidden",
-			"gone",
-			"method not allowed",
-			"temporary redirect",
-			"permanent redirect",
-			"moved permanently",
-			"see other",
-		}
-		for _, kw := range keywords {
-			if strings.Contains(lower, kw) {
-				return true
-			}
-		}
-	}
-	matches := statusCodePattern.FindAllStringSubmatch(lower, -1)
-	for _, match := range matches {
-		if len(match) < 2 {
-			continue
-		}
-		code, err := strconv.Atoi(match[1])
-		if err != nil {
-			continue
-		}
-		if code >= 400 && code < 500 {
-			return true
-		}
-	}
-	return false
 }
 
 // calculateBackoffDuration computes exponential backoff duration for retry attempts

--- a/internal/jobs/worker_diagnostics_test.go
+++ b/internal/jobs/worker_diagnostics_test.go
@@ -43,10 +43,9 @@ func TestPopulateRequestDiagnostics(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			wp := &WorkerPool{}
 			task := &db.Task{ID: "task-1"}
 
-			wp.populateRequestDiagnostics(task, tt.result)
+			populateRequestDiagnostics(task, tt.result)
 
 			if tt.expectJSON != "" {
 				if string(task.RequestDiagnostics) != tt.expectJSON {

--- a/internal/jobs/worker_page_content_test.go
+++ b/internal/jobs/worker_page_content_test.go
@@ -60,20 +60,19 @@ func TestBuildTaskHTMLUpload(t *testing.T) {
 	body := []byte("<html><body>Hello</body></html>")
 	capturedAt := time.Date(2026, time.March, 21, 7, 0, 0, 0, time.UTC)
 
-	upload, ok, err := buildTaskHTMLUpload(task, &crawler.CrawlResult{
+	upload, ok := buildHTMLUpload(task, &crawler.CrawlResult{
 		ContentType: "text/html; charset=utf-8",
 		Body:        body,
 	}, capturedAt)
 
-	require.NoError(t, err)
 	require.True(t, ok)
 	require.NotNil(t, upload)
 
-	assert.Equal(t, taskHTMLStorageBucket, upload.Bucket)
+	assert.Equal(t, htmlStorageBucket, upload.Bucket)
 	assert.Equal(t, "jobs/job-456/tasks/task-123/page-content.html.gz", upload.Path)
 	assert.Equal(t, "text/html; charset=utf-8", upload.ContentType)
 	assert.Equal(t, "text/html", upload.UploadContentType)
-	assert.Equal(t, taskHTMLContentEncoding, upload.ContentEncoding)
+	assert.Equal(t, htmlContentEncoding, upload.ContentEncoding)
 	assert.Equal(t, int64(len(body)), upload.SizeBytes)
 	assert.Equal(t, capturedAt, upload.CapturedAt)
 	assert.Len(t, upload.SHA256, 64)
@@ -99,12 +98,11 @@ func TestBuildTaskHTMLUploadSkipsIneligibleBodies(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			upload, ok, err := buildTaskHTMLUpload(&db.Task{ID: "task", JobID: "job"}, &crawler.CrawlResult{
+			upload, ok := buildHTMLUpload(&db.Task{ID: "task", JobID: "job"}, &crawler.CrawlResult{
 				ContentType: tt.contentType,
 				Body:        tt.body,
 			}, time.Now().UTC())
 
-			require.NoError(t, err)
 			assert.False(t, ok)
 			assert.Nil(t, upload)
 		})
@@ -133,7 +131,7 @@ func TestProcessTaskHTMLPersistencePersistsMetadataOnSuccess(t *testing.T) {
 		storageClient: &stubStorageUploader{uploadWithOptionsFunc: func(ctx context.Context, bucket, path string, data []byte, options storage.UploadOptions) (string, error) {
 			capturedOptions = options
 			capturedPayload = append([]byte(nil), data...)
-			assert.Equal(t, taskHTMLStorageBucket, bucket)
+			assert.Equal(t, htmlStorageBucket, bucket)
 			assert.Equal(t, "jobs/job-456/tasks/task-123/page-content.html.gz", path)
 			return bucket + "/" + path, nil
 		}},
@@ -142,16 +140,16 @@ func TestProcessTaskHTMLPersistencePersistsMetadataOnSuccess(t *testing.T) {
 	wp.processTaskHTMLPersistence(context.Background(), request)
 
 	assert.Equal(t, "task-123", persistedTaskID)
-	assert.Equal(t, taskHTMLStorageBucket, persistedMetadata.StorageBucket)
+	assert.Equal(t, htmlStorageBucket, persistedMetadata.StorageBucket)
 	assert.Equal(t, "jobs/job-456/tasks/task-123/page-content.html.gz", persistedMetadata.StoragePath)
 	assert.Equal(t, "text/html; charset=utf-8", persistedMetadata.ContentType)
-	assert.Equal(t, taskHTMLContentEncoding, persistedMetadata.ContentEncoding)
+	assert.Equal(t, htmlContentEncoding, persistedMetadata.ContentEncoding)
 	assert.Equal(t, int64(len(request.Body)), persistedMetadata.SizeBytes)
 	assert.Equal(t, int64(len(capturedPayload)), persistedMetadata.CompressedSizeBytes)
 	assert.Equal(t, capturedAt, persistedMetadata.CapturedAt)
 	assert.Len(t, persistedMetadata.SHA256, 64)
 	assert.Equal(t, "text/html", capturedOptions.ContentType)
-	assert.Equal(t, taskHTMLContentEncoding, capturedOptions.ContentEncoding)
+	assert.Equal(t, htmlContentEncoding, capturedOptions.ContentEncoding)
 	assert.Equal(t, request.Body, gunzipTestPayload(t, capturedPayload))
 }
 
@@ -190,7 +188,7 @@ func TestProcessTaskHTMLPersistenceDeletesUploadWhenMetadataPersistenceFails(t *
 			},
 			deleteFunc: func(ctx context.Context, bucket, path string) error {
 				deleted = true
-				assert.Equal(t, taskHTMLStorageBucket, bucket)
+				assert.Equal(t, htmlStorageBucket, bucket)
 				assert.Equal(t, "jobs/job-456/tasks/task-123/page-content.html.gz", path)
 				return nil
 			},


### PR DESCRIPTION
## Summary
- Adds `internal/broker/` package — Redis ZSET scheduler, Stream consumer/dispatcher, domain pacer (Lua scripts), running task counters
- Extracts crawl executor from `worker.go` into `executor.go` (pure function, returns `TaskOutcome` + `RetryDecision`)
- Creates `internal/jobs/stream_worker.go` — Redis Stream consuming worker pool with XAUTOCLAIM stale recovery
- Creates `cmd/worker/main.go` — dedicated worker binary connecting to Postgres + Redis
- Wires Redis into `dev.sh` (local Docker container), review app CI (Fly Upstash per PR), and `Dockerfile`

## What this does NOT change
- API server (`cmd/app/main.go`) still runs the old DB-queue worker pool
- No existing behaviour modified — this is additive scaffolding (Stage 1)
- All existing tests pass, 14 new broker tests added (miniredis)

## Test plan
- [x] `go build ./...` — clean
- [x] `go test ./internal/broker/...` — 14 tests pass
- [x] `go test ./internal/jobs/...` — all existing tests pass
- [x] Worker binary starts locally against Postgres + Redis, connects, idles
- [ ] CI lint + test + integration gates
- [ ] Review app deploys with Upstash Redis provisioned

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Redis-backed distributed worker system with stream-based task delivery, reclaim/retry handling, domain pacing and per-task execution outcomes.

* **Infrastructure**
  * Provisioning for ephemeral Redis in review apps and a worker runtime build for multi-instance deployments; dispatcher moves due tasks and running-task counters sync to the database.

* **Configuration**
  * New broker-related environment variables and local dev helpers to run Redis.

* **Tests**
  * Added unit and integration tests for pacing, scheduling and counters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->