### PR TITLE
Run Alloy sidecar on worker processes

### DIFF
--- a/.fly/review_apps.worker.toml
+++ b/.fly/review_apps.worker.toml
@@ -11,11 +11,13 @@ primary_region = "syd"
 
 [build]
 
-# Override the Dockerfile CMD (./start.sh) to run the worker binary
-# directly. start.sh only launches ./main, so without this override the
-# worker container would run the API instead of the consumer.
+# Override the Dockerfile CMD to run start.sh with the worker binary.
+# Passing "worker" as the argument makes start.sh launch ./worker while
+# still starting the Alloy metrics sidecar, so review apps emit
+# bee.worker.* and bee.broker.* series tagged with
+# app=hover-worker-pr-<N> and environment=staging.
 [processes]
-  worker = "./worker"
+  worker = "./start.sh worker"
 
 # Environment overrides for preview. Scaled down from fly.worker.toml to
 # fit within the Supabase preview branch's shared pool (see the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,17 @@ On merge, CI will:
 
 ## [Unreleased]
 
-_Add unreleased changes here._
+### Fixed
+
+- Worker Fly processes now launch via `scripts/start.sh` instead of running the
+  binary directly, so the Alloy metrics sidecar runs on every process. Without
+  this, `bee.worker.*` and `bee.broker.*` metrics from the prod `hover-worker`
+  app and every `hover-worker-pr-*` review app were silently dropped before
+  reaching Grafana Cloud.
+- `scripts/start.sh` now accepts the binary name as `$1` (default `main`), so a
+  single script launches either the API or the worker alongside Alloy. Both
+  `fly.worker.toml` and `.fly/review_apps.worker.toml` point at
+  `./start.sh worker`.
 
 ## Full changelog history
 

--- a/fly.worker.toml
+++ b/fly.worker.toml
@@ -122,7 +122,10 @@ primary_region = 'syd'
   strategy = "immediate"
 
 [processes]
-  worker = "./worker"
+  # Launch via start.sh so the Alloy metrics sidecar runs alongside the
+  # worker binary. Running ./worker directly skips Alloy, which silently
+  # drops every bee.worker.* and bee.broker.* metric from this process.
+  worker = "./start.sh worker"
 
 # Always restart on exit. The worker has no [http_service] block, so Fly
 # has no health-check hook to wake it up, and the default on-failure

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -3,10 +3,16 @@
 ulimit -n 65536 2>/dev/null || ulimit -n $(ulimit -Hn) 2>/dev/null
 echo "fd soft limit: $(ulimit -n)"
 
-# Start Alloy metrics agent in background (production only — skipped if either credential is absent)
+# Binary to launch — defaults to ./main (API). Pass "worker" (or any other
+# compiled binary in the image) as $1 to launch that instead. Keeps the
+# Alloy sidecar in one place so every Fly process group exports metrics,
+# regardless of which Go binary it runs.
+APP_BIN="${1:-main}"
+
+# Start Alloy metrics agent in background (skipped if either credential is absent)
 alloy_pid=""
 if [ -n "$GRAFANA_CLOUD_API_KEY" ] && [ -n "$GRAFANA_CLOUD_USER" ]; then
-  echo "Starting Alloy metrics agent"
+  echo "Starting Alloy metrics agent for ${APP_BIN}"
   /usr/local/bin/alloy run --storage.path=/tmp/alloy-wal /app/alloy.river &
   alloy_pid=$!
 else
@@ -16,14 +22,19 @@ fi
 # Forward SIGTERM/SIGINT to both processes and wait for clean shutdown
 term() {
   [ -n "$alloy_pid" ] && kill "$alloy_pid" 2>/dev/null || true
-  [ -n "$main_pid" ] && kill "$main_pid" 2>/dev/null || true
+  [ -n "$app_pid" ] && kill "$app_pid" 2>/dev/null || true
 }
 trap term INT TERM
 
-# Start main application and wait (keeps script as PID 1 for signal handling)
-./main &
-main_pid=$!
-wait "$main_pid"
+if [ ! -x "./${APP_BIN}" ]; then
+  echo "start.sh: ./${APP_BIN} is not executable in $(pwd)" >&2
+  exit 127
+fi
+
+# Start application and wait (keeps script as PID 1 for signal handling)
+"./${APP_BIN}" &
+app_pid=$!
+wait "$app_pid"
 status=$?
 
 [ -n "$alloy_pid" ] && kill "$alloy_pid" 2>/dev/null || true


### PR DESCRIPTION
## Summary

- Fixes `hover-worker` (prod) and every `hover-worker-pr-*` (review) emitting **zero** metrics to Grafana Cloud. The worker's Fly `[processes]` line ran `./worker` directly, bypassing `scripts/start.sh` — which is the only thing that launches the Alloy sidecar. Result: every `bee.worker.*` and `bee.broker.*` series has been silently dropped since the worker split landed.
- Surfaced while validating [#340](https://github.com/Harvey-AU/hover/pull/340): the new `bee.broker.outbox_sweep_total` counter never appeared in Grafana, and `hover-worker-pr-340` was missing from the `app` dropdown. Same root cause for prod.

## Changes

- `scripts/start.sh` now accepts the binary name as `$1`, defaulting to `main`. Single entry point for both API and worker keeps Alloy boot logic in one place.
- `fly.worker.toml` and `.fly/review_apps.worker.toml` both switch `[processes] worker` from `"./worker"` → `"./start.sh worker"`.
- Backwards compatible: the prod API (`./start.sh` with no arg) and review API (inherits Dockerfile CMD `./start.sh`) still default to `./main`.

## Test plan

- [ ] After merge, confirm `hover-worker` appears in the Grafana `app` dropdown.
- [ ] Open any subsequent PR and confirm `hover-worker-pr-<N>` appears in the dropdown with `environment=staging`.
- [ ] Confirm `bee.broker.outbox_sweep_total` and `bee.worker.task_outcome_total` panels populate for both.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed worker process telemetry collection in preview environments to properly emit metrics with the correct worker and broker tags. Worker processes now correctly initialize with the metrics sidecar.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->