### PR TITLE
Move Alloy metrics agent to hover sidecar

### DIFF
--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -57,6 +57,9 @@ jobs:
             op://Good Native/hover-runtime/GOOGLE_CLIENT_SECRET
           OTEL_EXPORTER_OTLP_HEADERS:
             op://Good Native/hover-runtime/OTEL_EXPORTER_OTLP_HEADERS
+          GRAFANA_CLOUD_USER: op://Good Native/hover-runtime/GRAFANA_CLOUD_USER
+          GRAFANA_CLOUD_API_KEY:
+            op://Good Native/hover-runtime/GRAFANA_CLOUD_API_KEY
           # Archive (R2 cold storage)
           ARCHIVE_ACCESS_KEY_ID:
             op://Good Native/hover-archive/ARCHIVE_ACCESS_KEY_ID
@@ -82,6 +85,8 @@ jobs:
             ARCHIVE_ACCESS_KEY_ID="$ARCHIVE_ACCESS_KEY_ID" \
             ARCHIVE_SECRET_ACCESS_KEY="$ARCHIVE_SECRET_ACCESS_KEY" \
             ARCHIVE_ENDPOINT="$ARCHIVE_ENDPOINT" \
+            GRAFANA_CLOUD_USER="$GRAFANA_CLOUD_USER" \
+            GRAFANA_CLOUD_API_KEY="$GRAFANA_CLOUD_API_KEY" \
             --stage
 
       - run: flyctl deploy --remote-only

--- a/.github/workflows/review-apps.yml
+++ b/.github/workflows/review-apps.yml
@@ -79,6 +79,9 @@ jobs:
           ARCHIVE_SECRET_ACCESS_KEY:
             op://Good Native/hover-archive/ARCHIVE_SECRET_ACCESS_KEY
           ARCHIVE_ENDPOINT: op://Good Native/hover-archive/ARCHIVE_ENDPOINT
+          GRAFANA_CLOUD_USER: op://Good Native/hover-runtime/GRAFANA_CLOUD_USER
+          GRAFANA_CLOUD_API_KEY:
+            op://Good Native/hover-runtime/GRAFANA_CLOUD_API_KEY
 
       - name: Get Supabase Preview Branch URL
         id: supabase
@@ -276,6 +279,8 @@ jobs:
               ARCHIVE_ACCESS_KEY_ID="$ARCHIVE_ACCESS_KEY_ID" \
               ARCHIVE_SECRET_ACCESS_KEY="$ARCHIVE_SECRET_ACCESS_KEY" \
               ARCHIVE_ENDPOINT="$ARCHIVE_ENDPOINT" \
+              GRAFANA_CLOUD_USER="$GRAFANA_CLOUD_USER" \
+              GRAFANA_CLOUD_API_KEY="$GRAFANA_CLOUD_API_KEY" \
               WEBFLOW_REDIRECT_URI="https://$APP_NAME.fly.dev/v1/integrations/webflow/callback" \
               APP_URL="https://$APP_NAME.fly.dev" \
               SETTINGS_URL="https://$APP_NAME.fly.dev/settings" \
@@ -295,6 +300,8 @@ jobs:
               ARCHIVE_ACCESS_KEY_ID="$ARCHIVE_ACCESS_KEY_ID" \
               ARCHIVE_SECRET_ACCESS_KEY="$ARCHIVE_SECRET_ACCESS_KEY" \
               ARCHIVE_ENDPOINT="$ARCHIVE_ENDPOINT" \
+              GRAFANA_CLOUD_USER="$GRAFANA_CLOUD_USER" \
+              GRAFANA_CLOUD_API_KEY="$GRAFANA_CLOUD_API_KEY" \
               WEBFLOW_REDIRECT_URI="https://$APP_NAME.fly.dev/v1/integrations/webflow/callback" \
               APP_URL="https://$APP_NAME.fly.dev" \
               SETTINGS_URL="https://$APP_NAME.fly.dev/settings" \

--- a/.gitignore
+++ b/.gitignore
@@ -67,8 +67,6 @@ node_modules/
 supabase/.temp/
 supabase/.branches/
 
