### PR TITLE
Fix post-REDIS throughput regression

### DIFF
--- a/.fly/review_apps.worker.toml
+++ b/.fly/review_apps.worker.toml
@@ -83,7 +83,7 @@ primary_region = "syd"
   ARCHIVE_CONCURRENCY = "5"
 
   # Outbox sweeper — mirror prod defaults.
-  OUTBOX_SWEEP_INTERVAL_MS = "1000"
+  OUTBOX_SWEEP_INTERVAL_MS = "200"
   OUTBOX_SWEEP_BATCH_SIZE = "100"
 
   # Explicitly source DATABASE_URL from secrets for parity with the API.

--- a/fly.worker.toml
+++ b/fly.worker.toml
@@ -49,11 +49,12 @@ primary_region = 'syd'
   REDIS_CONSUMER_READ_COUNT = "10"
   REDIS_AUTOCLAIM_INTERVAL_S = "30"
   REDIS_COUNTER_SYNC_INTERVAL_S = "5"
-  # Outbox sweep: moves task_outbox rows into the Redis ZSET. At 1s ×
-  # 100 that caps ingest at 6k/min — fine until throughput climbs past
-  # that. Bumping batch to 500 keeps the pipeline fed when 30+ jobs
-  # discover links in parallel during the ramp-up.
-  OUTBOX_SWEEP_INTERVAL_MS = "1000"
+  # Outbox sweep: moves task_outbox rows into the Redis ZSET. At 200ms ×
+  # 500 this caps ingest at 150k/min — well above current peak and keeps
+  # newly-discovered siblings from waiting a full tick after a parent
+  # completes. The sweep is an index-only SKIP LOCKED query so the extra
+  # frequency is negligible.
+  OUTBOX_SWEEP_INTERVAL_MS = "200"
   OUTBOX_SWEEP_BATCH_SIZE = "500"
   GNH_BATCH_CHANNEL_SIZE = "5000"
   # Batch size matches pre-merge fly.toml (16). Was bumped to 32

--- a/internal/broker/consumer.go
+++ b/internal/broker/consumer.go
@@ -281,6 +281,29 @@ func (c *Consumer) getDeliveryCount(ctx context.Context, streamKey, groupName, m
 	return pending[0].RetryCount, nil
 }
 
+// PendingCount returns the number of messages in the pending entries
+// list (PEL) for a job's consumer group — i.e. tasks that have been
+// delivered to a worker but not yet ACKed. This is the authoritative
+// source of "currently running" for a given job; the RunningCounters
+// HASH in Redis is a fast-path mirror that can drift under partial
+// failures. Returns 0 when the stream or group does not yet exist.
+func (c *Consumer) PendingCount(ctx context.Context, jobID string) (int64, error) {
+	streamKey := StreamKey(jobID)
+	groupName := ConsumerGroup(jobID)
+
+	summary, err := c.client.rdb.XPending(ctx, streamKey, groupName).Result()
+	if err != nil {
+		if isNoGroupErr(err) {
+			return 0, nil
+		}
+		return 0, fmt.Errorf("broker: XPENDING %s: %w", jobID, err)
+	}
+	if summary == nil {
+		return 0, nil
+	}
+	return summary.Count, nil
+}
+
 // isNoGroupErr returns true when Redis reports that the stream or
 // consumer group doesn't exist. This is expected before the
 // dispatcher first XADDs to a job's stream.

