### PR TITLE
Stop outbox inheriting stale run_at

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,20 @@ On merge, CI will:
 
 ## [Unreleased]
 
-_Add unreleased changes here._
+### Fixed
+
+- `promote_waiting_with_outbox` no longer inherits `tasks.run_at` into newly-
+  inserted `task_outbox` rows. Waiting tasks always carry `run_at = created_at`,
+  so promoting a task that had been waiting for hours/days baked an ancient
+  timestamp into the outbox row. Production ran ~881k waiting tasks with
+  `run_at` more than 30 minutes old (oldest > 3 days), causing the
+  `bee.broker.outbox_age_seconds` gauge to climb past 5 hours despite actual
+  outbox dwell times being sub-second. Outbox rows now use `NOW()` for `run_at`
+  on initial insert; retry/back-off paths in `Sweeper.bumpAttempts` continue to
+  set future `run_at` values.
+- `bee.broker.outbox_age_seconds` gauge now measures actual outbox dwell time
+  (`NOW() - MIN(created_at)` over due rows) instead of staleness of the
+  inherited `run_at` value.
 
 ## Full changelog history
 

--- a/internal/broker/probe.go
+++ b/internal/broker/probe.go
@@ -115,11 +115,16 @@ func (p *Probe) probeOutbox(ctx context.Context) {
 	)
 	// Only count rows that are actually due. Future-scheduled rows
 	// (retry backoff, throttled reschedule) aren't a backlog — counting
-	// them inflates the gauge and, worse, MIN(run_at) would be in the
-	// future and produce a negative age.
+	// them inflates the gauge.
+	//
+	// Age is measured against created_at, not run_at: run_at is the
+	// "earliest dispatch time" and may be inherited from a long-waiting
+	// parent task at insert time, which would inflate the gauge to the
+	// task's queue age rather than the row's outbox dwell time. created_at
+	// is set to NOW() on insert and is monotonic w.r.t. row arrival.
 	row := p.db.QueryRowContext(ctx, `
 		SELECT COUNT(*)::bigint,
-		       EXTRACT(EPOCH FROM NOW() - MIN(run_at))
+		       EXTRACT(EPOCH FROM NOW() - MIN(created_at))
 		  FROM task_outbox
 		 WHERE run_at <= NOW()
 	`)