-# Grafana/observability config with secrets
-alloy.river
 
 # Snyk Security Extension - AI Rules (auto-generated)
 .cursor/rules/snyk_rules.mdc

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Alloy metrics agent
-FROM grafana/alloy:latest AS alloy
+FROM grafana/alloy:v1.15.1@sha256:1f40cf52adda8fab3e058f9347a5d165624ecb9fbc1527769cb744748961940d AS alloy
 
 # Build stage
 FROM golang:1.26.1-alpine AS builder

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,8 +26,8 @@ RUN adduser -D -g '' appuser
 
 WORKDIR /app
 
-# Install ca-certificates for HTTPS
-RUN apk --no-cache add ca-certificates
+# Install ca-certificates for HTTPS; gcompat provides glibc compat for Alloy sidecar
+RUN apk --no-cache add ca-certificates gcompat
 
 # Copy Go binary
 COPY --from=builder /app/main .

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,9 @@ RUN adduser -D -g '' appuser
 WORKDIR /app
 
 # Install ca-certificates for HTTPS; gcompat provides glibc compat for Alloy sidecar
-RUN apk --no-cache add ca-certificates gcompat
+RUN apk --no-cache add \
+  ca-certificates=20250911-r0 \
+  gcompat=1.1.0-r4
 
 # Copy Go binary
 COPY --from=builder /app/main .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,6 @@
+# Alloy metrics agent
+FROM grafana/alloy:latest AS alloy
+
 # Build stage
 FROM golang:1.26.1-alpine AS builder
 
@@ -26,8 +29,16 @@ WORKDIR /app
 # Install ca-certificates for HTTPS
 RUN apk --no-cache add ca-certificates
 
-# Copy binary from builder
+# Copy Go binary
 COPY --from=builder /app/main .
+
+# Copy Alloy binary and config
+COPY --from=alloy /bin/alloy /usr/local/bin/alloy
+COPY alloy.river .
+
+# Copy startup script
+COPY scripts/start.sh .
+RUN chmod +x start.sh /usr/local/bin/alloy
 
 # Copy static files
 COPY --from=builder /app/dashboard.html .
@@ -54,5 +65,5 @@ EXPOSE 8080
 # Switch to non-root user
 USER appuser
 
-# Run the binary
-CMD ["sh", "-c", "ulimit -n 65536 2>/dev/null || ulimit -n $(ulimit -Hn) 2>/dev/null; echo \"fd soft limit: $(ulimit -n)\"; exec ./main"]
+# Run app + Alloy sidecar
+CMD ["./start.sh"]

--- a/alloy.river
+++ b/alloy.river
@@ -11,8 +11,8 @@ prometheus.remote_write "grafana_cloud" {
     url = "https://prometheus-prod-41-prod-au-southeast-1.grafana.net/api/prom/push"
 
     basic_auth {
-      username = env("GRAFANA_CLOUD_USER")
-      password = env("GRAFANA_CLOUD_API_KEY")
+      username = sys.env("GRAFANA_CLOUD_USER")
+      password = sys.env("GRAFANA_CLOUD_API_KEY")
     }
 
     remote_timeout = "2m"
@@ -23,11 +23,11 @@ prometheus.remote_write "grafana_cloud" {
       max_backoff          = "30s"
       max_samples_per_send = 500
     }
+  }
 
-    wal {
-      truncate_frequency = "1h"
-      min_keepalive_time = "5m"
-      max_keepalive_time = "1h"
-    }
+  wal {
+    truncate_frequency = "1h"
+    min_keepalive_time = "5m"
+    max_keepalive_time = "1h"
   }
 }

--- a/alloy.river
+++ b/alloy.river
@@ -1,0 +1,33 @@
+prometheus.scrape "hover" {
+  targets = [{
+    __address__ = "localhost:9464",
+  }]
+  scrape_interval = "60s"
+  forward_to = [prometheus.remote_write.grafana_cloud.receiver]
+}
+
+prometheus.remote_write "grafana_cloud" {
+  endpoint {
+    url = "https://prometheus-prod-41-prod-au-southeast-1.grafana.net/api/prom/push"
+
+    basic_auth {
+      username = env("GRAFANA_CLOUD_USER")
+      password = env("GRAFANA_CLOUD_API_KEY")
+    }
+
+    remote_timeout = "2m"
+
+    queue_config {
+      batch_send_deadline  = "10s"
+      min_backoff          = "1s"
+      max_backoff          = "30s"
+      max_samples_per_send = 500
+    }
+
+    wal {
+      truncate_frequency = "1h"
+      min_keepalive_time = "5m"
+      max_keepalive_time = "1h"
+    }
+  }
+}

