### PR TITLE
Expose worker /metrics for Alloy scrape

### DIFF
--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -5,7 +5,10 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net"
+	"net/http"
 	"os"
 	"os/signal"
 	"strconv"
@@ -55,12 +58,17 @@ func main() {
 		if serviceName == "" {
 			serviceName = "hover-worker"
 		}
+		metricsAddr := os.Getenv("METRICS_ADDR")
+		if metricsAddr == "" {
+			metricsAddr = ":9464"
+		}
 		providers, err := observability.Init(context.Background(), observability.Config{
-			Enabled:      true,
-			ServiceName:  serviceName,
-			Environment:  appEnv,
-			OTLPEndpoint: strings.TrimSpace(os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT")),
-			OTLPHeaders:  observability.ParseOTLPHeaders(os.Getenv("OTEL_EXPORTER_OTLP_HEADERS")),
+			Enabled:        true,
+			ServiceName:    serviceName,
+			Environment:    appEnv,
+			OTLPEndpoint:   strings.TrimSpace(os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT")),
+			OTLPHeaders:    observability.ParseOTLPHeaders(os.Getenv("OTEL_EXPORTER_OTLP_HEADERS")),
+			MetricsAddress: metricsAddr,
 		})
 		if err != nil {
 			workerLog.Warn("failed to initialise observability", "error", err)
@@ -70,6 +78,36 @@ func main() {
 				defer cancel()
 				_ = providers.Shutdown(ctx)
 			}()
+
+			// Expose the Prometheus registry on METRICS_ADDR so the Alloy
+			// sidecar (alloy.river) can scrape it and add app/environment
+			// labels. Without this the worker's metrics only reach Grafana
+			// via OTLP push and the dashboard's app filter excludes them.
+			if providers.MetricsHandler != nil && metricsAddr != "" {
+				metricsSrv := &http.Server{
+					Addr:              metricsAddr,
+					Handler:           providers.MetricsHandler,
+					ReadHeaderTimeout: 5 * time.Second,
+				}
+				metricsListener, err := net.Listen("tcp", metricsAddr)
+				if err != nil {
+					workerLog.Error("metrics server failed to bind", "error", err, "addr", metricsAddr)
+				} else {
+					go func() {
+						workerLog.Info("metrics server listening", "addr", metricsAddr)
+						if err := metricsSrv.Serve(metricsListener); err != nil && !errors.Is(err, http.ErrServerClosed) {
+							workerLog.Error("metrics server failed", "error", err)
+						}
+					}()
+					defer func() {
+						ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+						defer cancel()
+						if err := metricsSrv.Shutdown(ctx); err != nil && !errors.Is(err, http.ErrServerClosed) {
+							workerLog.Warn("graceful shutdown of metrics server failed", "error", err)
+						}
+					}()
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary

Follow-up to #344. Without this, the `app` filter added to the dashboard in #344 excludes every worker metric — we confirmed via `group by (app) (bee_db_pool_in_use)` that only `hover` / `hover-pr-*` (API apps) have the `app` label, never `hover-worker*`.

## Root cause

`observability.Init` returns `providers.MetricsHandler` (a Prometheus registry exposed as an `http.Handler`). The API (`cmd/app/main.go:473-505`) mounts it on `METRICS_ADDR` (default `:9464`) so the Alloy sidecar scrapes it and adds `app` / `environment` labels at scrape time (`alloy.river`). **The worker never did this step** — it called `Init` but never started an HTTP server, so Alloy was scraping a port that wasn't open. Worker metrics only reached Grafana via the OTLP push path, which carries `service_name` / `deployment_environment` from the OTEL resource but not `app` / `environment`.

## Fix

`cmd/worker/main.go` now mirrors the API's metrics-server block: listen on `METRICS_ADDR` (default `:9464`), serve `providers.MetricsHandler` in a goroutine, shut down cleanly on exit. Same error handling as the API (`bind` failure logs but doesn't abort; shutdown timeout of 5s).

## Test plan

- [ ] After merge + deploy, `group by (app) (bee_db_pool_in_use)` in Grafana Cloud Prometheus Explore should include `hover-worker` (and any open `hover-worker-pr-*`).
- [ ] Dashboard panels that were showing "No data" at idle should populate — broker dispatch, crawler phase, worker task outcomes, DB SQL latency, etc.
- [ ] Review app `App` dropdown in `App Performance Metrics` dashboard should list worker-side entries.

## Notes

- No change to `observability.Config` — `MetricsAddress` was already supported; the worker just wasn't passing it.
- No port conflict on Fly: `fly.worker.toml` has no `[http_service]` block, so `:9464` is free. Alloy scrapes `localhost:9464` in the same VM.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Worker now exposes metrics via a configurable HTTP endpoint (default: `:9464`) controlled by the `METRICS_ADDR` environment variable for enhanced monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->