### PR TITLE
Stop worker wedging on log backpressure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,47 @@ On merge, CI will:
 
 ## [Unreleased]
 
-_Add unreleased changes here._
+### Added
+
+- `internal/watchdog`: heartbeat-based wedge detector. The stream worker pool
+  ticks the heartbeat per task outcome; a background loop forces `os.Exit(1)` if
+  the heartbeat goes flat for 90s while jobs are alive, triggering Fly's restart
+  policy. Last-resort recovery for Go-side wedges (blocked stdout, exhausted
+  resource pool, mutex deadlock) that no in-process recovery can clear.
+- `internal/logging.AsyncWriter`: bounded non-blocking `io.Writer` wrapping
+  `os.Stdout` in production. slog handlers enqueue records into a
+  drop-on-overflow channel rather than synchronously writing to the pipe.
+  Prevents goroutines that hold DB transactions or other resources from wedging
+  on platform log-shipper backpressure.
+- pprof endpoints exposed on the worker's metrics port (`:9464`) alongside
+  `/metrics`. Enables `fly proxy 9464 -a hover-worker` to capture goroutine
+  dumps without redeploying.
+
+### Changed
+
+- `executeOnceWithContext` now calls `tx.Rollback()` immediately on error from
+  either `applyLocalStatementTimeout` or `fn`, before any logging or other
+  downstream work, with the deferred rollback suppressed via `committed=true`.
+  Production observed Go goroutines wedging between query-error and the deferred
+  rollback (e.g. inside a blocking slog write), leaving Postgres sessions in
+  `idle in transaction (aborted)` for 20+ minutes. Eager rollback releases the
+  connection regardless of what blocks afterwards.
+- `DefaultDBSyncFunc` clamps Redis counter values to ≥0 via `GREATEST(0, $1)`
+  before writing `running_tasks`. Eliminates the 6/min
+  `jobs_running_tasks_non_negative` constraint violations (HOVER-K4) caused by a
+  transient Redis underflow race between `HIncrBy(-1)` and the cleanup `HDel`.
+
+### Removed
+
+- The post-batch wide
+  `UPDATE jobs SET running_tasks = 0 WHERE running_tasks > 0 AND id != ALL(...)`
+  in `DefaultDBSyncFunc`. Walking job rows in index order acquired locks that
+  deadlocked against the AFTER trigger `update_job_queue_counters` fired by
+  concurrent task UPDATEs. The reconcile loop
+  (`REDIS_COUNTER_RECONCILE_INTERVAL_S=120`) authoritatively rebuilds Redis
+  state every two minutes, so missing this sweep only delays the
+  `running_tasks=0` reflection in PG by at most one reconcile interval —
+  acceptable in exchange for eliminating the deadlock class.
 
 ## Full changelog history
 

--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -437,6 +437,14 @@ func main() {
 	}
 
 	setupLogging(config)
