### PR TITLE
Guard outbox insert against duplicates

### DIFF
--- a/internal/db/queue.go
+++ b/internal/db/queue.go
@@ -1256,6 +1256,7 @@ func (q *DbQueue) EnqueueURLs(ctx context.Context, jobID string, pages []Page, s
 			       priority_score, retry_count, source_type, source_url, created_at
 			FROM ins
 			WHERE status IN ('pending', 'waiting')
+			ON CONFLICT (task_id) DO NOTHING
 		`
 
 		now := time.Now().UTC()


### PR DESCRIPTION
## Summary
- Adds `ON CONFLICT (task_id) DO NOTHING` to the bulk `EnqueueURLs` INSERT into `task_outbox` (internal/db/queue.go:1259).
- Fixes production crashes in `hover-worker` where re-enqueues of already-pending tasks trip the new `idx_task_outbox_task_id_unique` index and roll back the whole transaction (SQLSTATE 23505).
- Also closes a latent pre-merge bug where duplicate outbox rows were silently accepted, causing double-dispatch into the Redis ZSET.

## Context
PR #336 added the unique index so the promoter/enqueue paths could use `ON CONFLICT (task_id) DO NOTHING` — but the bulk `EnqueueURLs` INSERT still wrote unguarded. Worker logs after merge show 16× `duplicate key value violates unique constraint` per 100 lines on the bulk path.

## Test plan
- [x] `gofmt` + `go build ./...`
- [x] `go test ./internal/db/...`
- [ ] Merge + monitor `flyctl logs -a hover-worker` for SQLSTATE 23505 to drop to zero

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a critical concurrency issue that occurred during simultaneous task operations, which could result in duplicate task entries being created and processed. The system now properly handles such scenarios by preventing duplicate entries, ensuring reliable and efficient task processing, and significantly improving overall system stability during periods of high concurrent activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->