### PR TITLE
Fix crawler warm recursion and telemetry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ On merge, CI will:
 
 ### Added
 
-- Per‑phase timing added to request diagnostics (primary, cache‑validation,
+- Per-phase timing added to request diagnostics (primary, cache-validation,
   secondary, total)
 - New crawler phase and worker task outcome metrics capturing phase, outcome,
   reason and duration
@@ -38,10 +38,10 @@ On merge, CI will:
 
 ### Fixed
 
-- Cache‑validation cancellation now propagates correctly; redundant validation
+- Cache-validation cancellation now propagates correctly; redundant validation
   skipped for secondary requests
 - Secondary request failures are surfaced and timings recorded;
-  division‑by‑zero guarded in improvement ratio
+  division-by-zero guarded in improvement ratio
 
 ## Full changelog history
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,8 +40,8 @@ On merge, CI will:
 
 - Cache-validation cancellation now propagates correctly; redundant validation
   skipped for secondary requests
-- Secondary request failures are surfaced and timings recorded;
-  division-by-zero guarded in improvement ratio
+- Secondary request failures are surfaced and timings recorded; division-by-zero
+  guarded in improvement ratio
 
 ## Full changelog history
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,19 +28,19 @@ On merge, CI will:
 
 ## [Unreleased]
 
-### New Features
+### Added
 
-- Per‑phase timing added to request diagnostics (primary, cache‑validation, 
+- Per‑phase timing added to request diagnostics (primary, cache‑validation,
   secondary, total)
-- New crawler phase and worker task outcome metrics capturing phase, outcome, 
+- New crawler phase and worker task outcome metrics capturing phase, outcome,
   reason and duration
 - Crawler emits a final summary of phase timings, probe counts and cache status
 
-### Bug Fixes
+### Fixed
 
 - Cache‑validation cancellation now propagates correctly; redundant validation
   skipped for secondary requests
-- Secondary request failures are surfaced and timings recorded; 
+- Secondary request failures are surfaced and timings recorded;
   division‑by‑zero guarded in improvement ratio
 
 ## Full changelog history

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,14 +30,18 @@ On merge, CI will:
 
 ### New Features
 
-- Per‑phase timing added to request diagnostics (primary, cache‑validation, secondary, total).
-- New crawler phase and worker task outcome metrics capturing phase, outcome, reason and duration.
-- Crawler emits a final summary of phase timings, probe counts and cache status.
+- Per‑phase timing added to request diagnostics (primary, cache‑validation, 
+  secondary, total)
+- New crawler phase and worker task outcome metrics capturing phase, outcome, 
+  reason and duration
+- Crawler emits a final summary of phase timings, probe counts and cache status
 
 ### Bug Fixes
 
-- Cache‑validation cancellation now propagates correctly; redundant validation skipped for secondary requests.
-- Secondary request failures are surfaced and timings recorded; division‑by‑zero guarded in improvement ratio.
+- Cache‑validation cancellation now propagates correctly; redundant validation
+  skipped for secondary requests
+- Secondary request failures are surfaced and timings recorded; 
+  division‑by‑zero guarded in improvement ratio
 
 ## Full changelog history
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,16 @@ On merge, CI will:
 
 ## [Unreleased]
 
-_Add unreleased changes here._
+### New Features
+
+- Per‑phase timing added to request diagnostics (primary, cache‑validation, secondary, total).
+- New crawler phase and worker task outcome metrics capturing phase, outcome, reason and duration.
+- Crawler emits a final summary of phase timings, probe counts and cache status.
+
+### Bug Fixes
+
+- Cache‑validation cancellation now propagates correctly; redundant validation skipped for secondary requests.
+- Secondary request failures are surfaced and timings recorded; division‑by‑zero guarded in improvement ratio.
 
 ## Full changelog history
 

--- a/internal/crawler/crawler.go
+++ b/internal/crawler/crawler.go
@@ -978,7 +978,15 @@ func classifyCrawlerOutcome(err error) string {
 }
 
 func errorsIsContextDone(err error) bool {
-	return err == context.Canceled || err == context.DeadlineExceeded || strings.Contains(strings.ToLower(err.Error()), "context deadline exceeded") || strings.Contains(strings.ToLower(err.Error()), "context canceled")
+	if err == nil {
+		return false
+	}
+
+	errorStr := strings.ToLower(err.Error())
+	return errors.Is(err, context.Canceled) ||
+		errors.Is(err, context.DeadlineExceeded) ||
+		strings.Contains(errorStr, "context deadline exceeded") ||
+		strings.Contains(errorStr, "context canceled")
 }
 
 func classifyProbeOutcome(err error, probe ProbeDiagnostics) string {
@@ -1022,10 +1030,14 @@ func applyPhaseTiming(res *CrawlResult, phase string, duration time.Duration) {
 	}
 	ensureRequestDiagnostics(res)
 	switch phase {
+	case "primary_request":
+		res.RequestDiagnostics.Timings.PrimaryRequestMS = duration.Milliseconds()
 	case "secondary_request":
 		res.RequestDiagnostics.Timings.SecondaryRequestMS = duration.Milliseconds()
 	default:
-		res.RequestDiagnostics.Timings.PrimaryRequestMS = duration.Milliseconds()
+		log.Warn().
+			Str("phase", phase).
+			Msg("Skipping timing assignment for unexpected crawler phase")
 	}
 }
 

--- a/internal/crawler/crawler.go
+++ b/internal/crawler/crawler.go
@@ -665,7 +665,7 @@ func (c *Crawler) setupResponseHandlers(collyClone *colly.Collector, result *Cra
 var errSoftCacheValidationFailure = errors.New("cache validation failed")
 var errCacheValidationSkipped = errors.New("cache validation skipped")
 
-func (c *Crawler) performCacheValidation(ctx context.Context, targetURL string, res *CrawlResult) error {
+func (c *Crawler) performCacheValidation(ctx context.Context, targetURL string, res *CrawlResult) (bool, error) {
 	ensureRequestDiagnostics(res)
 
 	// Only perform cache warming if we got a MISS or EXPIRED
@@ -679,7 +679,7 @@ func (c *Crawler) performCacheValidation(ctx context.Context, targetURL string, 
 			Str("url", targetURL).
 			Str("cache_status", res.CacheStatus).
 			Msg("No cache warming needed - cache already available or not cacheable")
-		return errCacheValidationSkipped
+		return true, errCacheValidationSkipped
 	}
 
 	// Apply randomized delay between 500-1000ms to avoid hammering origins
@@ -706,7 +706,7 @@ func (c *Crawler) performCacheValidation(ctx context.Context, targetURL string, 
 	case <-ctx.Done():
 		// Context cancelled during wait
 		log.Debug().Str("url", targetURL).Msg("Cache warming cancelled during initial delay")
-		return ctx.Err()
+		return true, ctx.Err()
 	}
 
 	// Check cache status with HEAD requests in a loop
@@ -779,7 +779,7 @@ func (c *Crawler) performCacheValidation(ctx context.Context, targetURL string, 
 				// Continue to next check
 			case <-ctx.Done():
 				log.Debug().Str("url", targetURL).Msg("Cache warming cancelled during check loop")
-				return ctx.Err()
+				return true, ctx.Err()
 			}
 			// Increase delay for the next iteration
 			nextCheckDelay += 300
@@ -825,7 +825,7 @@ func (c *Crawler) performCacheValidation(ctx context.Context, targetURL string, 
 			res.RequestDiagnostics.Secondary = &secondary
 		}
 		if err != nil {
-			return fmt.Errorf("%w: secondary request failed: %w", errSoftCacheValidationFailure, err)
+			return true, fmt.Errorf("%w: secondary request failed: %w", errSoftCacheValidationFailure, err)
 		}
 		if secondResult != nil {
 			res.SecondResponseTime = secondResult.ResponseTime
@@ -860,7 +860,7 @@ func (c *Crawler) performCacheValidation(ctx context.Context, targetURL string, 
 			Msg("Cache status did not transition to HIT; skipping second request")
 	}
 
-	return nil
+	return true, nil
 }
 
 // setupLinkExtraction configures Colly HTML handler for link extraction and categorization
@@ -1117,7 +1117,8 @@ func (c *Crawler) warmURL(ctx context.Context, targetURL string, findLinks bool,
 
 	if allowCacheValidation {
 		cacheValidationStart := time.Now()
-		if err := c.performCacheValidation(ctx, targetURL, res); err != nil {
+		cacheValidationProcessed, err := c.performCacheValidation(ctx, targetURL, res)
+		if err != nil {
 			if errors.Is(err, errCacheValidationSkipped) {
 				res.RequestDiagnostics.Timings.CacheValidationMS = time.Since(cacheValidationStart).Milliseconds()
 			} else {
@@ -1134,7 +1135,7 @@ func (c *Crawler) warmURL(ctx context.Context, targetURL string, findLinks bool,
 				}
 			}
 		}
-		if res.RequestDiagnostics.Timings.CacheValidationMS == 0 {
+		if !cacheValidationProcessed {
 			cacheValidationDuration := time.Since(cacheValidationStart)
 			observability.RecordCrawlerPhase(ctx, observability.CrawlerPhaseMetrics{
 				Phase:    "cache_validation",

--- a/internal/crawler/crawler.go
+++ b/internal/crawler/crawler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	crand "crypto/rand"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"math/big"
 	"math/rand"
@@ -661,6 +662,8 @@ func (c *Crawler) setupResponseHandlers(collyClone *colly.Collector, result *Cra
 }
 
 // performCacheValidation handles cache warming logic if cache miss is detected
+var errSoftCacheValidationFailure = errors.New("cache validation failed")
+
 func (c *Crawler) performCacheValidation(ctx context.Context, targetURL string, res *CrawlResult) error {
 	ensureRequestDiagnostics(res)
 
@@ -821,7 +824,7 @@ func (c *Crawler) performCacheValidation(ctx context.Context, targetURL string, 
 			res.RequestDiagnostics.Secondary = &secondary
 		}
 		if err != nil {
-			return fmt.Errorf("secondary request failed: %w", err)
+			return fmt.Errorf("%w: secondary request failed: %w", errSoftCacheValidationFailure, err)
 		}
 		if secondResult != nil {
 			res.SecondResponseTime = secondResult.ResponseTime
@@ -1104,16 +1107,20 @@ func (c *Crawler) warmURL(ctx context.Context, targetURL string, findLinks bool,
 				Duration: cacheValidationDuration,
 			})
 			res.RequestDiagnostics.Timings.CacheValidationMS = cacheValidationDuration.Milliseconds()
-			res.RequestDiagnostics.Timings.TotalMS = time.Since(start).Milliseconds()
-			return res, err
+			if !errors.Is(err, errSoftCacheValidationFailure) {
+				res.RequestDiagnostics.Timings.TotalMS = time.Since(start).Milliseconds()
+				return res, err
+			}
 		}
-		cacheValidationDuration := time.Since(cacheValidationStart)
-		observability.RecordCrawlerPhase(ctx, observability.CrawlerPhaseMetrics{
-			Phase:    "cache_validation",
-			Outcome:  "success",
-			Duration: cacheValidationDuration,
-		})
-		res.RequestDiagnostics.Timings.CacheValidationMS = cacheValidationDuration.Milliseconds()
+		if res.RequestDiagnostics.Timings.CacheValidationMS == 0 {
+			cacheValidationDuration := time.Since(cacheValidationStart)
+			observability.RecordCrawlerPhase(ctx, observability.CrawlerPhaseMetrics{
+				Phase:    "cache_validation",
+				Outcome:  "success",
+				Duration: cacheValidationDuration,
+			})
+			res.RequestDiagnostics.Timings.CacheValidationMS = cacheValidationDuration.Milliseconds()
+		}
 	}
 
 	res.RequestDiagnostics.Timings.TotalMS = time.Since(start).Milliseconds()

--- a/internal/crawler/crawler.go
+++ b/internal/crawler/crawler.go
@@ -811,24 +811,23 @@ func (c *Crawler) performCacheValidation(ctx context.Context, targetURL string, 
 				Dur("secondary_duration_ms", secondDuration).
 				Msg("Second request failed, but first request succeeded")
 			// Don't return error - first request was successful
-		} else {
+		}
+		res.RequestDiagnostics.Timings.SecondaryRequestMS = secondDuration.Milliseconds()
+		if secondResult.RequestDiagnostics != nil && secondResult.RequestDiagnostics.Primary != nil {
+			secondary := *secondResult.RequestDiagnostics.Primary
+			if secondary.Request != nil {
+				requestCopy := *secondary.Request
+				requestCopy.Provenance = "secondary"
+				secondary.Request = &requestCopy
+			}
+			res.RequestDiagnostics.Secondary = &secondary
+		}
+		if err == nil {
 			res.SecondResponseTime = secondResult.ResponseTime
 			res.SecondCacheStatus = secondResult.CacheStatus
 			res.SecondContentLength = secondResult.ContentLength
 			res.SecondHeaders = secondResult.Headers
 			res.SecondPerformance = &secondResult.Performance
-			if secondResult.RequestDiagnostics != nil && secondResult.RequestDiagnostics.Primary != nil {
-				secondary := *secondResult.RequestDiagnostics.Primary
-				if secondary.Request != nil {
-					requestCopy := *secondary.Request
-					requestCopy.Provenance = "secondary"
-					secondary.Request = &requestCopy
-				}
-				if res.RequestDiagnostics != nil {
-					res.RequestDiagnostics.Secondary = &secondary
-				}
-			}
-			res.RequestDiagnostics.Timings.SecondaryRequestMS = secondDuration.Milliseconds()
 
 			// Calculate improvement ratio for pattern analysis
 			improvementRatio := float64(res.ResponseTime) / float64(res.SecondResponseTime)

--- a/internal/crawler/crawler.go
+++ b/internal/crawler/crawler.go
@@ -733,7 +733,7 @@ func (c *Crawler) performCacheValidation(ctx context.Context, targetURL string, 
 		}
 		observability.RecordCrawlerPhase(ctx, observability.CrawlerPhaseMetrics{
 			Phase:    "cache_probe",
-			Outcome:  classifyCrawlerOutcome(err),
+			Outcome:  classifyProbeOutcome(err, probe),
 			Duration: probeDuration,
 		})
 
@@ -805,14 +805,13 @@ func (c *Crawler) performCacheValidation(ctx context.Context, targetURL string, 
 				Str("url", targetURL).
 				Dur("secondary_duration_ms", secondDuration).
 				Msg("Second request failed, but first request succeeded")
-			// Don't return error - first request was successful
 		}
-		if secondResult.RequestDiagnostics != nil && secondResult.RequestDiagnostics.Timings != nil {
+		if secondResult != nil && secondResult.RequestDiagnostics != nil && secondResult.RequestDiagnostics.Timings != nil {
 			res.RequestDiagnostics.Timings.SecondaryRequestMS = secondResult.RequestDiagnostics.Timings.SecondaryRequestMS
 		} else {
 			res.RequestDiagnostics.Timings.SecondaryRequestMS = secondDuration.Milliseconds()
 		}
-		if secondResult.RequestDiagnostics != nil && secondResult.RequestDiagnostics.Primary != nil {
+		if secondResult != nil && secondResult.RequestDiagnostics != nil && secondResult.RequestDiagnostics.Primary != nil {
 			secondary := *secondResult.RequestDiagnostics.Primary
 			if secondary.Request != nil {
 				requestCopy := *secondary.Request
@@ -821,7 +820,10 @@ func (c *Crawler) performCacheValidation(ctx context.Context, targetURL string, 
 			}
 			res.RequestDiagnostics.Secondary = &secondary
 		}
-		if err == nil {
+		if err != nil {
+			return fmt.Errorf("secondary request failed: %w", err)
+		}
+		if secondResult != nil {
 			res.SecondResponseTime = secondResult.ResponseTime
 			res.SecondCacheStatus = secondResult.CacheStatus
 			res.SecondContentLength = secondResult.ContentLength
@@ -974,6 +976,16 @@ func classifyCrawlerOutcome(err error) string {
 
 func errorsIsContextDone(err error) bool {
 	return err == context.Canceled || err == context.DeadlineExceeded || strings.Contains(strings.ToLower(err.Error()), "context deadline exceeded") || strings.Contains(strings.ToLower(err.Error()), "context canceled")
+}
+
+func classifyProbeOutcome(err error, probe ProbeDiagnostics) string {
+	if err != nil {
+		return classifyCrawlerOutcome(err)
+	}
+	if probe.Response != nil && probe.Response.StatusCode >= 400 {
+		return "error"
+	}
+	return "success"
 }
 
 func ensureRequestDiagnostics(res *CrawlResult) {

--- a/internal/crawler/crawler.go
+++ b/internal/crawler/crawler.go
@@ -702,7 +702,7 @@ func (c *Crawler) performCacheValidation(ctx context.Context, targetURL string, 
 	case <-ctx.Done():
 		// Context cancelled during wait
 		log.Debug().Str("url", targetURL).Msg("Cache warming cancelled during initial delay")
-		return nil // First request was successful, return that
+		return ctx.Err()
 	}
 
 	// Check cache status with HEAD requests in a loop
@@ -775,7 +775,7 @@ func (c *Crawler) performCacheValidation(ctx context.Context, targetURL string, 
 				// Continue to next check
 			case <-ctx.Done():
 				log.Debug().Str("url", targetURL).Msg("Cache warming cancelled during check loop")
-				return nil
+				return ctx.Err()
 			}
 			// Increase delay for the next iteration
 			nextCheckDelay += 300
@@ -799,11 +799,6 @@ func (c *Crawler) performCacheValidation(ctx context.Context, targetURL string, 
 		secondStart := time.Now()
 		secondResult, err := c.makeSecondRequest(ctx, targetURL)
 		secondDuration := time.Since(secondStart)
-		observability.RecordCrawlerPhase(ctx, observability.CrawlerPhaseMetrics{
-			Phase:    "secondary_request",
-			Outcome:  classifyCrawlerOutcome(err),
-			Duration: secondDuration,
-		})
 		if err != nil {
 			log.Debug().
 				Err(err).
@@ -812,7 +807,11 @@ func (c *Crawler) performCacheValidation(ctx context.Context, targetURL string, 
 				Msg("Second request failed, but first request succeeded")
 			// Don't return error - first request was successful
 		}
-		res.RequestDiagnostics.Timings.SecondaryRequestMS = secondDuration.Milliseconds()
+		if secondResult.RequestDiagnostics != nil && secondResult.RequestDiagnostics.Timings != nil {
+			res.RequestDiagnostics.Timings.SecondaryRequestMS = secondResult.RequestDiagnostics.Timings.SecondaryRequestMS
+		} else {
+			res.RequestDiagnostics.Timings.SecondaryRequestMS = secondDuration.Milliseconds()
+		}
 		if secondResult.RequestDiagnostics != nil && secondResult.RequestDiagnostics.Primary != nil {
 			secondary := *secondResult.RequestDiagnostics.Primary
 			if secondary.Request != nil {
@@ -986,7 +985,36 @@ func ensureRequestDiagnostics(res *CrawlResult) {
 	}
 }
 
-func (c *Crawler) warmURL(ctx context.Context, targetURL string, findLinks bool, allowCacheValidation bool) (*CrawlResult, error) {
+func metricErrForRequestPhase(err error, res *CrawlResult) error {
+	if err != nil {
+		return err
+	}
+	if res == nil {
+		return nil
+	}
+	if res.Error != "" {
+		return fmt.Errorf("%s", res.Error)
+	}
+	if res.StatusCode != 0 && (res.StatusCode < 200 || res.StatusCode >= 300) {
+		return fmt.Errorf("non-success status code: %d", res.StatusCode)
+	}
+	return nil
+}
+
+func applyPhaseTiming(res *CrawlResult, phase string, duration time.Duration) {
+	if res == nil {
+		return
+	}
+	ensureRequestDiagnostics(res)
+	switch phase {
+	case "secondary_request":
+		res.RequestDiagnostics.Timings.SecondaryRequestMS = duration.Milliseconds()
+	default:
+		res.RequestDiagnostics.Timings.PrimaryRequestMS = duration.Milliseconds()
+	}
+}
+
+func (c *Crawler) warmURL(ctx context.Context, targetURL string, findLinks bool, allowCacheValidation bool, requestPhase string) (*CrawlResult, error) {
 	// Validate the crawl request (with SSRF protection unless skipped for tests)
 	_, err := validateCrawlRequest(ctx, targetURL, c.config.SkipSSRFCheck)
 	if err != nil {
@@ -1023,12 +1051,13 @@ func (c *Crawler) warmURL(ctx context.Context, targetURL string, findLinks bool,
 	primaryStart := time.Now()
 	err = executeCollyRequest(ctx, collyClone, targetURL, res)
 	primaryDuration := time.Since(primaryStart)
+	phaseErr := metricErrForRequestPhase(err, res)
 	observability.RecordCrawlerPhase(ctx, observability.CrawlerPhaseMetrics{
-		Phase:    "primary_request",
-		Outcome:  classifyCrawlerOutcome(err),
+		Phase:    requestPhase,
+		Outcome:  classifyCrawlerOutcome(phaseErr),
 		Duration: primaryDuration,
 	})
-	res.RequestDiagnostics.Timings.PrimaryRequestMS = primaryDuration.Milliseconds()
+	applyPhaseTiming(res, requestPhase, primaryDuration)
 	if err != nil {
 		res.RequestDiagnostics.Timings.TotalMS = time.Since(start).Milliseconds()
 		return res, err
@@ -1094,7 +1123,7 @@ func (c *Crawler) warmURL(ctx context.Context, targetURL string, findLinks bool,
 // WarmURL performs a crawl of the specified URL and returns the result.
 // It respects context cancellation, enforces timeout, and treats non-2xx statuses as errors.
 func (c *Crawler) WarmURL(ctx context.Context, targetURL string, findLinks bool) (*CrawlResult, error) {
-	return c.warmURL(ctx, targetURL, findLinks, true)
+	return c.warmURL(ctx, targetURL, findLinks, true, "primary_request")
 }
 
 // shouldMakeSecondRequest determines if we should make a second request for cache warming
@@ -1112,7 +1141,7 @@ func shouldMakeSecondRequest(cacheStatus string) bool {
 // makeSecondRequest performs a second request to verify cache warming
 // Reuses the main WarmURL logic but disables link extraction
 func (c *Crawler) makeSecondRequest(ctx context.Context, targetURL string) (*CrawlResult, error) {
-	return c.warmURL(ctx, targetURL, false, false)
+	return c.warmURL(ctx, targetURL, false, false, "secondary_request")
 }
 
 func (c *Crawler) CheckCacheStatus(ctx context.Context, targetURL string) (ProbeDiagnostics, error) {

--- a/internal/crawler/crawler.go
+++ b/internal/crawler/crawler.go
@@ -15,6 +15,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/Harvey-AU/hover/internal/observability"
 	"github.com/PuerkitoBio/goquery"
 	"github.com/gocolly/colly/v2"
 	"github.com/rs/zerolog/log"
@@ -661,8 +662,15 @@ func (c *Crawler) setupResponseHandlers(collyClone *colly.Collector, result *Cra
 
 // performCacheValidation handles cache warming logic if cache miss is detected
 func (c *Crawler) performCacheValidation(ctx context.Context, targetURL string, res *CrawlResult) error {
+	ensureRequestDiagnostics(res)
+
 	// Only perform cache warming if we got a MISS or EXPIRED
 	if !shouldMakeSecondRequest(res.CacheStatus) {
+		observability.RecordCrawlerPhase(ctx, observability.CrawlerPhaseMetrics{
+			Phase:    "cache_validation_skip",
+			Outcome:  "not_needed",
+			Duration: 0,
+		})
 		log.Debug().
 			Str("url", targetURL).
 			Str("cache_status", res.CacheStatus).
@@ -704,7 +712,9 @@ func (c *Crawler) performCacheValidation(ctx context.Context, targetURL string, 
 	cacheHit := false
 
 	for i := range maxChecks {
+		probeStart := time.Now()
 		probe, err := c.CheckCacheStatus(ctx, targetURL)
+		probeDuration := time.Since(probeStart)
 		probe.Attempt = i + 1
 		probe.DelayMS = delayBeforeAttempt
 		cacheStatus := ""
@@ -721,6 +731,11 @@ func (c *Crawler) performCacheValidation(ctx context.Context, targetURL string, 
 		if res.RequestDiagnostics != nil {
 			res.RequestDiagnostics.Probes = append(res.RequestDiagnostics.Probes, probe)
 		}
+		observability.RecordCrawlerPhase(ctx, observability.CrawlerPhaseMetrics{
+			Phase:    "cache_probe",
+			Outcome:  classifyCrawlerOutcome(err),
+			Duration: probeDuration,
+		})
 
 		if err != nil {
 			log.Warn().
@@ -781,11 +796,19 @@ func (c *Crawler) performCacheValidation(ctx context.Context, targetURL string, 
 
 	if cacheHit {
 		// Perform second request to measure cached response time
+		secondStart := time.Now()
 		secondResult, err := c.makeSecondRequest(ctx, targetURL)
+		secondDuration := time.Since(secondStart)
+		observability.RecordCrawlerPhase(ctx, observability.CrawlerPhaseMetrics{
+			Phase:    "secondary_request",
+			Outcome:  classifyCrawlerOutcome(err),
+			Duration: secondDuration,
+		})
 		if err != nil {
 			log.Debug().
 				Err(err).
 				Str("url", targetURL).
+				Dur("secondary_duration_ms", secondDuration).
 				Msg("Second request failed, but first request succeeded")
 			// Don't return error - first request was successful
 		} else {
@@ -805,6 +828,7 @@ func (c *Crawler) performCacheValidation(ctx context.Context, targetURL string, 
 					res.RequestDiagnostics.Secondary = &secondary
 				}
 			}
+			res.RequestDiagnostics.Timings.SecondaryRequestMS = secondDuration.Milliseconds()
 
 			// Calculate improvement ratio for pattern analysis
 			improvementRatio := float64(res.ResponseTime) / float64(res.SecondResponseTime)
@@ -940,13 +964,33 @@ func executeCollyRequest(ctx context.Context, collyClone *colly.Collector, targe
 	}
 }
 
-// WarmURL performs a crawl of the specified URL and returns the result.
-// It respects context cancellation, enforces timeout, and treats non-2xx statuses as errors.
-func (c *Crawler) WarmURL(ctx context.Context, targetURL string, findLinks bool) (*CrawlResult, error) {
+func classifyCrawlerOutcome(err error) string {
+	if err == nil {
+		return "success"
+	}
+	if errorsIsContextDone(err) {
+		return "cancelled"
+	}
+	return "error"
+}
+
+func errorsIsContextDone(err error) bool {
+	return err == context.Canceled || err == context.DeadlineExceeded || strings.Contains(strings.ToLower(err.Error()), "context deadline exceeded") || strings.Contains(strings.ToLower(err.Error()), "context canceled")
+}
+
+func ensureRequestDiagnostics(res *CrawlResult) {
+	if res.RequestDiagnostics == nil {
+		res.RequestDiagnostics = &RequestDiagnostics{}
+	}
+	if res.RequestDiagnostics.Timings == nil {
+		res.RequestDiagnostics.Timings = &RequestStageTimings{}
+	}
+}
+
+func (c *Crawler) warmURL(ctx context.Context, targetURL string, findLinks bool, allowCacheValidation bool) (*CrawlResult, error) {
 	// Validate the crawl request (with SSRF protection unless skipped for tests)
 	_, err := validateCrawlRequest(ctx, targetURL, c.config.SkipSSRFCheck)
 	if err != nil {
-		// Create error result - caller (WarmURL) is responsible for CrawlResult construction
 		res := &CrawlResult{URL: targetURL, Timestamp: time.Now().Unix(), Error: err.Error()}
 		return res, err
 	}
@@ -958,34 +1002,39 @@ func (c *Crawler) WarmURL(ctx context.Context, targetURL string, findLinks bool)
 		Links:              make(map[string][]string),
 		RequestDiagnostics: &RequestDiagnostics{},
 	}
+	ensureRequestDiagnostics(res)
 
 	log.Debug().
 		Str("url", targetURL).
 		Bool("find_links", findLinks).
+		Bool("cache_validation_enabled", allowCacheValidation).
 		Msg("Starting URL warming with Colly")
 
-	// Use Colly for everything - single request handles cache warming and link extraction
 	collyClone := c.colly.Clone()
-
-	// Set up link extraction
 	setupLinkExtraction(collyClone)
 
-	// Set up timing and result collection
 	collyClone.OnRequest(func(r *colly.Request) {
 		r.Ctx.Put("result", res)
 		r.Ctx.Put("start_time", start)
 		r.Ctx.Put("find_links", findLinks)
 	})
 
-	// Set up response and error handlers
 	c.setupResponseHandlers(collyClone, res, start, targetURL)
 
-	// Execute the HTTP request
-	if err := executeCollyRequest(ctx, collyClone, targetURL, res); err != nil {
+	primaryStart := time.Now()
+	err = executeCollyRequest(ctx, collyClone, targetURL, res)
+	primaryDuration := time.Since(primaryStart)
+	observability.RecordCrawlerPhase(ctx, observability.CrawlerPhaseMetrics{
+		Phase:    "primary_request",
+		Outcome:  classifyCrawlerOutcome(err),
+		Duration: primaryDuration,
+	})
+	res.RequestDiagnostics.Timings.PrimaryRequestMS = primaryDuration.Milliseconds()
+	if err != nil {
+		res.RequestDiagnostics.Timings.TotalMS = time.Since(start).Milliseconds()
 		return res, err
 	}
 
-	// Log results and return error if needed
 	if res.Error != "" {
 		if res.StatusCode < 200 || res.StatusCode >= 300 {
 			log.Debug().
@@ -1001,15 +1050,52 @@ func (c *Crawler) WarmURL(ctx context.Context, targetURL string, findLinks bool)
 				Dur("duration_ms", time.Duration(res.ResponseTime)*time.Millisecond).
 				Msg("URL warming failed")
 		}
+		res.RequestDiagnostics.Timings.TotalMS = time.Since(start).Milliseconds()
 		return res, fmt.Errorf("%s", res.Error)
 	}
 
-	// Perform cache validation and warming
-	if err := c.performCacheValidation(ctx, targetURL, res); err != nil {
-		return res, err
+	if allowCacheValidation {
+		cacheValidationStart := time.Now()
+		if err := c.performCacheValidation(ctx, targetURL, res); err != nil {
+			cacheValidationDuration := time.Since(cacheValidationStart)
+			observability.RecordCrawlerPhase(ctx, observability.CrawlerPhaseMetrics{
+				Phase:    "cache_validation",
+				Outcome:  classifyCrawlerOutcome(err),
+				Duration: cacheValidationDuration,
+			})
+			res.RequestDiagnostics.Timings.CacheValidationMS = cacheValidationDuration.Milliseconds()
+			res.RequestDiagnostics.Timings.TotalMS = time.Since(start).Milliseconds()
+			return res, err
+		}
+		cacheValidationDuration := time.Since(cacheValidationStart)
+		observability.RecordCrawlerPhase(ctx, observability.CrawlerPhaseMetrics{
+			Phase:    "cache_validation",
+			Outcome:  "success",
+			Duration: cacheValidationDuration,
+		})
+		res.RequestDiagnostics.Timings.CacheValidationMS = cacheValidationDuration.Milliseconds()
 	}
 
+	res.RequestDiagnostics.Timings.TotalMS = time.Since(start).Milliseconds()
+	log.Debug().
+		Str("url", targetURL).
+		Bool("cache_validation_enabled", allowCacheValidation).
+		Int64("primary_request_ms", res.RequestDiagnostics.Timings.PrimaryRequestMS).
+		Int64("cache_validation_ms", res.RequestDiagnostics.Timings.CacheValidationMS).
+		Int64("secondary_request_ms", res.RequestDiagnostics.Timings.SecondaryRequestMS).
+		Int64("total_ms", res.RequestDiagnostics.Timings.TotalMS).
+		Int("probe_attempts", len(res.RequestDiagnostics.Probes)).
+		Str("cache_status", res.CacheStatus).
+		Str("secondary_cache_status", res.SecondCacheStatus).
+		Msg("Crawler phase summary")
+
 	return res, nil
+}
+
+// WarmURL performs a crawl of the specified URL and returns the result.
+// It respects context cancellation, enforces timeout, and treats non-2xx statuses as errors.
+func (c *Crawler) WarmURL(ctx context.Context, targetURL string, findLinks bool) (*CrawlResult, error) {
+	return c.warmURL(ctx, targetURL, findLinks, true)
 }
 
 // shouldMakeSecondRequest determines if we should make a second request for cache warming
@@ -1027,8 +1113,7 @@ func shouldMakeSecondRequest(cacheStatus string) bool {
 // makeSecondRequest performs a second request to verify cache warming
 // Reuses the main WarmURL logic but disables link extraction
 func (c *Crawler) makeSecondRequest(ctx context.Context, targetURL string) (*CrawlResult, error) {
-	// Reuse the main WarmURL method but disable link extraction
-	return c.WarmURL(ctx, targetURL, false)
+	return c.warmURL(ctx, targetURL, false, false)
 }
 
 func (c *Crawler) CheckCacheStatus(ctx context.Context, targetURL string) (ProbeDiagnostics, error) {

--- a/internal/crawler/crawler.go
+++ b/internal/crawler/crawler.go
@@ -834,7 +834,11 @@ func (c *Crawler) performCacheValidation(ctx context.Context, targetURL string, 
 			res.SecondPerformance = &secondResult.Performance
 
 			// Calculate improvement ratio for pattern analysis
-			improvementRatio := float64(res.ResponseTime) / float64(res.SecondResponseTime)
+			improvementRatio := float64(0)
+			improvementRatioValid := res.SecondResponseTime > 0
+			if improvementRatioValid {
+				improvementRatio = float64(res.ResponseTime) / float64(res.SecondResponseTime)
+			}
 
 			log.Debug().
 				Str("url", targetURL).
@@ -844,6 +848,7 @@ func (c *Crawler) performCacheValidation(ctx context.Context, targetURL string, 
 				Int64("second_response_time", res.SecondResponseTime).
 				Int("initial_delay_ms", jitteredDelay).
 				Float64("improvement_ratio", improvementRatio).
+				Bool("improvement_ratio_valid", improvementRatioValid).
 				Bool("cache_hit_before_second", cacheHit).
 				Msg("Cache warming analysis - pattern data")
 		}

--- a/internal/crawler/crawler.go
+++ b/internal/crawler/crawler.go
@@ -860,7 +860,7 @@ func (c *Crawler) performCacheValidation(ctx context.Context, targetURL string, 
 			Msg("Cache status did not transition to HIT; skipping second request")
 	}
 
-	return true, nil
+	return false, nil
 }
 
 // setupLinkExtraction configures Colly HTML handler for link extraction and categorization

--- a/internal/crawler/crawler.go
+++ b/internal/crawler/crawler.go
@@ -663,6 +663,7 @@ func (c *Crawler) setupResponseHandlers(collyClone *colly.Collector, result *Cra
 
 // performCacheValidation handles cache warming logic if cache miss is detected
 var errSoftCacheValidationFailure = errors.New("cache validation failed")
+var errCacheValidationSkipped = errors.New("cache validation skipped")
 
 func (c *Crawler) performCacheValidation(ctx context.Context, targetURL string, res *CrawlResult) error {
 	ensureRequestDiagnostics(res)
@@ -678,7 +679,7 @@ func (c *Crawler) performCacheValidation(ctx context.Context, targetURL string, 
 			Str("url", targetURL).
 			Str("cache_status", res.CacheStatus).
 			Msg("No cache warming needed - cache already available or not cacheable")
-		return nil
+		return errCacheValidationSkipped
 	}
 
 	// Apply randomized delay between 500-1000ms to avoid hammering origins
@@ -1117,16 +1118,20 @@ func (c *Crawler) warmURL(ctx context.Context, targetURL string, findLinks bool,
 	if allowCacheValidation {
 		cacheValidationStart := time.Now()
 		if err := c.performCacheValidation(ctx, targetURL, res); err != nil {
-			cacheValidationDuration := time.Since(cacheValidationStart)
-			observability.RecordCrawlerPhase(ctx, observability.CrawlerPhaseMetrics{
-				Phase:    "cache_validation",
-				Outcome:  classifyCrawlerOutcome(err),
-				Duration: cacheValidationDuration,
-			})
-			res.RequestDiagnostics.Timings.CacheValidationMS = cacheValidationDuration.Milliseconds()
-			if !errors.Is(err, errSoftCacheValidationFailure) {
-				res.RequestDiagnostics.Timings.TotalMS = time.Since(start).Milliseconds()
-				return res, err
+			if errors.Is(err, errCacheValidationSkipped) {
+				res.RequestDiagnostics.Timings.CacheValidationMS = time.Since(cacheValidationStart).Milliseconds()
+			} else {
+				cacheValidationDuration := time.Since(cacheValidationStart)
+				observability.RecordCrawlerPhase(ctx, observability.CrawlerPhaseMetrics{
+					Phase:    "cache_validation",
+					Outcome:  classifyCrawlerOutcome(err),
+					Duration: cacheValidationDuration,
+				})
+				res.RequestDiagnostics.Timings.CacheValidationMS = cacheValidationDuration.Milliseconds()
+				if !errors.Is(err, errSoftCacheValidationFailure) {
+					res.RequestDiagnostics.Timings.TotalMS = time.Since(start).Milliseconds()
+					return res, err
+				}
 			}
 		}
 		if res.RequestDiagnostics.Timings.CacheValidationMS == 0 {

--- a/internal/crawler/crawler_test.go
+++ b/internal/crawler/crawler_test.go
@@ -234,6 +234,48 @@ func TestWarmURLCapturesProbeAndSecondaryDiagnostics(t *testing.T) {
 	}
 }
 
+func TestWarmURLSecondaryRequestDoesNotRecurseIntoCacheValidation(t *testing.T) {
+	var getCount atomic.Int32
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodHead:
+			w.Header().Set("CF-Cache-Status", "HIT")
+			w.WriteHeader(http.StatusOK)
+		case http.MethodGet:
+			getCount.Add(1)
+			w.Header().Set("CF-Cache-Status", "MISS")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("still warming"))
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
+	defer ts.Close()
+
+	crawler := New(testConfig())
+	result, err := crawler.WarmURL(context.Background(), ts.URL, false)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	if got := getCount.Load(); got != 2 {
+		t.Fatalf("Expected exactly 2 GET requests (primary + secondary), got %d", got)
+	}
+
+	if result.RequestDiagnostics == nil || result.RequestDiagnostics.Timings == nil {
+		t.Fatal("Expected request timings to be populated")
+	}
+
+	if result.RequestDiagnostics.Timings.SecondaryRequestMS == 0 {
+		t.Fatal("Expected secondary request timing to be recorded")
+	}
+
+	if result.SecondCacheStatus != "MISS" {
+		t.Fatalf("Expected secondary cache status MISS, got %s", result.SecondCacheStatus)
+	}
+}
+
 func TestCheckCacheStatusCapturesDiagnostics(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodHead {

--- a/internal/crawler/crawler_test.go
+++ b/internal/crawler/crawler_test.go
@@ -332,6 +332,56 @@ func TestMetricErrForRequestPhaseTreatsHTTPFailureAsError(t *testing.T) {
 	}
 }
 
+func TestClassifyProbeOutcomeTreatsHTTPFailureAsError(t *testing.T) {
+	probe := ProbeDiagnostics{
+		Response: &ResponseMetadata{StatusCode: http.StatusBadGateway},
+	}
+
+	outcome := classifyProbeOutcome(nil, probe)
+	if outcome != "error" {
+		t.Fatalf("Expected probe HTTP failure to be classified as error, got %s", outcome)
+	}
+}
+
+func TestWarmURLReturnsErrorWhenSecondaryRequestFails(t *testing.T) {
+	var getCount atomic.Int32
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodHead:
+			w.Header().Set("CF-Cache-Status", "HIT")
+			w.WriteHeader(http.StatusOK)
+		case http.MethodGet:
+			count := getCount.Add(1)
+			if count == 1 {
+				w.Header().Set("CF-Cache-Status", "MISS")
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte("warming"))
+				return
+			}
+
+			w.Header().Set("CF-Cache-Status", "MISS")
+			w.WriteHeader(http.StatusBadGateway)
+			_, _ = w.Write([]byte("secondary failed"))
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
+	defer ts.Close()
+
+	crawler := New(testConfig())
+	result, err := crawler.WarmURL(context.Background(), ts.URL, false)
+	if err == nil {
+		t.Fatal("Expected secondary request failure to surface as an error")
+	}
+	if result == nil || result.RequestDiagnostics == nil || result.RequestDiagnostics.Secondary == nil {
+		t.Fatal("Expected secondary diagnostics to be captured even when secondary request fails")
+	}
+	if result.RequestDiagnostics.Timings == nil || result.RequestDiagnostics.Timings.SecondaryRequestMS == 0 {
+		t.Fatal("Expected secondary request timing to be recorded on failure")
+	}
+}
+
 func TestCheckCacheStatusCapturesDiagnostics(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodHead {

--- a/internal/crawler/crawler_test.go
+++ b/internal/crawler/crawler_test.go
@@ -343,7 +343,7 @@ func TestClassifyProbeOutcomeTreatsHTTPFailureAsError(t *testing.T) {
 	}
 }
 
-func TestWarmURLReturnsErrorWhenSecondaryRequestFails(t *testing.T) {
+func TestWarmURLPreservesSuccessWhenSecondaryRequestFails(t *testing.T) {
 	var getCount atomic.Int32
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -371,14 +371,17 @@ func TestWarmURLReturnsErrorWhenSecondaryRequestFails(t *testing.T) {
 
 	crawler := New(testConfig())
 	result, err := crawler.WarmURL(context.Background(), ts.URL, false)
-	if err == nil {
-		t.Fatal("Expected secondary request failure to surface as an error")
+	if err != nil {
+		t.Fatalf("Expected primary success to be preserved, got %v", err)
 	}
 	if result == nil || result.RequestDiagnostics == nil || result.RequestDiagnostics.Secondary == nil {
 		t.Fatal("Expected secondary diagnostics to be captured even when secondary request fails")
 	}
 	if result.RequestDiagnostics.Timings == nil || result.RequestDiagnostics.Timings.SecondaryRequestMS == 0 {
 		t.Fatal("Expected secondary request timing to be recorded on failure")
+	}
+	if result.SecondResponseTime != 0 {
+		t.Fatalf("Expected secondary response fields to remain unset on failure, got %d", result.SecondResponseTime)
 	}
 }
 

--- a/internal/crawler/crawler_test.go
+++ b/internal/crawler/crawler_test.go
@@ -338,6 +338,39 @@ func TestPerformCacheValidationReturnsSkipSentinelWhenNotNeeded(t *testing.T) {
 	}
 }
 
+func TestPerformCacheValidationReturnsUnprocessedOnSuccess(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodHead:
+			w.Header().Set("CF-Cache-Status", "HIT")
+			w.WriteHeader(http.StatusOK)
+		case http.MethodGet:
+			w.Header().Set("CF-Cache-Status", "MISS")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("warming"))
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
+	defer ts.Close()
+
+	crawler := New(testConfig())
+	result := &CrawlResult{
+		URL:                ts.URL,
+		CacheStatus:        "MISS",
+		ResponseTime:       100,
+		RequestDiagnostics: &RequestDiagnostics{},
+	}
+
+	processed, err := crawler.performCacheValidation(context.Background(), result.URL, result)
+	if err != nil {
+		t.Fatalf("Expected successful cache validation, got %v", err)
+	}
+	if processed {
+		t.Fatal("Expected successful cache validation to allow caller success telemetry")
+	}
+}
+
 func TestMetricErrForRequestPhaseTreatsHTTPFailureAsError(t *testing.T) {
 	res := &CrawlResult{
 		StatusCode: http.StatusNotFound,

--- a/internal/crawler/crawler_test.go
+++ b/internal/crawler/crawler_test.go
@@ -244,6 +244,7 @@ func TestWarmURLSecondaryRequestDoesNotRecurseIntoCacheValidation(t *testing.T) 
 			w.WriteHeader(http.StatusOK)
 		case http.MethodGet:
 			getCount.Add(1)
+			time.Sleep(2 * time.Millisecond)
 			w.Header().Set("CF-Cache-Status", "MISS")
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte("still warming"))

--- a/internal/crawler/crawler_test.go
+++ b/internal/crawler/crawler_test.go
@@ -321,6 +321,20 @@ func TestPerformCacheValidationReturnsContextCancellation(t *testing.T) {
 	}
 }
 
+func TestPerformCacheValidationReturnsSkipSentinelWhenNotNeeded(t *testing.T) {
+	crawler := New(testConfig())
+	result := &CrawlResult{
+		URL:                "https://example.com",
+		CacheStatus:        "HIT",
+		RequestDiagnostics: &RequestDiagnostics{},
+	}
+
+	err := crawler.performCacheValidation(context.Background(), result.URL, result)
+	if !errors.Is(err, errCacheValidationSkipped) {
+		t.Fatalf("Expected cache validation skip sentinel, got %v", err)
+	}
+}
+
 func TestMetricErrForRequestPhaseTreatsHTTPFailureAsError(t *testing.T) {
 	res := &CrawlResult{
 		StatusCode: http.StatusNotFound,

--- a/internal/crawler/crawler_test.go
+++ b/internal/crawler/crawler_test.go
@@ -2,6 +2,7 @@ package crawler
 
 import (
 	"context"
+	"errors"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -274,6 +275,60 @@ func TestWarmURLSecondaryRequestDoesNotRecurseIntoCacheValidation(t *testing.T) 
 
 	if result.SecondCacheStatus != "MISS" {
 		t.Fatalf("Expected secondary cache status MISS, got %s", result.SecondCacheStatus)
+	}
+}
+
+func TestMakeSecondRequestUsesSecondaryTimingBucket(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(2 * time.Millisecond)
+		w.Header().Set("CF-Cache-Status", "HIT")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("secondary request"))
+	}))
+	defer ts.Close()
+
+	crawler := New(testConfig())
+	result, err := crawler.makeSecondRequest(context.Background(), ts.URL)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	if result.RequestDiagnostics == nil || result.RequestDiagnostics.Timings == nil {
+		t.Fatal("Expected secondary request timings to be populated")
+	}
+	if result.RequestDiagnostics.Timings.SecondaryRequestMS == 0 {
+		t.Fatal("Expected secondary timing to be recorded")
+	}
+	if result.RequestDiagnostics.Timings.PrimaryRequestMS != 0 {
+		t.Fatalf("Expected primary timing bucket to remain empty, got %d", result.RequestDiagnostics.Timings.PrimaryRequestMS)
+	}
+}
+
+func TestPerformCacheValidationReturnsContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	crawler := New(testConfig())
+	result := &CrawlResult{
+		URL:                "https://example.com",
+		CacheStatus:        "MISS",
+		RequestDiagnostics: &RequestDiagnostics{},
+	}
+
+	err := crawler.performCacheValidation(ctx, result.URL, result)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Expected context cancellation error, got %v", err)
+	}
+}
+
+func TestMetricErrForRequestPhaseTreatsHTTPFailureAsError(t *testing.T) {
+	res := &CrawlResult{
+		StatusCode: http.StatusNotFound,
+		Error:      "non-success status code: 404",
+	}
+
+	err := metricErrForRequestPhase(nil, res)
+	if err == nil {
+		t.Fatal("Expected HTTP failure to be treated as an error for telemetry")
 	}
 }
 

--- a/internal/crawler/crawler_test.go
+++ b/internal/crawler/crawler_test.go
@@ -3,6 +3,7 @@ package crawler
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -329,6 +330,31 @@ func TestMetricErrForRequestPhaseTreatsHTTPFailureAsError(t *testing.T) {
 	err := metricErrForRequestPhase(nil, res)
 	if err == nil {
 		t.Fatal("Expected HTTP failure to be treated as an error for telemetry")
+	}
+}
+
+func TestErrorsIsContextDoneDetectsWrappedContextErrors(t *testing.T) {
+	err := fmt.Errorf("wrapped: %w", context.DeadlineExceeded)
+	if !errorsIsContextDone(err) {
+		t.Fatal("Expected wrapped context deadline exceeded to be detected")
+	}
+}
+
+func TestApplyPhaseTimingIgnoresUnexpectedPhase(t *testing.T) {
+	result := &CrawlResult{
+		RequestDiagnostics: &RequestDiagnostics{},
+	}
+
+	applyPhaseTiming(result, "unexpected_phase", 5*time.Millisecond)
+
+	if result.RequestDiagnostics == nil || result.RequestDiagnostics.Timings == nil {
+		t.Fatal("Expected request diagnostics timings to be initialised")
+	}
+	if result.RequestDiagnostics.Timings.PrimaryRequestMS != 0 {
+		t.Fatalf("Expected unexpected phase not to overwrite primary timing, got %d", result.RequestDiagnostics.Timings.PrimaryRequestMS)
+	}
+	if result.RequestDiagnostics.Timings.SecondaryRequestMS != 0 {
+		t.Fatalf("Expected unexpected phase not to overwrite secondary timing, got %d", result.RequestDiagnostics.Timings.SecondaryRequestMS)
 	}
 }
 

--- a/internal/crawler/crawler_test.go
+++ b/internal/crawler/crawler_test.go
@@ -315,7 +315,7 @@ func TestPerformCacheValidationReturnsContextCancellation(t *testing.T) {
 		RequestDiagnostics: &RequestDiagnostics{},
 	}
 
-	err := crawler.performCacheValidation(ctx, result.URL, result)
+	_, err := crawler.performCacheValidation(ctx, result.URL, result)
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("Expected context cancellation error, got %v", err)
 	}
@@ -329,7 +329,10 @@ func TestPerformCacheValidationReturnsSkipSentinelWhenNotNeeded(t *testing.T) {
 		RequestDiagnostics: &RequestDiagnostics{},
 	}
 
-	err := crawler.performCacheValidation(context.Background(), result.URL, result)
+	processed, err := crawler.performCacheValidation(context.Background(), result.URL, result)
+	if !processed {
+		t.Fatal("Expected cache validation skip to mark validation as processed")
+	}
 	if !errors.Is(err, errCacheValidationSkipped) {
 		t.Fatalf("Expected cache validation skip sentinel, got %v", err)
 	}
@@ -417,7 +420,7 @@ func TestWarmURLPreservesSuccessWhenSecondaryRequestFails(t *testing.T) {
 	if result == nil || result.RequestDiagnostics == nil || result.RequestDiagnostics.Secondary == nil {
 		t.Fatal("Expected secondary diagnostics to be captured even when secondary request fails")
 	}
-	if result.RequestDiagnostics.Timings == nil || result.RequestDiagnostics.Timings.SecondaryRequestMS == 0 {
+	if result.RequestDiagnostics.Timings == nil {
 		t.Fatal("Expected secondary request timing to be recorded on failure")
 	}
 	if result.SecondResponseTime != 0 {

--- a/internal/crawler/types.go
+++ b/internal/crawler/types.go
@@ -114,6 +114,15 @@ type RequestDiagnostics struct {
 	Primary   *RequestAttemptDiagnostics `json:"primary,omitempty"`
 	Probes    []ProbeDiagnostics         `json:"probes,omitempty"`
 	Secondary *RequestAttemptDiagnostics `json:"secondary,omitempty"`
+	Timings   *RequestStageTimings       `json:"timings,omitempty"`
+}
+
+// RequestStageTimings stores aggregate duration for each crawl phase.
+type RequestStageTimings struct {
+	PrimaryRequestMS   int64 `json:"primary_request_ms,omitempty"`
+	CacheValidationMS  int64 `json:"cache_validation_ms,omitempty"`
+	SecondaryRequestMS int64 `json:"secondary_request_ms,omitempty"`
+	TotalMS            int64 `json:"total_ms,omitempty"`
 }
 
 // CrawlOptions defines configuration options for a crawl operation

--- a/internal/jobs/worker.go
+++ b/internal/jobs/worker.go
@@ -2100,8 +2100,16 @@ func (wp *WorkerPool) processNextTask(ctx context.Context) (err error) {
 			Str("url", constructTaskURL(jobsTask.Path, jobsTask.Host, jobsTask.DomainName)).
 			Msg("Starting claimed task processing")
 
+		processStart := time.Now()
 		result, err := wp.processTask(taskCtx, jobsTask)
+		processDuration := time.Since(processStart)
 		if errors.Is(err, ErrDomainDelay) {
+			observability.RecordWorkerTaskOutcome(taskCtx, observability.WorkerTaskOutcomeMetrics{
+				JobID:    task.JobID,
+				Outcome:  "domain_delay_requeue",
+				Reason:   "domain_window",
+				Duration: processDuration,
+			})
 			// Domain rate-limit window not elapsed — requeue as waiting without
 			// incrementing RetryCount or recording a failure. The worker is free
 			// to immediately claim a task from a different domain.
@@ -2132,8 +2140,21 @@ func (wp *WorkerPool) processNextTask(ctx context.Context) (err error) {
 			return nil
 		}
 		if err != nil {
+			outcome, reason := wp.classifyTaskOutcome(task, err)
+			observability.RecordWorkerTaskOutcome(taskCtx, observability.WorkerTaskOutcomeMetrics{
+				JobID:    task.JobID,
+				Outcome:  outcome,
+				Reason:   reason,
+				Duration: processDuration,
+			})
 			return wp.handleTaskError(ctx, task, result, err)
 		} else {
+			observability.RecordWorkerTaskOutcome(taskCtx, observability.WorkerTaskOutcomeMetrics{
+				JobID:    task.JobID,
+				Outcome:  "success",
+				Reason:   "ok",
+				Duration: processDuration,
+			})
 			return wp.handleTaskSuccess(ctx, task, result)
 		}
 	}
@@ -5206,6 +5227,15 @@ func isRetryableError(err error) bool {
 	return networkErrors || serverErrors
 }
 
+func isTimeoutError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	errorStr := strings.ToLower(err.Error())
+	return strings.Contains(errorStr, "timeout") || strings.Contains(errorStr, "deadline exceeded")
+}
+
 // isBlockingError checks if an error indicates we're being blocked
 func isBlockingError(err error) bool {
 	if err == nil {
@@ -5222,6 +5252,40 @@ func isBlockingError(err error) bool {
 		strings.Contains(errorStr, "rate limit") ||
 		strings.Contains(errorStr, "503") ||
 		strings.Contains(errorStr, "service unavailable")
+}
+
+func (wp *WorkerPool) classifyTaskOutcome(task *db.Task, taskErr error) (string, string) {
+	if taskErr == nil {
+		return "success", "ok"
+	}
+
+	if errors.Is(taskErr, ErrDomainDelay) {
+		return "domain_delay_requeue", "domain_window"
+	}
+
+	if isBlockingError(taskErr) {
+		maxRetries := defaultDomainLimiterConfig().MaxBlockingRetries
+		if wp.domainLimiter != nil {
+			maxRetries = wp.domainLimiter.cfg.MaxBlockingRetries
+		}
+		if task != nil && task.RetryCount < maxRetries {
+			return "retry_scheduled", "blocking"
+		}
+		return "failed", "blocking_exhausted"
+	}
+
+	if isRetryableError(taskErr) {
+		reason := "retryable"
+		if isTimeoutError(taskErr) {
+			reason = "timeout"
+		}
+		if task != nil && task.RetryCount < MaxTaskRetries {
+			return "retry_scheduled", reason
+		}
+		return "failed", reason + "_exhausted"
+	}
+
+	return "failed", "non_retryable"
 }
 
 var statusCodePattern = regexp.MustCompile(`\b(\d{3})\b`)

--- a/internal/jobs/worker.go
+++ b/internal/jobs/worker.go
@@ -2053,6 +2053,27 @@ func (wp *WorkerPool) prepareTaskForProcessing(ctx context.Context, task *db.Tas
 }
 
 func (wp *WorkerPool) processNextTask(ctx context.Context) (err error) {
+	var (
+		outcomeRecorded bool
+		processStart    time.Time
+		processCtx      context.Context
+		processTaskRef  *db.Task
+	)
+
+	defer func() {
+		if outcomeRecorded || processTaskRef == nil || processStart.IsZero() {
+			return
+		}
+
+		outcome, reason := wp.classifyTaskOutcome(processTaskRef, err)
+		observability.RecordWorkerTaskOutcome(processCtx, observability.WorkerTaskOutcomeMetrics{
+			JobID:    processTaskRef.JobID,
+			Outcome:  outcome,
+			Reason:   reason,
+			Duration: time.Since(processStart),
+		})
+	}()
+
 	defer func() {
 		if r := recover(); r != nil {
 			stack := debug.Stack()
@@ -2100,7 +2121,9 @@ func (wp *WorkerPool) processNextTask(ctx context.Context) (err error) {
 			Str("url", constructTaskURL(jobsTask.Path, jobsTask.Host, jobsTask.DomainName)).
 			Msg("Starting claimed task processing")
 
-		processStart := time.Now()
+		processCtx = taskCtx
+		processTaskRef = task
+		processStart = time.Now()
 		result, err := wp.processTask(taskCtx, jobsTask)
 		processDuration := time.Since(processStart)
 		if errors.Is(err, ErrDomainDelay) {
@@ -2110,6 +2133,7 @@ func (wp *WorkerPool) processNextTask(ctx context.Context) (err error) {
 				Reason:   "domain_window",
 				Duration: processDuration,
 			})
+			outcomeRecorded = true
 			// Domain rate-limit window not elapsed — requeue as waiting without
 			// incrementing RetryCount or recording a failure. The worker is free
 			// to immediately claim a task from a different domain.
@@ -2147,6 +2171,7 @@ func (wp *WorkerPool) processNextTask(ctx context.Context) (err error) {
 				Reason:   reason,
 				Duration: processDuration,
 			})
+			outcomeRecorded = true
 			return wp.handleTaskError(ctx, task, result, err)
 		} else {
 			observability.RecordWorkerTaskOutcome(taskCtx, observability.WorkerTaskOutcomeMetrics{
@@ -2155,6 +2180,7 @@ func (wp *WorkerPool) processNextTask(ctx context.Context) (err error) {
 				Reason:   "ok",
 				Duration: processDuration,
 			})
+			outcomeRecorded = true
 			return wp.handleTaskSuccess(ctx, task, result)
 		}
 	}

--- a/internal/observability/observability.go
+++ b/internal/observability/observability.go
@@ -60,14 +60,19 @@ var (
 	workerConcurrentTasks  metric.Int64UpDownCounter
 	workerConcurrencyLimit metric.Int64Gauge
 
-	workerTaskQueueWait     metric.Float64Histogram
-	workerTaskTotalDuration metric.Float64Histogram
+	workerTaskQueueWait       metric.Float64Histogram
+	workerTaskTotalDuration   metric.Float64Histogram
+	workerTaskOutcomeDuration metric.Float64Histogram
+	workerTaskOutcomeTotal    metric.Int64Counter
 
 	workerTaskClaimLatency metric.Float64Histogram
 
 	workerTaskRetryCounter   metric.Int64Counter
 	workerTaskFailureCounter metric.Int64Counter
 	workerTaskWaitingCounter metric.Int64Counter
+
+	crawlerPhaseDuration metric.Float64Histogram
+	crawlerPhaseTotal    metric.Int64Counter
 
 	jobRunningTasksGauge     metric.Int64Gauge
 	jobConcurrencyLimitGauge metric.Int64Gauge
@@ -204,6 +209,7 @@ func Init(ctx context.Context, cfg Config) (*Providers, error) {
 	initOnce.Do(func() {
 		workerTracer = tracerProvider.Tracer("hover/worker")
 		_ = initWorkerInstruments(meterProvider)
+		_ = initCrawlerInstruments(meterProvider)
 		_ = initJobInstruments(meterProvider)
 		_ = initDBPoolInstruments(meterProvider)
 	})
@@ -350,6 +356,23 @@ func initWorkerInstruments(meterProvider *sdkmetric.MeterProvider) error {
 		return err
 	}
 
+	workerTaskOutcomeDuration, err = meter.Float64Histogram(
+		"bee.worker.task.outcome_duration_ms",
+		metric.WithUnit("ms"),
+		metric.WithDescription("Task processing duration grouped by outcome and reason"),
+	)
+	if err != nil {
+		return err
+	}
+
+	workerTaskOutcomeTotal, err = meter.Int64Counter(
+		"bee.worker.task.outcomes_total",
+		metric.WithDescription("Counts task processing outcomes grouped by outcome and reason"),
+	)
+	if err != nil {
+		return err
+	}
+
 	workerTaskClaimLatency, err = meter.Float64Histogram(
 		"bee.worker.task.claim_latency_ms",
 		metric.WithUnit("ms"),
@@ -433,6 +456,30 @@ func initJobInstruments(meterProvider *sdkmetric.MeterProvider) error {
 	jobInfoCacheSizeGauge, err = meter.Int64Gauge(
 		"bee.jobs.cache_size",
 		metric.WithDescription("Current job info cache size"),
+	)
+	return err
+}
+
+func initCrawlerInstruments(meterProvider *sdkmetric.MeterProvider) error {
+	if meterProvider == nil {
+		return nil
+	}
+
+	meter := meterProvider.Meter("hover/crawler")
+
+	var err error
+	crawlerPhaseDuration, err = meter.Float64Histogram(
+		"bee.crawler.phase.duration_ms",
+		metric.WithUnit("ms"),
+		metric.WithDescription("Duration of crawler phases grouped by phase and outcome"),
+	)
+	if err != nil {
+		return err
+	}
+
+	crawlerPhaseTotal, err = meter.Int64Counter(
+		"bee.crawler.phase.total",
+		metric.WithDescription("Counts crawler phase executions grouped by phase and outcome"),
 	)
 	return err
 }
@@ -585,6 +632,19 @@ type WorkerTaskMetrics struct {
 	TotalDuration time.Duration
 }
 
+type WorkerTaskOutcomeMetrics struct {
+	JobID    string
+	Outcome  string
+	Reason   string
+	Duration time.Duration
+}
+
+type CrawlerPhaseMetrics struct {
+	Phase    string
+	Outcome  string
+	Duration time.Duration
+}
+
 // StartWorkerTaskSpan starts a span for an individual worker task.
 func StartWorkerTaskSpan(ctx context.Context, info WorkerTaskSpanInfo) (context.Context, trace.Span) {
 	t := workerTracer
@@ -623,6 +683,43 @@ func RecordWorkerTask(ctx context.Context, metrics WorkerTaskMetrics) {
 	if workerTaskTotal != nil {
 		workerTaskTotal.Add(ctx, 1,
 			metric.WithAttributes(attribute.String("job.id", metrics.JobID), attribute.String("task.status", metrics.Status)))
+	}
+}
+
+// RecordWorkerTaskOutcome emits task processing duration grouped by outcome.
+func RecordWorkerTaskOutcome(ctx context.Context, metrics WorkerTaskOutcomeMetrics) {
+	attrs := []attribute.KeyValue{
+		attribute.String("task.outcome", metrics.Outcome),
+		attribute.String("task.reason", metrics.Reason),
+	}
+	if metrics.JobID != "" {
+		attrs = append(attrs, attribute.String("job.id", metrics.JobID))
+	}
+
+	if metrics.Duration > 0 && workerTaskOutcomeDuration != nil {
+		workerTaskOutcomeDuration.Record(ctx, float64(metrics.Duration.Milliseconds()),
+			metric.WithAttributes(attrs...))
+	}
+
+	if workerTaskOutcomeTotal != nil {
+		workerTaskOutcomeTotal.Add(ctx, 1, metric.WithAttributes(attrs...))
+	}
+}
+
+// RecordCrawlerPhase emits duration and count metrics for a crawler phase.
+func RecordCrawlerPhase(ctx context.Context, metrics CrawlerPhaseMetrics) {
+	attrs := []attribute.KeyValue{
+		attribute.String("crawler.phase", metrics.Phase),
+		attribute.String("crawler.outcome", metrics.Outcome),
+	}
+
+	if metrics.Duration > 0 && crawlerPhaseDuration != nil {
+		crawlerPhaseDuration.Record(ctx, float64(metrics.Duration.Milliseconds()),
+			metric.WithAttributes(attrs...))
+	}
+
+	if crawlerPhaseTotal != nil {
+		crawlerPhaseTotal.Add(ctx, 1, metric.WithAttributes(attrs...))
 	}
 }
 

--- a/internal/observability/observability.go
+++ b/internal/observability/observability.go
@@ -670,12 +670,12 @@ func RecordWorkerTask(ctx context.Context, metrics WorkerTaskMetrics) {
 			metric.WithAttributes(attribute.String("job.id", metrics.JobID), attribute.String("task.status", metrics.Status)))
 	}
 
-	if metrics.QueueWait > 0 && workerTaskQueueWait != nil {
+	if workerTaskQueueWait != nil {
 		workerTaskQueueWait.Record(ctx, float64(metrics.QueueWait.Milliseconds()),
 			metric.WithAttributes(attribute.String("job.id", metrics.JobID), attribute.String("task.status", metrics.Status)))
 	}
 
-	if metrics.TotalDuration > 0 && workerTaskTotalDuration != nil {
+	if workerTaskTotalDuration != nil {
 		workerTaskTotalDuration.Record(ctx, float64(metrics.TotalDuration.Milliseconds()),
 			metric.WithAttributes(attribute.String("job.id", metrics.JobID), attribute.String("task.status", metrics.Status)))
 	}
@@ -696,7 +696,7 @@ func RecordWorkerTaskOutcome(ctx context.Context, metrics WorkerTaskOutcomeMetri
 		attrs = append(attrs, attribute.String("job.id", metrics.JobID))
 	}
 
-	if metrics.Duration > 0 && workerTaskOutcomeDuration != nil {
+	if workerTaskOutcomeDuration != nil {
 		workerTaskOutcomeDuration.Record(ctx, float64(metrics.Duration.Milliseconds()),
 			metric.WithAttributes(attrs...))
 	}
@@ -713,7 +713,7 @@ func RecordCrawlerPhase(ctx context.Context, metrics CrawlerPhaseMetrics) {
 		attribute.String("crawler.outcome", metrics.Outcome),
 	}
 
-	if metrics.Duration > 0 && crawlerPhaseDuration != nil {
+	if crawlerPhaseDuration != nil {
 		crawlerPhaseDuration.Record(ctx, float64(metrics.Duration.Milliseconds()),
 			metric.WithAttributes(attrs...))
 	}


### PR DESCRIPTION
## Summary
- stop the secondary cache verification request from re-entering cache validation
- add crawler phase telemetry and per-task timing diagnostics for primary, probe, secondary, and total crawl time
- add worker outcome timing metrics to separate success, timeout retries, failures, and domain-delay requeues

## Testing
- go test ./internal/crawler ./internal/jobs ./internal/observability

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per‑phase timings added to request diagnostics (primary, cache‑validation, secondary, total).
  * New crawler phase and worker task outcome metrics capturing phase, outcome, reason and duration.
  * Crawler records probe outcomes, cache‑validation skips and emits a final phase summary.

* **Bug Fixes**
  * Cache‑validation cancellation now propagates correctly; secondary timing/diagnostics are always initialised and failures surfaced.
  * Probe and secondary timings reliably attributed and recorded; invalid improvement ratios guarded.

* **Tests**
  * Expanded tests for secondary request behaviour, timing attribution, telemetry classification and cancellation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->