--- a/fly.toml
+++ b/fly.toml
@@ -93,7 +93,7 @@ primary_region = 'syd'
       Content-Type = "text/plain"
 
 [processes]
-  app = "./main"
+  app = "./start.sh"
 
 [[vm]]
   memory = '8gb'

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+# Set file descriptor limits
+ulimit -n 65536 2>/dev/null || ulimit -n $(ulimit -Hn) 2>/dev/null
+echo "fd soft limit: $(ulimit -n)"
+
+# Start Alloy metrics agent in background (production only — skipped if secrets absent)
+if [ -n "$GRAFANA_CLOUD_API_KEY" ]; then
+  echo "Starting Alloy metrics agent"
+  /usr/local/bin/alloy run --storage.path=/tmp/alloy-wal /app/alloy.river &
+else
+  echo "GRAFANA_CLOUD_API_KEY not set, skipping metrics agent"
+fi
+
+# Start main application
+exec ./main

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -3,13 +3,29 @@
 ulimit -n 65536 2>/dev/null || ulimit -n $(ulimit -Hn) 2>/dev/null
 echo "fd soft limit: $(ulimit -n)"
 
-# Start Alloy metrics agent in background (production only — skipped if secrets absent)
-if [ -n "$GRAFANA_CLOUD_API_KEY" ]; then
+# Start Alloy metrics agent in background (production only — skipped if either credential is absent)
+alloy_pid=""
+if [ -n "$GRAFANA_CLOUD_API_KEY" ] && [ -n "$GRAFANA_CLOUD_USER" ]; then
   echo "Starting Alloy metrics agent"
   /usr/local/bin/alloy run --storage.path=/tmp/alloy-wal /app/alloy.river &
+  alloy_pid=$!
 else
-  echo "GRAFANA_CLOUD_API_KEY not set, skipping metrics agent"
+  echo "Grafana Cloud credentials not fully set, skipping metrics agent"
 fi
 
-# Start main application
-exec ./main
+# Forward SIGTERM/SIGINT to both processes and wait for clean shutdown
+term() {
+  [ -n "$alloy_pid" ] && kill "$alloy_pid" 2>/dev/null || true
+  [ -n "$main_pid" ] && kill "$main_pid" 2>/dev/null || true
+}
+trap term INT TERM
+
+# Start main application and wait (keeps script as PID 1 for signal handling)
+./main &
+main_pid=$!
+wait "$main_pid"
+status=$?
+
+[ -n "$alloy_pid" ] && kill "$alloy_pid" 2>/dev/null || true
+wait "$alloy_pid" 2>/dev/null || true
+exit "$status"


### PR DESCRIPTION
## Summary

- Removes the separate `bee-observability` Fly app and runs Grafana Alloy as a sidecar process inside the `hover` VM
- Alloy scrapes `localhost:9464` (same machine, no network hop) and pushes to Grafana Cloud
- Credentials moved from hardcoded config to Fly secrets, sourced from 1Password in CI
- Alloy only starts if `GRAFANA_CLOUD_API_KEY` is present — review apps automatically skip it unless the secret is set (it now is, so all envs get metrics)
- WAL capped at 1h, scrape interval increased to 60s, batch size limited to 500 samples — prevents the OOM death spiral seen in `bee-observability`

## Changes

- `Dockerfile` — adds Alloy binary from `grafana/alloy:latest` build stage
- `alloy.river` — new config (was gitignored when it contained hardcoded secrets; now uses `env()`)
- `scripts/start.sh` — new startup script; handles ulimit, starts Alloy in background, then `exec ./main`
- `fly.toml` — process updated to `./start.sh`
- `fly-deploy.yml` + `review-apps.yml` — `GRAFANA_CLOUD_USER` and `GRAFANA_CLOUD_API_KEY` added from 1Password `hover-runtime`
- `.gitignore` — removed `alloy.river` exclusion

## After merging

Suspend the old app once production is confirmed healthy:
```
flyctl apps suspend bee-observability
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled observability: app metrics are now forwarded to Grafana Cloud for improved monitoring and visibility.
  * Startup now runs a background metrics agent alongside the app when credentials are available.

* **Chores**
  * Deployment workflows updated to provision Grafana Cloud credentials to review and production deployments.
  * Observability configuration is now tracked in source control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->