### PR TITLE
Fix hover CLI on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,10 @@ On merge, CI will:
 - Worker metrics now scraped by Alloy sidecar (added to Docker build); four
   broken Grafana panels restored after metrics rename; semaphore wait corrected
   to µs
+- `hover` CLI on Windows: replaced `/bin/sh` stub with a Node launcher so
+  `npm install -g @harvey-au/hover` produces a working `hover.cmd`/`hover.ps1`
+  shim; install script now extracts the Go binary as `hover-bin[.exe]` to avoid
+  a filename collision with the launcher
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,24 @@ On merge, CI will:
 
 ## [Unreleased]
 
-_Add unreleased changes here._
+### Added
+
+- Grafana deploy annotations posted on every main merge; dashboards synced from
+  repo; panels and traces scoped by app
+
+### Fixed
+
+- Post-redis-broker-merge throughput regression resolved — pacer, FIFO ordering,
+  and domain-delay defaults restored
+- Broker counter drift stabilised with configurable env vars; reclaim
+  classification hardened; metric label cardinality reduced
+- Worker metrics now scraped by Alloy sidecar (added to Docker build); four
+  broken Grafana panels restored after metrics rename; semaphore wait corrected
+  to µs
+
+### Changed
+
+- Go bumped to 1.26.2 for security fixes
 
 ## Full changelog history
 

--- a/npm/bin/hover
+++ b/npm/bin/hover
@@ -1,8 +1,32 @@
-#!/bin/sh
-echo "Error: hover binary is missing or failed to extract during installation." >&2
-echo "Please try the following repair commands:" >&2
-echo "  npm rebuild @harvey-au/hover" >&2
-echo "  npm install --verbose" >&2
-echo "" >&2
-echo "If the issue persists, check your npm install/rebuild logs and PATH configuration." >&2
-exit 1
+#!/usr/bin/env node
+"use strict";
+
+const { spawnSync } = require("child_process");
+const fs = require("fs");
+const path = require("path");
+
+const binary = path.join(
+  __dirname,
+  process.platform === "win32" ? "hover-bin.exe" : "hover-bin"
+);
+
+if (!fs.existsSync(binary)) {
+  console.error(
+    "hover binary is missing or failed to extract during installation."
+  );
+  console.error("Try: npm rebuild -g @harvey-au/hover");
+  process.exit(1);
+}
+
+const result = spawnSync(binary, process.argv.slice(2), { stdio: "inherit" });
+
+if (result.error) {
+  console.error(`Failed to run hover: ${result.error.message}`);
+  process.exit(1);
+}
+
+if (result.signal) {
+  process.kill(process.pid, result.signal);
+}
+
+process.exit(result.status ?? 1);

--- a/npm/install.js
+++ b/npm/install.js
@@ -8,8 +8,9 @@ const path = require("path");
 
 const REPO = "Harvey-AU/hover";
 const BIN_DIR = path.join(__dirname, "bin");
-const BIN_NAME = process.platform === "win32" ? "hover.exe" : "hover";
+const BIN_NAME = process.platform === "win32" ? "hover-bin.exe" : "hover-bin";
 const BIN_PATH = path.join(BIN_DIR, BIN_NAME);
+const ARCHIVE_BIN_NAME = process.platform === "win32" ? "hover.exe" : "hover";
 
 const PLATFORM_MAP = { darwin: "darwin", linux: "linux", win32: "windows" };
 const ARCH_MAP = { x64: "amd64", arm64: "arm64" };
@@ -90,10 +91,18 @@ async function main() {
     fs.writeFileSync(tmpFile, buffer);
     execFileSync("tar", ["xzf", tmpFile, "-C", BIN_DIR], { stdio: "ignore" });
     fs.unlinkSync(tmpFile);
-    fs.chmodSync(BIN_PATH, 0o755);
   }
-  if (!fs.existsSync(BIN_PATH)) {
-    throw new Error(`Binary not found after extraction: ${BIN_PATH}`);
+
+  // The release archive ships the binary as `hover` / `hover.exe`, which
+  // collides with the Node shim at `bin/hover`. Rename it so the shim and the
+  // real binary can coexist.
+  const extracted = path.join(BIN_DIR, ARCHIVE_BIN_NAME);
+  if (!fs.existsSync(extracted)) {
+    throw new Error(`Binary not found after extraction: ${extracted}`);
+  }
+  fs.renameSync(extracted, BIN_PATH);
+  if (!isWindows()) {
+    fs.chmodSync(BIN_PATH, 0o755);
   }
   console.log("hover installed successfully.");
 }