--- a/internal/observability/observability.go
+++ b/internal/observability/observability.go
@@ -1029,7 +1029,7 @@ func initBrokerInstruments(meterProvider *sdkmetric.MeterProvider) error {
 	brokerOutboxAgeGauge, err = meter.Float64Gauge(
 		"bee.broker.outbox_age_seconds",
 		metric.WithUnit("s"),
-		metric.WithDescription("Age of the oldest due task_outbox row (NOW - MIN(run_at))"),
+		metric.WithDescription("Dwell time of the oldest due task_outbox row (NOW - MIN(created_at))"),
 	)
 	if err != nil {
 		return err

--- a/supabase/migrations/20260425081706_outbox_runat_use_now.sql
+++ b/supabase/migrations/20260425081706_outbox_runat_use_now.sql
@@ -1,0 +1,101 @@
+-- Stop promote_waiting_with_outbox from baking stale timestamps into
+-- task_outbox.run_at.
+--
+-- Background:
+--   The function previously inserted `COALESCE(t.run_at, NOW())` into
+--   task_outbox.run_at. tasks.run_at is NOT NULL and, for tasks in the
+--   `waiting` state, equals tasks.created_at — the task is never in
+--   waiting because of a future schedule, only because the upstream
+--   admission loop hasn't promoted it yet. Production held ~881k
+--   waiting tasks with run_at older than 30 min (oldest > 3 days),
+--   so every fresh outbox row inherited an arbitrarily old run_at.
+--
+--   Downstream effects:
+--     * Sweeper still picks the row immediately (run_at <= NOW()), so
+--       no functional dispatch delay — but ORDER BY run_at biases
+--       picks toward whichever waiting task happened to be queued
+--       longest, not toward the order rows entered the outbox.
+--     * Probe metric `bee.broker.outbox_age_seconds` is computed as
+--       NOW() - MIN(run_at), which then reports hours/days even when
+--       the actual outbox dwell time is sub-second. The companion
+--       commit fixes the metric to use created_at.
+--
+-- Fix:
+--   Insert NOW() unconditionally. The outbox row's run_at semantically
+--   means "earliest dispatch time" — for a fresh promote that's now.
+--   Retry/back-off paths (Sweeper.bumpAttempts) keep setting future
+--   run_at values; this only changes the initial-insert value.
+--
+-- Semantics preserved:
+--   * Picked rows still ordered by priority_score DESC, created_at ASC,
+--     id ASC (deadlock-safe ordering from 20260425000001).
+--   * Outbox uses ON CONFLICT (task_id) DO NOTHING.
+--   * Function still returns the count of waiting->pending transitions.
+
+CREATE OR REPLACE FUNCTION promote_waiting_with_outbox(
+    p_job_id UUID,
+    p_slots INTEGER
+)
+RETURNS INTEGER
+LANGUAGE plpgsql
+SET search_path = public
+AS $$
+DECLARE
+    promoted INTEGER;
+BEGIN
+    IF p_slots <= 0 THEN
+        RETURN 0;
+    END IF;
+
+    WITH picked AS (
+        SELECT id
+          FROM tasks
+         WHERE job_id = p_job_id
+           AND status = 'waiting'
+         ORDER BY priority_score DESC, created_at ASC, id ASC
+         LIMIT p_slots
+         FOR UPDATE SKIP LOCKED
+    ),
+    picked_ordered AS (
+        SELECT id FROM picked ORDER BY id
+    ),
+    updated AS (
+        UPDATE tasks t
+           SET status = 'pending'
+          FROM picked_ordered
+         WHERE t.id = picked_ordered.id
+     RETURNING t.id, t.job_id, t.page_id, t.host, t.path,
+               t.priority_score, t.retry_count,
+               t.source_type,
+               COALESCE(t.source_url, '') AS source_url
+    ),
+    inserted AS (
+        INSERT INTO task_outbox (
+            task_id, job_id, page_id, host, path, priority,
+            retry_count, source_type, source_url, run_at,
+            attempts, created_at
+        )
+        SELECT id, job_id, page_id, host, path, priority_score,
+               retry_count, source_type, source_url, NOW(),
+               0, NOW()
+          FROM updated
+         ORDER BY id
+        ON CONFLICT (task_id) DO NOTHING
+        RETURNING 1
+    )
+    SELECT COUNT(*)::INTEGER INTO promoted FROM updated;
+
+    RETURN COALESCE(promoted, 0);
+END;
+$$;
+
+COMMENT ON FUNCTION promote_waiting_with_outbox(UUID, INTEGER) IS
+    'Atomically promote up to p_slots waiting tasks for a job to pending '
+    'and enqueue corresponding task_outbox rows. Locks task rows in id '
+    'order (after priority/created tie-breakers) to keep the row-lock '
+    'graph acyclic across concurrent promoters and avoid 40P01 deadlocks '
+    'against the trg_update_job_queue_counters AFTER trigger. The outbox '
+    'row''s run_at is set to NOW() — the parent task''s run_at is not '
+    'inherited because waiting tasks always carry their created_at as '
+    'run_at (no future-schedule path sets a waiting task''s run_at), so '
+    'inheriting it would bake task age into the outbox dispatch time.';


### PR DESCRIPTION
## Summary

The Grafana `Outbox oldest age` panel sawtoothed up to 5+ hours despite `Dispatch success ratio = 100%`, `Outbox backlog < 50`, and `task_outbox_dead` being empty. Investigation against production data found two compounding bugs.

## Root cause

`promote_waiting_with_outbox` inserts `COALESCE(t.run_at, NOW())` into `task_outbox.run_at`. `tasks.run_at` is `NOT NULL` and equals `created_at` for waiting tasks (no code path schedules a future `run_at` on a waiting task). With ~881k waiting tasks in production carrying `run_at` more than 30 minutes old (oldest > 3 days), every freshly-promoted outbox row inherited an arbitrarily ancient timestamp.

Live evidence (sampled at 18:16 AEST):
- Outbox row created 1 second ago, `run_at` 6h 13min in the past
- Outbox row created 1.4s ago, `run_at` 3h 17min in the past
- All 10 oldest-by-`run_at` rows had outbox dwell time < 1.5 seconds

The probe metric `bee.broker.outbox_age_seconds` is computed `NOW() - MIN(run_at) WHERE run_at <= NOW()`, so it reported the inherited staleness rather than actual outbox dwell time. The sawtooth on the dashboard was the gauge tracking the inherited age of whichever long-waiting task got promoted next, not rows being stuck.

## Fix

1. **Migration `20260425081706_outbox_runat_use_now.sql`** — `promote_waiting_with_outbox` now inserts `NOW()` into `task_outbox.run_at` instead of inheriting from the parent task. Retry/back-off paths in `Sweeper.bumpAttempts` continue to set future `run_at` values; only the initial insert changes.
2. **`internal/broker/probe.go`** — gauge now measures `NOW() - MIN(created_at)` over due rows, i.e. true dwell time. `created_at` is set to `NOW()` on insert and is monotonic w.r.t. row arrival.
3. **`internal/observability/observability.go`** — gauge description updated to match.

Deadlock-safe `ORDER BY id` ordering from migration `20260425000001` is preserved. `ON CONFLICT (task_id) DO NOTHING` semantics unchanged. Function return value unchanged.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (all packages pass)
- [ ] Migration applies cleanly on review app
- [ ] Post-deploy: `bee.broker.outbox_age_seconds` should drop into the seconds range and stay there. Sawtooth pattern should disappear.
- [ ] Sample new outbox rows: `outbox_run_at_age` should be ≤ outbox row dwell time, not minutes/hours ahead of it.

## Out of scope

The 881k waiting tasks with stale `run_at` are unrelated to this fix and should drain naturally as the admission loop catches up. If they don't, a follow-up housekeeping task can `UPDATE tasks SET run_at = NOW() WHERE status = 'waiting' AND run_at < NOW() - interval '1 hour'`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed task outbox dispatch timing to use current time when inserting new tasks, instead of inheriting timing from parent tasks, ensuring more predictable task dispatch behavior.
  * Corrected the outbox queue age metric to measure true dwell time from task creation rather than inherited dispatch times, providing more accurate performance insights.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->