--- a/internal/broker/outbox.go
+++ b/internal/broker/outbox.go
@@ -11,7 +11,7 @@ import (
 
 // OutboxSweeperOpts configures a Sweeper.
 type OutboxSweeperOpts struct {
-	// Interval between sweep ticks. Default: 5s.
+	// Interval between sweep ticks. Default: 500ms.
 	Interval time.Duration
 	// BatchSize caps how many rows are claimed per tick. Default: 200.
 	BatchSize int

--- a/internal/broker/outbox.go
+++ b/internal/broker/outbox.go
@@ -23,9 +23,16 @@ type OutboxSweeperOpts struct {
 }
 
 // DefaultOutboxSweeperOpts returns sensible production defaults.
+//
+// The sweep interval was lowered from 5s to 500ms because the outbox
+// sits on the hot path between newly-authored tasks and the Redis
+// ZSET that dispatchers poll. At 5s, each just-completed task waited
+// up to 5s for its newly-discovered siblings to reach a worker, which
+// dominated end-to-end throughput on small jobs. The sweep is an
+// index-only SKIP LOCKED query; running it 10× more often is cheap.
 func DefaultOutboxSweeperOpts() OutboxSweeperOpts {
 	return OutboxSweeperOpts{
-		Interval:    5 * time.Second,
+		Interval:    500 * time.Millisecond,
 		BatchSize:   200,
 		BaseBackoff: 2 * time.Second,
 		MaxBackoff:  5 * time.Minute,
@@ -47,7 +54,7 @@ type Sweeper struct {
 // NewOutboxSweeper constructs a Sweeper.
 func NewOutboxSweeper(db *sql.DB, scheduler *Scheduler, opts OutboxSweeperOpts) *Sweeper {
 	if opts.Interval <= 0 {
-		opts.Interval = 5 * time.Second
+		opts.Interval = 500 * time.Millisecond
 	}
 	if opts.BatchSize <= 0 {
 		opts.BatchSize = 200

--- a/internal/db/batch.go
+++ b/internal/db/batch.go
@@ -562,8 +562,10 @@ func (bm *BatchManager) flushTaskUpdates(ctx context.Context, updates []*TaskUpd
 			}
 		}
 
-		// Running task counters and waiting→pending promotion are handled by the
-		// Redis broker (counters + scheduler), not the batch manager.
+		// Running task counters are decremented by the stream worker on task
+		// outcome. Waiting→pending promotion is driven per-completion by
+		// DbQueue.PromoteWaitingToPending, invoked from the stream worker after
+		// the counter decrement succeeds.
 
 		return nil
 	})
@@ -707,6 +709,7 @@ func (bm *BatchManager) batchUpdateCompleted(ctx context.Context, tx *sql.Tx, ta
 
 	// Build arrays for all fields
 	ids := make([]string, len(tasks))
+	startedAts := make([]time.Time, len(tasks))
 	completedAts := make([]time.Time, len(tasks))
 	statusCodes := make([]int, len(tasks))
 	responseTimes := make([]int64, len(tasks))
@@ -743,6 +746,13 @@ func (bm *BatchManager) batchUpdateCompleted(ctx context.Context, tx *sql.Tx, ta
 
 	for i, task := range tasks {
 		ids[i] = task.ID
+		// StartedAt is populated by the stream worker when the task is dispatched.
+		// Fall back to CompletedAt so the column is never NULL for completed rows.
+		if !task.StartedAt.IsZero() {
+			startedAts[i] = task.StartedAt
+		} else {
+			startedAts[i] = task.CompletedAt
+		}
 		completedAts[i] = task.CompletedAt
 		statusCodes[i] = task.StatusCode
 		responseTimes[i] = task.ResponseTime
@@ -809,6 +819,7 @@ func (bm *BatchManager) batchUpdateCompleted(ctx context.Context, tx *sql.Tx, ta
 	query := `
 		UPDATE tasks
 		SET status = 'completed',
+			started_at = COALESCE(tasks.started_at, updates.started_at),
 			completed_at = updates.completed_at,
 			status_code = updates.status_code,
 			response_time = updates.response_time,
@@ -877,7 +888,8 @@ func (bm *BatchManager) batchUpdateCompleted(ctx context.Context, tx *sql.Tx, ta
 				unnest($31::bigint[]) AS html_size_bytes,
 				unnest($32::bigint[]) AS html_compressed_size_bytes,
 				unnest($33::text[]) AS html_sha256,
-				NULLIF(unnest($34::text[]), '')::timestamptz AS html_captured_at
+				NULLIF(unnest($34::text[]), '')::timestamptz AS html_captured_at,
+				unnest($35::timestamptz[]) AS started_at
 		) AS updates
 		WHERE tasks.id = updates.id
 	`
@@ -917,6 +929,7 @@ func (bm *BatchManager) batchUpdateCompleted(ctx context.Context, tx *sql.Tx, ta
 		pq.Array(htmlCompressedSizeBytes),
 		pq.Array(htmlSHA256s),
 		pq.Array(htmlCapturedAts),
+		pq.Array(startedAts),
 	)
 
 	if err != nil {
@@ -935,6 +948,7 @@ func (bm *BatchManager) batchUpdateFailed(ctx context.Context, tx *sql.Tx, tasks
 	}
 
 	ids := make([]string, len(tasks))
+	startedAts := make([]time.Time, len(tasks))
 	completedAts := make([]time.Time, len(tasks))
 	errors := make([]string, len(tasks))
 	retryCounts := make([]int, len(tasks))
@@ -943,6 +957,11 @@ func (bm *BatchManager) batchUpdateFailed(ctx context.Context, tx *sql.Tx, tasks
 
 	for i, task := range tasks {
 		ids[i] = task.ID
+		if !task.StartedAt.IsZero() {
+			startedAts[i] = task.StartedAt
+		} else {
+			startedAts[i] = task.CompletedAt
+		}
 		completedAts[i] = task.CompletedAt
 		errors[i] = task.Error
 		retryCounts[i] = task.RetryCount
@@ -957,6 +976,7 @@ func (bm *BatchManager) batchUpdateFailed(ctx context.Context, tx *sql.Tx, tasks
 	query := `
 		UPDATE tasks
 		SET status = updates.status,
+			started_at = COALESCE(tasks.started_at, updates.started_at),
 			completed_at = updates.completed_at,
 			error = updates.error,
 			retry_count = updates.retry_count,
@@ -968,7 +988,8 @@ func (bm *BatchManager) batchUpdateFailed(ctx context.Context, tx *sql.Tx, tasks
 				unnest($3::timestamptz[]) AS completed_at,
 				unnest($4::text[]) AS error,
 				unnest($5::integer[]) AS retry_count,
-				unnest($6::text[]) AS request_diagnostics
+				unnest($6::text[]) AS request_diagnostics,
+				unnest($7::timestamptz[]) AS started_at
 		) AS updates
 		WHERE tasks.id = updates.id
 	`
@@ -980,6 +1001,7 @@ func (bm *BatchManager) batchUpdateFailed(ctx context.Context, tx *sql.Tx, tasks
 		pq.Array(errors),
 		pq.Array(retryCounts),
 		pq.Array(requestDiagnostics),
+		pq.Array(startedAts),
 	)
 
 	if err != nil {

--- a/internal/db/queue.go
+++ b/internal/db/queue.go
@@ -1740,3 +1740,72 @@ func (q *DbQueue) UpdateDomainTechnologies(ctx context.Context, domainID int, te
 	}
 	return q.db.UpdateDomainTechnologies(ctx, domainID, technologies, headers, htmlPath)
 }
+
+// PromoteWaitingToPending moves up to `limit` waiting tasks for the job
+// into pending status and inserts matching task_outbox rows so the
+// OutboxSweeper picks them up on its next tick. Returns the number of
+// rows promoted.
+//
+// Called reactively after a counter decrement in the stream worker so a
+// freshly freed concurrency slot gets reused by a stranded waiting task
+// rather than sitting idle until the next link-discovery burst arrives.
+// Before this path existed, waiting rows never transitioned back to
+// pending (classifyEnqueuedTask only runs on INSERT), so crawls on
+// mature sites with heavy dedupe went idle with large waiting backlogs.
+//
+// The SELECT uses FOR UPDATE SKIP LOCKED so simultaneous promotions for
+// the same job cannot both pick the same row; task_outbox has a unique
+// index on task_id (migration 20260422112007) so the INSERT can rely on
+// ON CONFLICT DO NOTHING to collapse any remaining double-enqueue race
+// against the normal EnqueueURLs path.
+func (q *DbQueue) PromoteWaitingToPending(ctx context.Context, jobID string, limit int) (int, error) {
+	if limit <= 0 {
+		return 0, nil
+	}
+
+	var promoted int
+	err := q.Execute(ctx, func(tx *sql.Tx) error {
+		result, execErr := tx.ExecContext(ctx, `
+			WITH picked AS (
+				SELECT id
+				  FROM tasks
+				 WHERE job_id = $1
+				   AND status = 'waiting'
+				 ORDER BY priority_score DESC, created_at ASC
+				 LIMIT $2
+				 FOR UPDATE SKIP LOCKED
+			),
+			promoted AS (
+				UPDATE tasks t
+				   SET status = 'pending'
+				  FROM picked
+				 WHERE t.id = picked.id
+			 RETURNING t.id, t.job_id, t.page_id, t.host, t.path,
+					   t.priority_score, t.retry_count,
+					   t.source_type, COALESCE(t.source_url, ''),
+					   COALESCE(t.run_at, NOW())
+			)
+			INSERT INTO task_outbox (
+				task_id, job_id, page_id, host, path, priority,
+				retry_count, source_type, source_url, run_at,
+				attempts, created_at
+			)
+			SELECT id, job_id, page_id, host, path, priority_score,
+				   retry_count, source_type, source_url, run_at,
+				   0, NOW()
+			  FROM promoted
+		 ON CONFLICT (task_id) DO NOTHING
+		`, jobID, limit)
+		if execErr != nil {
+			return fmt.Errorf("promote waiting->pending for job %s: %w", jobID, execErr)
+		}
+
+		n, rowsErr := result.RowsAffected()
+		if rowsErr != nil {
+			return fmt.Errorf("promote waiting->pending rows affected for job %s: %w", jobID, rowsErr)
+		}
+		promoted = int(n)
+		return nil
+	})
+	return promoted, err
+}

--- a/internal/db/queue.go
+++ b/internal/db/queue.go
@@ -1765,7 +1765,14 @@ func (q *DbQueue) PromoteWaitingToPending(ctx context.Context, jobID string, lim
 
 	var promoted int
 	err := q.Execute(ctx, func(tx *sql.Tx) error {
-		result, execErr := tx.ExecContext(ctx, `
+		// Run the UPDATE as its own statement with RETURNING so the row
+		// count reflects actual waiting->pending transitions. A prior
+		// version tucked the INSERT into the same CTE and read the outer
+		// statement's RowsAffected — but with ON CONFLICT DO NOTHING that
+		// count reports only newly-inserted outbox rows, under-reporting
+		// whenever a race with EnqueueURLs has already placed an outbox
+		// row for the same task_id.
+		rows, queryErr := tx.QueryContext(ctx, `
 			WITH picked AS (
 				SELECT id
 				  FROM tasks
@@ -1774,37 +1781,101 @@ func (q *DbQueue) PromoteWaitingToPending(ctx context.Context, jobID string, lim
 				 ORDER BY priority_score DESC, created_at ASC
 				 LIMIT $2
 				 FOR UPDATE SKIP LOCKED
-			),
-			promoted AS (
-				UPDATE tasks t
-				   SET status = 'pending'
-				  FROM picked
-				 WHERE t.id = picked.id
-			 RETURNING t.id, t.job_id, t.page_id, t.host, t.path,
-					   t.priority_score, t.retry_count,
-					   t.source_type, COALESCE(t.source_url, ''),
-					   COALESCE(t.run_at, NOW())
 			)
+			UPDATE tasks t
+			   SET status = 'pending'
+			  FROM picked
+			 WHERE t.id = picked.id
+		 RETURNING t.id, t.job_id, t.page_id, t.host, t.path,
+				   t.priority_score, t.retry_count,
+				   t.source_type, COALESCE(t.source_url, ''),
+				   COALESCE(t.run_at, NOW())
+		`, jobID, limit)
+		if queryErr != nil {
+			return fmt.Errorf("promote waiting->pending for job %s: %w", jobID, queryErr)
+		}
+		defer rows.Close()
+
+		var (
+			taskIDs     []string
+			jobIDs      []string
+			pageIDs     []int
+			hosts       []string
+			paths       []string
+			priorities  []float64
+			retries     []int
+			sourceTypes []string
+			sourceURLs  []string
+			runAts      []time.Time
+		)
+		for rows.Next() {
+			var (
+				taskID, tJobID, host, path, sourceType, sourceURL string
+				pageID, retryCount                                int
+				priority                                          float64
+				runAt                                             time.Time
+			)
+			if err := rows.Scan(&taskID, &tJobID, &pageID, &host, &path,
+				&priority, &retryCount, &sourceType, &sourceURL, &runAt); err != nil {
+				return fmt.Errorf("promote waiting->pending scan for job %s: %w", jobID, err)
+			}
+			taskIDs = append(taskIDs, taskID)
+			jobIDs = append(jobIDs, tJobID)
+			pageIDs = append(pageIDs, pageID)
+			hosts = append(hosts, host)
+			paths = append(paths, path)
+			priorities = append(priorities, priority)
+			retries = append(retries, retryCount)
+			sourceTypes = append(sourceTypes, sourceType)
+			sourceURLs = append(sourceURLs, sourceURL)
+			runAts = append(runAts, runAt)
+		}
+		if err := rows.Err(); err != nil {
+			return fmt.Errorf("promote waiting->pending rows for job %s: %w", jobID, err)
+		}
+
+		promoted = len(taskIDs)
+		if promoted == 0 {
+			return nil
+		}
+
+		// ON CONFLICT DO NOTHING still guards against the rare race with
+		// EnqueueURLs placing a pending row for the same task_id; the
+		// promoted count above is unaffected by whether the INSERT was
+		// elided for any individual row.
+		if _, err := tx.ExecContext(ctx, `
 			INSERT INTO task_outbox (
 				task_id, job_id, page_id, host, path, priority,
 				retry_count, source_type, source_url, run_at,
 				attempts, created_at
 			)
-			SELECT id, job_id, page_id, host, path, priority_score,
-				   retry_count, source_type, source_url, run_at,
-				   0, NOW()
-			  FROM promoted
+			SELECT unnest($1::uuid[]),
+				   unnest($2::uuid[]),
+				   unnest($3::int[]),
+				   unnest($4::text[]),
+				   unnest($5::text[]),
+				   unnest($6::double precision[]),
+				   unnest($7::int[]),
+				   unnest($8::text[]),
+				   unnest($9::text[]),
+				   unnest($10::timestamptz[]),
+				   0,
+				   NOW()
 		 ON CONFLICT (task_id) DO NOTHING
-		`, jobID, limit)
-		if execErr != nil {
-			return fmt.Errorf("promote waiting->pending for job %s: %w", jobID, execErr)
+		`,
+			pq.Array(taskIDs),
+			pq.Array(jobIDs),
+			pq.Array(pageIDs),
+			pq.Array(hosts),
+			pq.Array(paths),
+			pq.Array(priorities),
+			pq.Array(retries),
+			pq.Array(sourceTypes),
+			pq.Array(sourceURLs),
+			pq.Array(runAts),
+		); err != nil {
+			return fmt.Errorf("promote waiting->pending outbox insert for job %s: %w", jobID, err)
 		}
-
-		n, rowsErr := result.RowsAffected()
-		if rowsErr != nil {
-			return fmt.Errorf("promote waiting->pending rows affected for job %s: %w", jobID, rowsErr)
-		}
-		promoted = int(n)
 		return nil
 	})
 	return promoted, err

--- a/internal/jobs/interfaces.go
+++ b/internal/jobs/interfaces.go
@@ -32,4 +32,5 @@ type DbQueueInterface interface {
 	MarkTaskArchived(ctx context.Context, taskID, provider, bucket, key string) error
 	MarkArchiveSkipped(ctx context.Context, taskID string) error
 	MarkFullyArchivedJobs(ctx context.Context) (int64, error)
+	PromoteWaitingToPending(ctx context.Context, jobID string, limit int) (int, error)
 }

--- a/internal/jobs/stream_worker.go
+++ b/internal/jobs/stream_worker.go
@@ -151,11 +151,11 @@ func NewStreamWorkerPool(deps StreamWorkerDeps, opts StreamWorkerOpts) *StreamWo
 func (swp *StreamWorkerPool) Start(ctx context.Context) {
 	ctx, swp.cancel = context.WithCancel(ctx)
 
-	// Reconcile running counters from Postgres.
-	swp.reconcileCounters(ctx)
-
-	// Refresh active jobs immediately.
+	// Refresh active jobs first so reconcile knows which streams to probe.
 	swp.refreshActiveJobs(ctx)
+
+	// Reconcile running counters from the Redis PEL (XPENDING).
+	swp.reconcileCounters(ctx)
 
 	// Start consumer goroutines.
 	for i := range swp.opts.NumWorkers {
@@ -263,11 +263,18 @@ func (swp *StreamWorkerPool) workerLoop(ctx context.Context, workerID int) {
 		}
 
 		if !processed {
-			// No messages from any stream — block briefly on first stream.
-			if len(jobIDs) > 0 {
-				msgs, err := swp.consumer.Read(ctx, jobIDs[0])
+			// No messages from any stream — block briefly on one job.
+			//
+			// Previously every worker blocked on jobIDs[0] here, which meant
+			// under low load the first active job saw N workers queued on its
+			// stream while the other N-1 jobs saw none. Shard by workerID so
+			// workers spread across the active set instead, keeping BLOCK
+			// pressure evenly distributed.
+			if n := len(jobIDs); n > 0 {
+				target := jobIDs[workerID%n]
+				msgs, err := swp.consumer.Read(ctx, target)
 				if err != nil {
-					logger.Warn("blocking read error", "error", err)
+					logger.Warn("blocking read error", "error", err, "job_id", target)
 				}
 				for _, msg := range msgs {
 					dispatch(msg)
@@ -346,8 +353,26 @@ func (swp *StreamWorkerPool) handleOutcome(ctx context.Context, msg broker.Strea
 	}
 
 	// Decrement running counter.
+	decrementedOK := true
 	if _, err := swp.counters.Decrement(ctx, msg.JobID); err != nil {
+		decrementedOK = false
 		jobsLog.Warn("counter decrement failed", "error", err, "job_id", msg.JobID)
+	}
+
+	// A concurrency slot just freed. Promote one waiting task for this
+	// job into pending so the freshly vacated slot doesn't sit idle
+	// until the next link-discovery burst arrives. Skipped when the
+	// decrement failed because the counter state is ambiguous and
+	// double-promotion on retry would exceed the concurrency cap.
+	//
+	// Intentionally synchronous: the promoter is a single UPDATE +
+	// INSERT and runs on the bulk lane, so adding a goroutine here
+	// would just introduce a race for no throughput benefit.
+	if decrementedOK && swp.dbQueue != nil {
+		if _, err := swp.dbQueue.PromoteWaitingToPending(ctx, msg.JobID, 1); err != nil {
+			jobsLog.Warn("waiting->pending promotion failed",
+				"error", err, "job_id", msg.JobID)
+		}
 	}
 
 	// Release domain pacer.
@@ -657,29 +682,54 @@ func (swp *StreamWorkerPool) fetchJobInfo(ctx context.Context, jobID string) (*J
 
 // --- counter reconciliation ---
 
+// reconcileCounters rebuilds the per-job RunningCounters HASH in Redis
+// from the authoritative stream PEL (XPENDING). The previous version
+// queried Postgres for tasks where status='running', but the batch
+// writer never transitions tasks through that status — they go
+// pending → completed/failed in one UPDATE — so the query always
+// returned zero and the reconcile silently wiped the counters,
+// stalling dispatch until the next decrement restored them.
+//
+// The PEL is the source of truth for in-flight work per job because
+// a message stays in the PEL from XREADGROUP delivery until XACK,
+// which brackets the worker's crawl + persist lifecycle.
 func (swp *StreamWorkerPool) reconcileCounters(ctx context.Context) {
-	counts := make(map[string]int64)
+	jobIDs := swp.getActiveJobs()
 
-	err := swp.dbQueue.ExecuteControl(ctx, func(tx *sql.Tx) error {
-		rows, err := tx.QueryContext(ctx,
-			`SELECT job_id, COUNT(*) FROM tasks WHERE status = 'running' GROUP BY job_id`)
-		if err != nil {
-			return err
-		}
-		defer rows.Close()
-		for rows.Next() {
-			var jobID string
-			var count int64
-			if err := rows.Scan(&jobID, &count); err != nil {
-				return err
-			}
-			counts[jobID] = count
-		}
-		return rows.Err()
-	})
+	// Also include any job currently present in the Redis counters hash,
+	// in case refreshActiveJobs hasn't surfaced it yet (e.g. a job that
+	// just transitioned status).
+	existing, err := swp.counters.GetAll(ctx)
 	if err != nil {
-		jobsLog.Error("failed to query running task counts for reconciliation", "error", err)
-		return
+		jobsLog.Warn("failed to read existing running counters; continuing with active-job set only", "error", err)
+	} else {
+		seen := make(map[string]struct{}, len(jobIDs))
+		for _, id := range jobIDs {
+			seen[id] = struct{}{}
+		}
+		for id := range existing {
+			if _, ok := seen[id]; !ok {
+				jobIDs = append(jobIDs, id)
+			}
+		}
+	}
+
+	counts := make(map[string]int64, len(jobIDs))
+	for _, jobID := range jobIDs {
+		n, err := swp.consumer.PendingCount(ctx, jobID)
+		if err != nil {
+			jobsLog.Warn("PendingCount failed during reconcile; skipping job", "job_id", jobID, "error", err)
+			// Preserve the existing counter rather than zeroing it on a
+			// transient Redis hiccup — better to over-count briefly than
+			// to flood a job with extra dispatches.
+			if prev, ok := existing[jobID]; ok {
+				counts[jobID] = prev
+			}
+			continue
+		}
+		if n > 0 {
+			counts[jobID] = n
+		}
 	}
 
 	if err := swp.counters.Reconcile(ctx, counts); err != nil {
@@ -691,7 +741,10 @@ func (swp *StreamWorkerPool) reconcileCounters(ctx context.Context) {
 	for _, c := range counts {
 		total += c
 	}
-	jobsLog.Info("reconciled running counters", "total_running", total, "jobs", len(counts))
+	jobsLog.Info("reconciled running counters from PEL",
+		"total_running", total,
+		"jobs_probed", len(jobIDs),
+		"jobs_with_pel", len(counts))
 }
 
 // --- concurrency checking (for dispatcher) ---

--- a/internal/mocks/db_queue.go
+++ b/internal/mocks/db_queue.go
@@ -114,3 +114,9 @@ func (m *MockDbQueue) UpdateTaskStatus(ctx context.Context, task *db.Task) error
 	args := m.Called(ctx, task)
 	return args.Error(0)
 }
+
+// PromoteWaitingToPending mocks the PromoteWaitingToPending method.
+func (m *MockDbQueue) PromoteWaitingToPending(ctx context.Context, jobID string, limit int) (int, error) {
+	args := m.Called(ctx, jobID, limit)
+	return args.Int(0), args.Error(1)
+}

--- a/supabase/migrations/20260422112007_add_task_outbox_unique_task_id.sql
+++ b/supabase/migrations/20260422112007_add_task_outbox_unique_task_id.sql
@@ -1,0 +1,18 @@
+-- Enforce one outbox row per task.
+--
+-- task_outbox buffers tasks between Postgres (where they are authored)
+-- and the Redis ZSET (where the dispatcher picks them up). The sweeper
+-- deletes rows on successful ScheduleBatch, so in the steady state each
+-- task_id should appear at most once.
+--
+-- Adding the unique index now lets the new waiting->pending promoter
+-- (internal/jobs/stream_worker.go handleOutcome) safely use
+-- `INSERT ... ON CONFLICT (task_id) DO NOTHING` — otherwise a race
+-- between the promoter and a concurrent EnqueueURLs path could
+-- double-enqueue a task into the ZSET and cause a duplicate crawl.
+--
+-- The index is additive and the table is small (rows are deleted on
+-- each sweep tick), so the CREATE is effectively instant.
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_task_outbox_task_id_unique
+  ON public.task_outbox (task_id);


### PR DESCRIPTION
## Context

Post-PR #330 (Redis broker v2), crawl throughput dropped from ~4000 tasks/min
(pre-merge) to a range of 85–1700/min depending on job count. Root-cause
investigation surfaced five distinct bugs in the stream worker + outbox path:

| # | Bug                                                              | Effect                                                              |
| - | ---------------------------------------------------------------- | ------------------------------------------------------------------- |
| 1 | `waiting` tasks never get promoted to `pending`                  | Tasks accumulate in `waiting` forever; throughput relies on brand-new URL discovery |
| 2 | `started_at` never persisted for completed/failed rows            | Queue-wait latency unobservable; breaks capacity sizing             |
| 3 | `reconcileCounters` queries `status='running'` (never exists)    | Startup wipes the Redis counters hash, stalling dispatch            |
| 4 | All workers block on `jobIDs[0]` under quiet streams             | One job hoards N workers; others starve                             |
| 5 | Outbox sweep runs every 5s (default) / 1s (prod)                  | Newly-discovered sibling URLs wait a full tick after each completion |

## Changes

### Fix 1: waiting → pending promoter (new)

- `supabase/migrations/20260422112007_add_task_outbox_unique_task_id.sql`
  adds a unique index on `task_outbox.task_id` so the promoter can
  `INSERT ... ON CONFLICT (task_id) DO NOTHING` safely.
- `internal/db/queue.go#PromoteWaitingToPending` selects one `waiting`
  task per job with `FOR UPDATE SKIP LOCKED`, flips it to `pending`,
  and enqueues the outbox row in a single CTE-based transaction on
  the bulk lane.
- `internal/jobs/stream_worker.go#handleOutcome` now calls the
  promoter after a successful counter decrement, so each completion
  unblocks exactly one waiter.
- `internal/jobs/interfaces.go` + `internal/mocks/db_queue.go`
  extended to match.

### Fix 2: persist `started_at`

- `internal/db/batch.go` — both `batchUpdateCompleted` and
  `batchUpdateFailed` now carry `started_at` into the UPDATE
  (`COALESCE(tasks.started_at, updates.started_at)`), backfilling
  from `completed_at` when the worker didn't stamp it.

### Fix 3: reconcile counters from Redis PEL

- `internal/broker/consumer.go#PendingCount` wraps `XPENDING` and
  returns the per-group PEL depth.
- `internal/jobs/stream_worker.go#reconcileCounters` now probes the
  PEL for every active job (and every job already carrying a
  counter), rather than a Postgres query that always returned zero.
- Reorders `Start` so `refreshActiveJobs` runs before the reconcile.

### Fix 4: shard blocking read across jobs

- `internal/jobs/stream_worker.go#workerLoop` now does the blocking
  `XREADGROUP` against `jobIDs[workerID % len(jobIDs)]` instead of
  the first active job, so N workers spread across the active set.

### Fix 5: lower outbox sweep interval

- Default interval dropped from 5s to 500ms in
  `internal/broker/outbox.go`. Sweep is an index-only
  SKIP LOCKED query — the extra frequency is negligible.
- `fly.worker.toml` and `.fly/review_apps.worker.toml` drop
  `OUTBOX_SWEEP_INTERVAL_MS` from 1000 to 200 (5× faster tick
  than before, with the same batch size).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (all packages green)
- [x] `scripts/security-check.sh` (gosec clean, existing pgx CVE unchanged)
- [ ] Deploy to review app; confirm throughput scales above ~2k/min at 10 jobs
- [ ] Verify `task_outbox` row count stays small (sweep keeps up)
- [ ] Verify `hover:running` HASH matches per-job `XLEN hover:stream:{jobID}` PEL counts
- [ ] Confirm `started_at` is populated on new completed task rows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Outbox sweeper runs on a 200ms interval for faster dispatching.

* **Bug Fixes / Reliability**
  * Rebuilt task reconciliation to use the message stream for accurate pending counts.
  * Improved handling of missing stream groups and related error paths.
  * Ensured task start times are recorded during batch updates.

* **Infrastructure**
  * Enforced unique task entries in the task_outbox to prevent duplicates.
* **New Features**
  * DB queue can promote waiting tasks to pending to resume work promptly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->