--- a/npm/install.js
+++ b/npm/install.js
@@ -72,35 +72,56 @@ async function main() {
 
   // Write archive to temp file and extract.
   fs.mkdirSync(BIN_DIR, { recursive: true });
+  const tmpFile = path.join(
+    BIN_DIR,
+    isWindows() ? "_download.zip" : "_download.tar.gz"
+  );
+  const tempDir = fs.mkdtempSync(path.join(BIN_DIR, "_extract-"));
 
-  if (isWindows()) {
-    const tmpFile = path.join(BIN_DIR, "_download.zip");
+  try {
     fs.writeFileSync(tmpFile, buffer);
-    execFileSync(
-      "powershell",
-      [
-        "-NoProfile",
-        "-Command",
-        `Expand-Archive -Force -Path '${tmpFile}' -DestinationPath '${BIN_DIR}'`,
-      ],
-      { stdio: "ignore" }
-    );
-    fs.unlinkSync(tmpFile);
-  } else {
-    const tmpFile = path.join(BIN_DIR, "_download.tar.gz");
-    fs.writeFileSync(tmpFile, buffer);
-    execFileSync("tar", ["xzf", tmpFile, "-C", BIN_DIR], { stdio: "ignore" });
-    fs.unlinkSync(tmpFile);
+
+    if (isWindows()) {
+      execFileSync(
+        "powershell",
+        [
+          "-NoProfile",
+          "-Command",
+          `Expand-Archive -Force -Path '${tmpFile}' -DestinationPath '${tempDir}'`,
+        ],
+        { stdio: "ignore" }
+      );
+    } else {
+      execFileSync("tar", ["xzf", tmpFile, "-C", tempDir], { stdio: "ignore" });
+    }
+
+    // The release archive ships the binary as `hover` / `hover.exe`, which
+    // collides with the Node shim at `bin/hover`. Stage extraction elsewhere,
+    // then move only the native binary into place.
+    const extracted = path.join(tempDir, ARCHIVE_BIN_NAME);
+    if (!fs.existsSync(extracted)) {
+      throw new Error(`Binary not found after extraction: ${extracted}`);
+    }
+
+    try {
+      fs.renameSync(extracted, BIN_PATH);
+    } catch (err) {
+      if (
+        !err ||
+        (err.code !== "EEXIST" && err.code !== "EPERM" && err.code !== "EXDEV")
+      ) {
+        throw err;
+      }
+      fs.copyFileSync(extracted, BIN_PATH);
+      fs.unlinkSync(extracted);
+    }
+  } finally {
+    if (fs.existsSync(tmpFile)) {
+      fs.unlinkSync(tmpFile);
+    }
+    fs.rmSync(tempDir, { recursive: true, force: true });
   }
 
-  // The release archive ships the binary as `hover` / `hover.exe`, which
-  // collides with the Node shim at `bin/hover`. Rename it so the shim and the
-  // real binary can coexist.
-  const extracted = path.join(BIN_DIR, ARCHIVE_BIN_NAME);
-  if (!fs.existsSync(extracted)) {
-    throw new Error(`Binary not found after extraction: ${extracted}`);
-  }
-  fs.renameSync(extracted, BIN_PATH);
   if (!isWindows()) {
     fs.chmodSync(BIN_PATH, 0o755);
   }


### PR DESCRIPTION
## Summary

- `npm install -g @harvey-au/hover` produced a broken `hover` command on Windows: PowerShell errored with `/bin/sh.exe` not found, cmd.exe with "system cannot find the path specified".
- Root cause: `npm/bin/hover` had a `#!/bin/sh` shebang, so npm's generated `hover.cmd`/`hover.ps1` shims tried to invoke `/bin/sh` on Windows.
- Replaced the shell stub with a Node launcher (`#!/usr/bin/env node`) that execs the extracted Go binary with stdio/exit-code/signal forwarding.
- `install.js` now extracts the binary as `hover-bin[.exe]` (renamed post-extraction) to avoid colliding with the launcher filename.

## Test plan

- [x] Local PowerShell: `npm install -g ./harvey-au-hover-0.1.16.tgz` → `hover --help` prints help text, no `/bin/sh.exe` error
- [ ] cmd.exe in fresh window: `hover --help` prints help text
- [ ] macOS regression check after release lands: `npm install -g @harvey-au/hover` then `hover --help` still works
- [ ] Confirm `bin/` contains both `hover` (Node shim) and `hover-bin[.exe]` (Go binary) in the installed package

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Grafana deploy annotations and dashboard/panel/trace syncing scoped by app

* **Bug Fixes**
  * Restored Redis broker throughput and fixed broker counter drift
  * Repaired worker metrics collection and restored affected Grafana panels
  * Corrected semaphore wait unit to microseconds

* **Improvements**
  * Windows CLI packaging updated to a Node-based launcher; installer avoids filename collisions
  * Bumped Go runtime to 1.26.2 for security fixes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->