+	defer func() {
+		// Flush any buffered log lines before the process exits.
+		// Idempotent, safe even if the async writer wasn't installed
+		// (e.g. dev mode, where StdoutAsync returns nil).
+		if a := logging.StdoutAsync(); a != nil {
+			a.Close()
+		}
+	}()
 
 	var (
 		obsProviders *observability.Providers

--- a/cmd/archive_key_migrate/main.go
+++ b/cmd/archive_key_migrate/main.go
@@ -27,6 +27,11 @@ type archivedTask struct {
 
 func main() {
 	logging.Setup(logging.ParseLevel("info"), "production")
+	defer func() {
+		if a := logging.StdoutAsync(); a != nil {
+			a.Close()
+		}
+	}()
 
 	var (
 		apply = flag.Bool("apply", false, "apply the migration; default is dry run")

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -7,8 +7,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net"
 	"net/http"
+	"net/http/pprof"
 	"os"
 	"os/signal"
 	"strconv"
@@ -22,6 +24,7 @@ import (
 	"github.com/Harvey-AU/hover/internal/jobs"
 	"github.com/Harvey-AU/hover/internal/logging"
 	"github.com/Harvey-AU/hover/internal/observability"
+	"github.com/Harvey-AU/hover/internal/watchdog"
 	"github.com/getsentry/sentry-go"
 )
 
@@ -83,10 +86,22 @@ func main() {
 			// sidecar (alloy.river) can scrape it and add app/environment
 			// labels. Without this the worker's metrics only reach Grafana
 			// via OTLP push and the dashboard's app filter excludes them.
+			//
+			// Also mount /debug/pprof on the same port so a wedged worker
+			// can be debugged via `fly proxy 9464` without redeploying. The
+			// metrics port is on Fly's internal network only, so no auth
+			// guard is required.
 			if providers.MetricsHandler != nil && metricsAddr != "" {
+				mux := http.NewServeMux()
+				mux.Handle("/metrics", providers.MetricsHandler)
+				mux.HandleFunc("/debug/pprof/", pprof.Index)
+				mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+				mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+				mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+				mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
 				metricsSrv := &http.Server{
 					Addr:              metricsAddr,
-					Handler:           providers.MetricsHandler,
+					Handler:           mux,
 					ReadHeaderTimeout: 5 * time.Second,
 				}
 				metricsListener, err := net.Listen("tcp", metricsAddr)
@@ -270,6 +285,14 @@ func main() {
 		JobManager:   jobManager,
 	}, swpOpts)
 
+	// Wedge watchdog: tick the heartbeat per task outcome and exit the
+	// process if the heartbeat goes flat with active jobs. This is the
+	// last-resort recovery when a Go-side wedge (blocked stdout, exhausted
+	// resource, mutex deadlock) prevents in-process recovery. Fly's
+	// restart=always policy brings the worker back with fresh state.
+	heartbeat := &watchdog.Heartbeat{}
+	swp.SetHeartbeat(heartbeat)
+
 	// --- dispatcher ---
 	dispatcherOpts := broker.DefaultDispatcherOpts()
 	dispatcher := broker.NewDispatcher(
@@ -324,6 +347,8 @@ func main() {
 	go outboxSweeper.Run(ctx)
 	go probe.Run(ctx)
 
+	go startWatchdog(ctx, heartbeat, swp)
+
 	workerLog.Info("hover worker ready",
 		"workers", numWorkers,
 		"tasks_per_worker", tasksPerWorker,
@@ -355,6 +380,29 @@ func main() {
 }
 
 // --- helpers ---
+
+// startWatchdog wires the wedge watchdog using the stream worker's
+// active-jobs view as the "should be working" signal. Extracted from
+// main to keep main's cyclomatic complexity bounded.
+func startWatchdog(ctx context.Context, hb *watchdog.Heartbeat, swp *jobs.StreamWorkerPool) {
+	watchdog.Run(ctx, hb, watchdog.Options{
+		StallThreshold: 90 * time.Second,
+		CheckInterval:  15 * time.Second,
+		GracePeriod:    2 * time.Minute,
+		HasWork: func(checkCtx context.Context) bool {
+			ids, err := swp.ActiveJobIDs(checkCtx)
+			if err != nil {
+				// Treat unknown work state as "yes": false-trip is
+				// safer than missing a real wedge. The check has its
+				// own 5s context timeout in the watchdog so this
+				// can't itself wedge.
+				return true
+			}
+			return len(ids) > 0
+		},
+		Logger: slog.Default().With("component", "watchdog"),
+	})
+}
 
 func envInt(key string, def int) int {
 	v := os.Getenv(key)

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -50,6 +50,7 @@ func main() {
 
 	// --- logging (slog + sentry fanout) ---
 	logging.Setup(logging.ParseLevel(os.Getenv("LOG_LEVEL")), appEnv)
+	defer flushAsyncLogs()
 
 	workerLog.Info("hover worker starting")
 
@@ -381,12 +382,29 @@ func main() {
 
 // --- helpers ---
 
+// flushAsyncLogs drains the async stdout buffer (if installed) so
+// logs queued at process exit reach the platform log shipper.
+// Idempotent and safe in dev mode (StdoutAsync returns nil).
+func flushAsyncLogs() {
+	if a := logging.StdoutAsync(); a != nil {
+		a.Close()
+	}
+}
+
 // startWatchdog wires the wedge watchdog using the stream worker's
 // active-jobs view as the "should be working" signal. Extracted from
 // main to keep main's cyclomatic complexity bounded.
+//
+// StallThreshold is sized to comfortably exceed the per-task context
+// timeout in stream_worker.processTask (2 minutes). Heartbeat ticks
+// only fire after handleOutcome returns, so a single long-running task
+// — or a brief pacer-throttled idle while jobs are alive — can leave
+// the heartbeat flat for up to one task budget. 3 minutes provides
+// 60s margin against the worst single-task case while still catching
+// genuine wedges within minutes.
 func startWatchdog(ctx context.Context, hb *watchdog.Heartbeat, swp *jobs.StreamWorkerPool) {
 	watchdog.Run(ctx, hb, watchdog.Options{
-		StallThreshold: 90 * time.Second,
+		StallThreshold: 3 * time.Minute,
 		CheckInterval:  15 * time.Second,
 		GracePeriod:    2 * time.Minute,
 		HasWork: func(checkCtx context.Context) bool {

--- a/internal/broker/counters.go
+++ b/internal/broker/counters.go
@@ -195,10 +195,15 @@ func DefaultDBSyncFunc(sqlDB *sql.DB) DBSyncFunc {
 		// transaction pooling — pgx v5 hashes SQL to deterministic
 		// stmt_<md5> names that clash across logical clients sharing the
 		// same backend.
+		//
+		// GREATEST(0, $1) clamps any transient negative Redis counter
+		// (a race between HIncrBy returning -1 and HDel cleaning the
+		// entry) so we don't violate the jobs_running_tasks_non_negative
+		// CHECK constraint and abort the rest of the sync (HOVER-K4).
 		for _, jobID := range jobIDs {
 			count := counts[jobID]
 			if _, err := sqlDB.ExecContext(ctx,
-				`UPDATE jobs SET running_tasks = $1
+				`UPDATE jobs SET running_tasks = GREATEST(0, $1)
 				   WHERE id = $2 AND status IN ('running', 'pending')`,
 				count, jobID); err != nil {
 				return fmt.Errorf("update job %s: %w", jobID, err)
@@ -207,18 +212,19 @@ func DefaultDBSyncFunc(sqlDB *sql.DB) DBSyncFunc {
 				math.Abs(float64(count-priorCounts[jobID])))
 		}
 
-		// Zero out any active jobs whose counters are no longer tracked
-		// (they finished between sync intervals). Single statement —
-		// holds locks only for the duration of the UPDATE.
-		if _, err := sqlDB.ExecContext(ctx,
-			`UPDATE jobs SET running_tasks = 0
-			   WHERE running_tasks > 0
-			     AND status IN ('running', 'pending')
-			     AND id != ALL($1)`,
-			pq.Array(jobIDs),
-		); err != nil {
-			return fmt.Errorf("zero stale running_tasks: %w", err)
-		}
+		// NOTE: previous versions also issued a wide
+		//   UPDATE jobs SET running_tasks = 0
+		//      WHERE running_tasks > 0 AND id != ALL($1) ...
+		// to zero out finished jobs whose counters are no longer
+		// tracked. That UPDATE walks an index range and acquires row
+		// locks across many jobs, deadlocking with the AFTER trigger
+		// update_job_queue_counters fired by concurrent task UPDATEs.
+		// The reconcile loop (REDIS_COUNTER_RECONCILE_INTERVAL_S=120)
+		// authoritatively rebuilds the Redis HASH from XPENDING every
+		// two minutes, so missing this sweep merely delays the
+		// running_tasks=0 reflection in PG by at most one reconcile
+		// interval — acceptable in exchange for eliminating the
+		// deadlock class.
 
 		return nil
 	}

--- a/internal/db/queue.go
+++ b/internal/db/queue.go
@@ -413,12 +413,28 @@ func (q *DbQueue) executeOnceWithContext(ctx context.Context, fn func(context.Co
 	}()
 
 	if err := applyLocalStatementTimeout(ctx, tx); err != nil {
+		// Roll back eagerly for the same reason as the fn() error
+		// path below — don't depend on the deferred Rollback firing
+		// promptly when intervening code (caller, logging) could
+		// block.
+		_ = tx.Rollback()
+		committed = true
 		return err
 	}
 
 	queryStart := time.Now()
 	if err := fn(ctx, tx); err != nil {
 		queryDuration := time.Since(queryStart)
+		// Roll back IMMEDIATELY, before any logging or other downstream
+		// work. Production has shown the goroutine can wedge between an
+		// error return and the deferred Rollback (e.g. on a blocked
+		// stdout pipe inside slog), leaving Postgres sessions in
+		// `idle in transaction (aborted)` for tens of minutes. Calling
+		// Rollback eagerly releases the connection regardless of what
+		// happens afterwards; the deferred Rollback is suppressed via
+		// committed=true so it won't fire again.
+		_ = tx.Rollback()
+		committed = true
 		// Log slow queries even when they fail
 		if queryDuration > 5*time.Second {
 			queueLog.Warn("Slow query failed in transaction",

--- a/internal/jobs/stream_worker.go
+++ b/internal/jobs/stream_worker.go
@@ -134,8 +134,19 @@ type StreamWorkerPool struct {
 	// pool headroom for promotion, counter sync, and the outbox sweeper.
 	linkDiscoverySem chan struct{}
 
+	// heartbeat, when set, is ticked on each completed task outcome so
+	// the watchdog can detect a wedged worker. Optional — nil when no
+	// watchdog is wired (e.g. in tests).
+	heartbeat interface{ Tick() }
+
 	wg     sync.WaitGroup
 	cancel context.CancelFunc
+}
+
+// SetHeartbeat installs a heartbeat sink that is ticked once per task
+// outcome. Wire this from cmd/worker so the watchdog can detect a stall.
+func (swp *StreamWorkerPool) SetHeartbeat(h interface{ Tick() }) {
+	swp.heartbeat = h
 }
 
 // defaultLinkDiscoveryMaxInflight: at 32 the cap throttled production
@@ -355,6 +366,14 @@ func (swp *StreamWorkerPool) processMessage(ctx context.Context, msg broker.Stre
 
 	// Act on the outcome.
 	swp.handleOutcome(ctx, msg, outcome)
+
+	// Tick the watchdog heartbeat AFTER handleOutcome returns so we
+	// only count fully-handled outcomes as forward progress. A wedge
+	// inside handleOutcome will leave the heartbeat flat and the
+	// watchdog will trip.
+	if swp.heartbeat != nil {
+		swp.heartbeat.Tick()
+	}
 }
 
 func (swp *StreamWorkerPool) handleOutcome(ctx context.Context, msg broker.StreamMessage, outcome *TaskOutcome) {

--- a/internal/logging/async_writer.go
+++ b/internal/logging/async_writer.go
@@ -2,6 +2,7 @@ package logging
 
 import (
 	"io"
+	"sync"
 	"sync/atomic"
 )
 
@@ -29,7 +30,13 @@ type AsyncWriter struct {
 	dropped    atomic.Uint64
 	written    atomic.Uint64
 	underlying io.Writer
-	done       chan struct{}
+	// stop is closed by Close to signal the drain goroutine that no
+	// more sends will arrive. Writers also observe stop and treat a
+	// closed stop as "drop the payload" instead of attempting to send,
+	// so a Write racing with Close cannot panic on send-to-closed.
+	stop      chan struct{}
+	done      chan struct{}
+	closeOnce sync.Once
 }
 
 // NewAsyncWriter wraps underlying with a bounded async writer. bufferSize
@@ -43,6 +50,7 @@ func NewAsyncWriter(underlying io.Writer, bufferSize int) *AsyncWriter {
 	aw := &AsyncWriter{
 		ch:         make(chan []byte, bufferSize),
 		underlying: underlying,
+		stop:       make(chan struct{}),
 		done:       make(chan struct{}),
 	}
 	go aw.drain()
@@ -50,10 +58,29 @@ func NewAsyncWriter(underlying io.Writer, bufferSize int) *AsyncWriter {
 }
 
 // Write copies p into the channel and returns. It never blocks: when the
-// channel is full the payload is dropped and the dropped counter is
-// incremented. The returned n is always len(p) so that slog handlers
-// don't treat a drop as a partial write.
+// channel is full or Close has been called, the payload is dropped and
+// the dropped counter is incremented. The returned n is always len(p)
+// so that slog handlers don't treat a drop as a partial write.
+//
+// Concurrency-safe with Close: instead of closing the data channel
+// (which would race with concurrent Writes), Close signals via the
+// stop channel and Write checks stop before attempting to send. Even
+// if a Write observes stop as not-yet-closed and Close completes
+// during the select, the data channel is never closed, so the send
+// either succeeds (drained later by drain on stop) or hits the
+// default branch (drop).
 func (a *AsyncWriter) Write(p []byte) (int, error) {
+	// Reject sends after Close so we don't grow the buffer indefinitely
+	// once nobody is going to drain it. The check is best-effort
+	// (a concurrent Close could fire after this branch is skipped) but
+	// safe — the data channel is never closed.
+	select {
+	case <-a.stop:
+		a.dropped.Add(1)
+		return len(p), nil
+	default:
+	}
+
 	// slog handlers reuse their internal buffer across records, so we
 	// must copy before queuing.
 	cp := make([]byte, len(p))
@@ -68,34 +95,54 @@ func (a *AsyncWriter) Write(p []byte) (int, error) {
 }
 
 // Dropped returns the cumulative number of log lines dropped due to a
-// full buffer. Exposed for metrics surface.
+// full buffer or a closed writer. Exposed for metrics surface.
 func (a *AsyncWriter) Dropped() uint64 { return a.dropped.Load() }
 
 // Written returns the cumulative number of log lines successfully
 // written to the underlying writer.
 func (a *AsyncWriter) Written() uint64 { return a.written.Load() }
 
-// Close stops the drain goroutine after flushing any queued lines.
-// Safe to call multiple times.
+// Close stops accepting new writes, drains any already-queued lines to
+// the underlying writer, and waits for the drain goroutine to exit.
+// Idempotent and safe to call concurrently with Write.
 func (a *AsyncWriter) Close() {
-	select {
-	case <-a.done:
-		return
-	default:
-	}
-	close(a.ch)
+	a.closeOnce.Do(func() {
+		close(a.stop)
+	})
 	<-a.done
 }
 
+// drain reads from a.ch until stop is signalled and the queue is
+// empty, writing each payload to the underlying writer. The data
+// channel is never closed, so Writes racing with Close cannot panic.
 func (a *AsyncWriter) drain() {
 	defer close(a.done)
-	for line := range a.ch {
-		// Errors writing to the underlying writer are ignored: we
-		// can't surface them anywhere safer than the writer that
-		// just failed. The async wrapper's job is only to keep
-		// callers unblocked.
-		if _, err := a.underlying.Write(line); err == nil {
-			a.written.Add(1)
+	for {
+		select {
+		case line := <-a.ch:
+			a.writeLine(line)
+		case <-a.stop:
+			// Flush whatever is still buffered after stop. Use a
+			// non-blocking inner select so we exit promptly once
+			// the buffer is empty.
+			for {
+				select {
+				case line := <-a.ch:
+					a.writeLine(line)
+				default:
+					return
+				}
+			}
 		}
+	}
+}
+
+// writeLine writes one payload to the underlying writer. Errors are
+// ignored — there is no safer place to surface them than the writer
+// that just failed. The async wrapper's only job is to keep callers
+// unblocked.
+func (a *AsyncWriter) writeLine(line []byte) {
+	if _, err := a.underlying.Write(line); err == nil {
+		a.written.Add(1)
 	}
 }

--- a/internal/logging/async_writer.go
+++ b/internal/logging/async_writer.go
@@ -1,0 +1,101 @@
+package logging
+
+import (
+	"io"
+	"sync/atomic"
+)
+
+// AsyncWriter is a non-blocking io.Writer wrapper. Each Write copies the
+// payload into a bounded channel and returns immediately; a single
+// background goroutine drains the channel and writes to the underlying
+// writer in order.
+//
+// When the channel is full (i.e. the underlying writer can't keep up —
+// typical cause: the platform log shipper has backpressured the stdout
+// pipe), Write drops the payload and increments a counter rather than
+// blocking the caller.
+//
+// This protects every goroutine in the process from logging-induced
+// wedges: a goroutine that holds a DB transaction or a mutex can no
+// longer get stuck inside slog.Handler.Handle waiting on the OS pipe.
+//
+// Trade-off: under sustained backpressure some log lines are lost. The
+// alternative — blocking — has been observed in production to wedge
+// goroutines that hold DB connections, leaving Postgres sessions in
+// `idle in transaction (aborted)` for tens of minutes (HOVER-K* class
+// of incidents).
+type AsyncWriter struct {
+	ch         chan []byte
+	dropped    atomic.Uint64
+	written    atomic.Uint64
+	underlying io.Writer
+	done       chan struct{}
+}
+
+// NewAsyncWriter wraps underlying with a bounded async writer. bufferSize
+// is the max number of pending log lines; choose generously enough to
+// absorb burst spikes (the common case) but bounded enough to bound
+// memory under sustained backpressure. 8192 is a reasonable default.
+func NewAsyncWriter(underlying io.Writer, bufferSize int) *AsyncWriter {
+	if bufferSize <= 0 {
+		bufferSize = 8192
+	}
+	aw := &AsyncWriter{
+		ch:         make(chan []byte, bufferSize),
+		underlying: underlying,
+		done:       make(chan struct{}),
+	}
+	go aw.drain()
+	return aw
+}
+
+// Write copies p into the channel and returns. It never blocks: when the
+// channel is full the payload is dropped and the dropped counter is
+// incremented. The returned n is always len(p) so that slog handlers
+// don't treat a drop as a partial write.
+func (a *AsyncWriter) Write(p []byte) (int, error) {
+	// slog handlers reuse their internal buffer across records, so we
+	// must copy before queuing.
+	cp := make([]byte, len(p))
+	copy(cp, p)
+	select {
+	case a.ch <- cp:
+		// queued
+	default:
+		a.dropped.Add(1)
+	}
+	return len(p), nil
+}
+
+// Dropped returns the cumulative number of log lines dropped due to a
+// full buffer. Exposed for metrics surface.
+func (a *AsyncWriter) Dropped() uint64 { return a.dropped.Load() }
+
+// Written returns the cumulative number of log lines successfully
+// written to the underlying writer.
+func (a *AsyncWriter) Written() uint64 { return a.written.Load() }
+
+// Close stops the drain goroutine after flushing any queued lines.
+// Safe to call multiple times.
+func (a *AsyncWriter) Close() {
+	select {
+	case <-a.done:
+		return
+	default:
+	}
+	close(a.ch)
+	<-a.done
+}
+
+func (a *AsyncWriter) drain() {
+	defer close(a.done)
+	for line := range a.ch {
+		// Errors writing to the underlying writer are ignored: we
+		// can't surface them anywhere safer than the writer that
+		// just failed. The async wrapper's job is only to keep
+		// callers unblocked.
+		if _, err := a.underlying.Write(line); err == nil {
+			a.written.Add(1)
+		}
+	}
+}

--- a/internal/logging/async_writer_test.go
+++ b/internal/logging/async_writer_test.go
@@ -1,0 +1,151 @@
+package logging
+
+import (
+	"bytes"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// blockingWriter blocks every Write until release is closed.
+type blockingWriter struct {
+	released chan struct{}
+	written  atomic.Uint64
+}
+
+func newBlockingWriter() *blockingWriter {
+	return &blockingWriter{released: make(chan struct{})}
+}
+
+func (b *blockingWriter) Write(p []byte) (int, error) {
+	<-b.released
+	b.written.Add(1)
+	return len(p), nil
+}
+
+func (b *blockingWriter) Release() { close(b.released) }
+
+func TestAsyncWriter_WriteIsNonBlocking(t *testing.T) {
+	t.Parallel()
+
+	bw := newBlockingWriter()
+	aw := NewAsyncWriter(bw, 4) // tiny buffer
+	defer aw.Close()
+
+	// First few writes should buffer fine. Subsequent writes (after the
+	// underlying blocks) should drop rather than block the caller. We
+	// fire many writes in succession and verify none take longer than a
+	// generous threshold — proving the caller never blocked on the
+	// underlying writer.
+	const totalWrites = 100
+	start := time.Now()
+	for i := 0; i < totalWrites; i++ {
+		n, err := aw.Write([]byte("log line\n"))
+		if err != nil {
+			t.Fatalf("Write returned error: %v", err)
+		}
+		if n != len("log line\n") {
+			t.Fatalf("Write returned partial length %d", n)
+		}
+	}
+	elapsed := time.Since(start)
+	if elapsed > 100*time.Millisecond {
+		t.Fatalf("Writes took %v, expected near-instant since underlying is blocked", elapsed)
+	}
+
+	// Most writes should have been dropped (only the buffer's worth queued).
+	dropped := aw.Dropped()
+	if dropped == 0 {
+		t.Fatal("expected drops when underlying blocked, got 0")
+	}
+	if dropped > totalWrites {
+		t.Fatalf("dropped %d > total %d, accounting bug", dropped, totalWrites)
+	}
+
+	// Releasing the underlying lets the drain goroutine catch up.
+	bw.Release()
+	// Close flushes the queue and waits for drain to exit.
+	aw.Close()
+
+	written := aw.Written()
+	if written == 0 {
+		t.Fatal("expected some writes to reach the underlying after release")
+	}
+	if written+dropped < totalWrites {
+		t.Fatalf("written(%d)+dropped(%d) = %d < total(%d)", written, dropped, written+dropped, totalWrites)
+	}
+}
+
+func TestAsyncWriter_DeliversToUnderlying(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	var mu sync.Mutex
+	w := writeFn(func(p []byte) (int, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		return buf.Write(p)
+	})
+	aw := NewAsyncWriter(w, 64)
+
+	for i := 0; i < 10; i++ {
+		_, _ = aw.Write([]byte("line\n"))
+	}
+	aw.Close()
+
+	mu.Lock()
+	defer mu.Unlock()
+	got := buf.String()
+	if got != "line\nline\nline\nline\nline\nline\nline\nline\nline\nline\n" {
+		t.Fatalf("unexpected delivered output: %q", got)
+	}
+}
+
+func TestAsyncWriter_CloseIsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	aw := NewAsyncWriter(writeFn(func(p []byte) (int, error) { return len(p), nil }), 4)
+	aw.Close()
+	aw.Close() // must not panic
+}
+
+func TestAsyncWriter_CopiesPayload(t *testing.T) {
+	t.Parallel()
+
+	var seen [][]byte
+	var mu sync.Mutex
+	w := writeFn(func(p []byte) (int, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		// Copy so a later reuse of p doesn't corrupt our record.
+		cp := make([]byte, len(p))
+		copy(cp, p)
+		seen = append(seen, cp)
+		return len(p), nil
+	})
+	aw := NewAsyncWriter(w, 64)
+
+	// Reuse the same buffer (mimicking slog handler behaviour) — verifying
+	// that the async writer copies and isn't subject to the in-place
+	// mutation.
+	buf := []byte("first ")
+	_, _ = aw.Write(buf)
+	buf[0] = 'X'
+	_, _ = aw.Write([]byte("second"))
+	aw.Close()
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(seen) < 2 {
+		t.Fatalf("expected at least 2 deliveries, got %d", len(seen))
+	}
+	if string(seen[0]) != "first " {
+		t.Fatalf("first delivery mutated: %q", seen[0])
+	}
+}
+
+// writeFn adapts a function into an io.Writer.
+type writeFn func(p []byte) (int, error)
+
+func (f writeFn) Write(p []byte) (int, error) { return f(p) }

--- a/internal/logging/async_writer_test.go
+++ b/internal/logging/async_writer_test.go
@@ -145,6 +145,49 @@ func TestAsyncWriter_CopiesPayload(t *testing.T) {
 	}
 }
 
+func TestAsyncWriter_ConcurrentWriteAndClose(t *testing.T) {
+	t.Parallel()
+
+	// Many concurrent writers racing with Close must never panic and
+	// every Write must return without blocking. Reproduces the
+	// send-on-closed-channel and double-close races that the previous
+	// implementation could trip.
+	for round := 0; round < 50; round++ {
+		aw := NewAsyncWriter(writeFn(func(p []byte) (int, error) { return len(p), nil }), 32)
+
+		var wg sync.WaitGroup
+		const writers = 32
+		wg.Add(writers)
+		for i := 0; i < writers; i++ {
+			go func() {
+				defer wg.Done()
+				for j := 0; j < 200; j++ {
+					_, _ = aw.Write([]byte("racing\n"))
+				}
+			}()
+		}
+
+		// Concurrent closers: must be idempotent.
+		var closeWg sync.WaitGroup
+		closeWg.Add(4)
+		for c := 0; c < 4; c++ {
+			go func() {
+				defer closeWg.Done()
+				aw.Close()
+			}()
+		}
+
+		wg.Wait()
+		closeWg.Wait()
+
+		// Sanity: at least one write was either delivered or dropped
+		// — never blocked.
+		if aw.Written()+aw.Dropped() == 0 {
+			t.Fatalf("round %d: no writes accounted for", round)
+		}
+	}
+}
+
 // writeFn adapts a function into an io.Writer.
 type writeFn func(p []byte) (int, error)
 

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -215,10 +215,28 @@ func (h *fanoutHandler) WithGroup(name string) slog.Handler {
 	return &fanoutHandler{handlers: handlers}
 }
 
+// stdoutAsync is the active async wrapper around os.Stdout, set by
+// Setup. Exposed via StdoutAsync so callers (e.g. metrics surface)
+// can read drop/written counters.
+var stdoutAsync *AsyncWriter
+
+// StdoutAsync returns the AsyncWriter wrapping os.Stdout, or nil if
+// Setup has not been called or async logging is disabled (development).
+func StdoutAsync() *AsyncWriter { return stdoutAsync }
+
 // Setup configures the global slog default with both stdout output and
 // Sentry capture. Call this after sentry.Init() during application startup.
 //
-// In development, logs are human-readable text. In production, JSON.
+// In development, logs are human-readable text written synchronously to
+// stdout (so test output is deterministic).
+//
+// In production, logs are JSON written through an AsyncWriter: every
+// slog.Write enqueues into a bounded channel and returns immediately, so
+// no goroutine can wedge inside slog.Handler.Handle waiting on the OS
+// stdout pipe. When the platform log shipper backpressures the pipe,
+// log lines are dropped (with a counter) rather than blocking caller
+// goroutines that may hold DB transactions or other resources.
+//
 // Error-level logs are auto-captured to Sentry with component tags
 // and static fingerprints.
 func Setup(level slog.Level, env string) {
@@ -229,7 +247,8 @@ func Setup(level slog.Level, env string) {
 	if env == "development" {
 		outputHandler = slog.NewTextHandler(os.Stdout, opts)
 	} else {
-		outputHandler = slog.NewJSONHandler(os.Stdout, opts)
+		stdoutAsync = NewAsyncWriter(os.Stdout, 8192)
+		outputHandler = slog.NewJSONHandler(stdoutAsync, opts)
 	}
 
 	sentryHandler := sentryslog.Option{

--- a/internal/watchdog/watchdog.go
+++ b/internal/watchdog/watchdog.go
@@ -1,0 +1,147 @@
+// Package watchdog detects worker process wedges and forcibly exits so
+// the platform's restart policy can recover the service.
+//
+// The pattern is deliberately simple: a heartbeat counter is bumped from
+// the hot path (per-task completion in the worker), and a background
+// loop verifies the counter has advanced within the configured stall
+// window. If the counter has not advanced AND a "should be working"
+// predicate returns true, the process logs a high-priority message and
+// calls os.Exit(1).
+//
+// This is the last line of defence against latent Go-side wedges (e.g.
+// blocked stdout pipe, mutex deadlock, exhausted resource pool) that no
+// amount of in-process recovery can clear. It does not replace fixing
+// the underlying cause — it bounds the blast radius while the real fix
+// is being developed.
+package watchdog
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"sync/atomic"
+	"time"
+)
+
+// Heartbeat is a monotonically increasing counter representing forward
+// progress in the worker's hot path. The watchdog observes the counter
+// at intervals; failure to increase across a stall window combined with
+// active workload triggers a forced exit.
+type Heartbeat struct {
+	beats atomic.Uint64
+}
+
+// Tick increments the heartbeat counter. Cheap and lock-free; safe to
+// call from hot paths.
+func (h *Heartbeat) Tick() { h.beats.Add(1) }
+
+// Read returns the current heartbeat value.
+func (h *Heartbeat) Read() uint64 { return h.beats.Load() }
+
+// Options configures Run.
+type Options struct {
+	// StallThreshold is how long the heartbeat may stay flat before
+	// the watchdog considers the worker wedged. Default 90s.
+	StallThreshold time.Duration
+
+	// CheckInterval is how often the watchdog samples. Default 15s.
+	CheckInterval time.Duration
+
+	// GracePeriod after Run starts before any check fires; protects
+	// against trip during slow startup. Default 2 minutes.
+	GracePeriod time.Duration
+
+	// HasWork returns true if the worker should be doing something.
+	// When false (no jobs alive), heartbeat staleness is ignored.
+	// If nil, the watchdog assumes work always exists.
+	HasWork func(ctx context.Context) bool
+
+	// Logger receives the pre-exit message; required.
+	Logger *slog.Logger
+
+	// Exit is called when a wedge is detected. Tests substitute a
+	// non-fatal handler; production leaves it nil so the default
+	// (os.Exit(1)) runs.
+	Exit func(code int)
+}
+
+// Run drives the watchdog loop until ctx is cancelled. Heartbeat is
+// observed every CheckInterval; if the heartbeat hasn't advanced in
+// StallThreshold and HasWork() is true, the configured Exit is called.
+func Run(ctx context.Context, hb *Heartbeat, opts Options) {
+	if hb == nil {
+		return
+	}
+	if opts.StallThreshold <= 0 {
+		opts.StallThreshold = 90 * time.Second
+	}
+	if opts.CheckInterval <= 0 {
+		opts.CheckInterval = 15 * time.Second
+	}
+	if opts.GracePeriod <= 0 {
+		opts.GracePeriod = 2 * time.Minute
+	}
+	if opts.Exit == nil {
+		opts.Exit = os.Exit
+	}
+	if opts.Logger == nil {
+		opts.Logger = slog.Default()
+	}
+
+	startedAt := time.Now()
+	lastBeats := hb.Read()
+	lastChange := time.Now()
+
+	timer := time.NewTicker(opts.CheckInterval)
+	defer timer.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case now := <-timer.C:
+			cur := hb.Read()
+			if cur != lastBeats {
+				lastBeats = cur
+				lastChange = now
+				continue
+			}
+
+			if now.Sub(startedAt) < opts.GracePeriod {
+				continue
+			}
+
+			stallFor := now.Sub(lastChange)
+			if stallFor < opts.StallThreshold {
+				continue
+			}
+
+			hasWork := true
+			if opts.HasWork != nil {
+				// Bound the work check so it can't itself wedge the
+				// watchdog.
+				checkCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+				hasWork = opts.HasWork(checkCtx)
+				cancel()
+			}
+			if !hasWork {
+				// Reset the change timestamp so we don't trip
+				// immediately when work resumes.
+				lastChange = now
+				continue
+			}
+
+			opts.Logger.Error(
+				"worker wedge detected — heartbeat stale with active workload, forcing process exit so platform restarts",
+				"stall_for", stallFor.String(),
+				"stall_threshold", opts.StallThreshold.String(),
+				"heartbeat", cur,
+			)
+			// Best-effort flush of stdout so the message reaches the
+			// log shipper before the process dies. Ignore errors.
+			_ = os.Stdout.Sync()
+			opts.Exit(1)
+			return
+		}
+	}
+}

--- a/internal/watchdog/watchdog_test.go
+++ b/internal/watchdog/watchdog_test.go
@@ -1,0 +1,176 @@
+package watchdog
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func TestRun_TripsWhenHeartbeatStallsAndWorkExists(t *testing.T) {
+	t.Parallel()
+
+	hb := &Heartbeat{}
+	var exitCode atomic.Int32
+	exitCode.Store(-1)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		Run(ctx, hb, Options{
+			StallThreshold: 30 * time.Millisecond,
+			CheckInterval:  10 * time.Millisecond,
+			GracePeriod:    1 * time.Millisecond,
+			HasWork:        func(_ context.Context) bool { return true },
+			Logger:         discardLogger(),
+			Exit: func(code int) {
+				// Exit codes are bounded to small positive
+				// integers; the conversion is safe and avoids
+				// the gosec G115 false-positive on int->int32.
+				if code >= 0 && code <= 255 {
+					exitCode.Store(int32(code))
+				}
+				cancel()
+			},
+		})
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("watchdog did not trip within timeout")
+	}
+
+	if exitCode.Load() != 1 {
+		t.Fatalf("expected exit code 1, got %d", exitCode.Load())
+	}
+}
+
+func TestRun_DoesNotTripWhileHeartbeatAdvances(t *testing.T) {
+	t.Parallel()
+
+	hb := &Heartbeat{}
+	var tripped atomic.Bool
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Tick at 5ms while watchdog stall threshold is 50ms — heartbeat
+	// always fresh, so the watchdog must not trip.
+	tickerStop := make(chan struct{})
+	go func() {
+		t := time.NewTicker(5 * time.Millisecond)
+		defer t.Stop()
+		for {
+			select {
+			case <-tickerStop:
+				return
+			case <-t.C:
+				hb.Tick()
+			}
+		}
+	}()
+	defer close(tickerStop)
+
+	go Run(ctx, hb, Options{
+		StallThreshold: 50 * time.Millisecond,
+		CheckInterval:  10 * time.Millisecond,
+		GracePeriod:    1 * time.Millisecond,
+		HasWork:        func(_ context.Context) bool { return true },
+		Logger:         discardLogger(),
+		Exit: func(code int) {
+			tripped.Store(true)
+		},
+	})
+
+	time.Sleep(300 * time.Millisecond)
+	cancel()
+	time.Sleep(20 * time.Millisecond)
+
+	if tripped.Load() {
+		t.Fatal("watchdog tripped despite advancing heartbeat")
+	}
+}
+
+func TestRun_DoesNotTripDuringGracePeriod(t *testing.T) {
+	t.Parallel()
+
+	hb := &Heartbeat{}
+	var tripped atomic.Bool
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go Run(ctx, hb, Options{
+		StallThreshold: 5 * time.Millisecond,
+		CheckInterval:  5 * time.Millisecond,
+		GracePeriod:    200 * time.Millisecond,
+		HasWork:        func(_ context.Context) bool { return true },
+		Logger:         discardLogger(),
+		Exit: func(code int) {
+			tripped.Store(true)
+		},
+	})
+
+	// Sleep for less than the grace period — heartbeat is flat, but
+	// the watchdog should hold off.
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+	time.Sleep(20 * time.Millisecond)
+
+	if tripped.Load() {
+		t.Fatal("watchdog tripped inside grace period")
+	}
+}
+
+func TestRun_DoesNotTripWhenNoWork(t *testing.T) {
+	t.Parallel()
+
+	hb := &Heartbeat{}
+	var tripped atomic.Bool
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go Run(ctx, hb, Options{
+		StallThreshold: 30 * time.Millisecond,
+		CheckInterval:  10 * time.Millisecond,
+		GracePeriod:    1 * time.Millisecond,
+		HasWork:        func(_ context.Context) bool { return false },
+		Logger:         discardLogger(),
+		Exit: func(code int) {
+			tripped.Store(true)
+		},
+	})
+
+	time.Sleep(200 * time.Millisecond)
+	cancel()
+	time.Sleep(20 * time.Millisecond)
+
+	if tripped.Load() {
+		t.Fatal("watchdog tripped despite HasWork returning false")
+	}
+}
+
+func TestHeartbeat_TickAdvances(t *testing.T) {
+	t.Parallel()
+
+	hb := &Heartbeat{}
+	if hb.Read() != 0 {
+		t.Fatalf("expected initial heartbeat 0, got %d", hb.Read())
+	}
+	hb.Tick()
+	hb.Tick()
+	if hb.Read() != 2 {
+		t.Fatalf("expected heartbeat 2 after two ticks, got %d", hb.Read())
+	}
+}


### PR DESCRIPTION
## Summary

Operational defences against the worker-wedge incident observed in production at 2026-04-25 20:31 AEST: 30+ Postgres sessions stuck in `idle in transaction (aborted)` for 21+ minutes after the worker stopped emitting logs entirely. Diagnosis pointed to a Go-side wedge (most likely platform log-shipper backpressure on `os.Stdout`) preventing goroutines from progressing past their error-logging branches and reaching `tx.Rollback()`.

This PR adds the wedge-prevention layer plus a small revert of PR #349's leftover wide UPDATE. Phase 3 (statement-level trigger conversion to address the underlying deadlock contention) is deliberately deferred to a separate, properly-tested PR.

## Changes

### Operational defences

- **`internal/watchdog`**: heartbeat-based wedge detector. The stream worker pool ticks the heartbeat per task outcome; a background loop forces `os.Exit(1)` if the heartbeat goes flat for 90s while jobs are alive, triggering Fly's `restart=always` policy. Last-resort recovery for any Go-side wedge that no in-process recovery can clear.
- **`internal/logging.AsyncWriter`**: bounded non-blocking `io.Writer` wrapping `os.Stdout` in production. slog handlers enqueue into a drop-on-overflow channel rather than synchronously writing to the pipe. Prevents goroutines that hold DB transactions or other resources from wedging on platform log-shipper backpressure.
- **pprof on worker**: mounted on the existing `:9464` metrics port alongside `/metrics`. Enables `fly proxy 9464 -a hover-worker` to capture goroutine dumps without redeploying — closes the diagnostic gap that prevented direct root-cause analysis of this incident.
- **Eager `tx.Rollback()`** in `executeOnceWithContext`: on error from either `applyLocalStatementTimeout` or `fn`, roll back immediately before any logging, with the deferred rollback suppressed via `committed=true`. The deferred-only pattern was vulnerable to anything blocking between the error-receive and the function return holding the connection open.

### Counter-sync hardening

- **`GREATEST(0, $1)` clamp** on per-job `running_tasks` UPDATEs. Eliminates the 6/min `jobs_running_tasks_non_negative` constraint violations (HOVER-K4) caused by a transient Redis underflow race between `HIncrBy(-1)` and the cleanup `HDel`.
- **Removed the wide post-batch `UPDATE jobs SET running_tasks = 0 WHERE running_tasks > 0 AND id != ALL(...)`**. Walking job rows in index order acquired locks that deadlocked against the AFTER trigger `update_job_queue_counters` fired by concurrent task UPDATEs. The reconcile loop (`REDIS_COUNTER_RECONCILE_INTERVAL_S=120`) authoritatively rebuilds Redis state every two minutes, so missing this sweep only delays the `running_tasks=0` reflection in PG by at most one reconcile interval.

## Out of scope

The dominant deadlock pattern (~808/min `failed to get job configuration and task count` and ~96/min `failed to batch update completed tasks`) is structural: AFTER FOR EACH ROW triggers on `tasks` UPDATEs serialise concurrent batch operations on overlapping job sets. Converting both triggers to FOR EACH STATEMENT with transition tables is the proper architectural fix. That work needs local Supabase testing infrastructure and a dedicated load test against the review app to validate trigger semantics (status preservation, terminal-state detection, cancel-then-complete races) — deferred to a follow-up PR.

After this lands and the watchdog/eager-rollback proves stable, the chronic deadlock noise will continue but the worker can no longer wedge silently. Phase 3 will then eliminate the noise.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (all packages pass; new tests for watchdog + AsyncWriter)
- [x] `golangci-lint run ./...` (clean)
- [ ] Review app: confirm worker starts, `/debug/pprof/goroutine` reachable via `fly proxy 9464`, `bee.broker.counter_sync_skew` metric still emits, no startup regressions
- [ ] Force a wedge scenario on the review app (e.g. `kill -STOP` the alloy sidecar to back-pressure stdout) and verify the watchdog trips inside 90s + the worker restarts cleanly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Worker watchdog that detects stalled workers and triggers restart
  * Asynchronous bounded stdout logging with drop-on-overflow semantics and flush-on-exit
  * pprof diagnostic endpoints exposed on the worker metrics port

* **Bug Fixes**
  * Redis counter writes clamped to prevent negative job counts
  * More reliable transaction rollback on error paths

* **Tests**
  * Added watchdog and async-logging test suites
<!-- end of auto-generated comment: release notes by coderabbit.ai -->