### PR TITLE
Reset usage and integration tables

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -649,8 +649,32 @@ func (db *DB) ResetDataOnly() error {
 	dbLog.Warn("Clearing all data from database tables (schema preserved)")
 
 	// Use TRUNCATE instead of DELETE - it's atomic, faster, and handles concurrent access better
-	// TRUNCATE automatically handles foreign key constraints with CASCADE
-	tables := []string{"tasks", "jobs", "job_share_links", "schedulers", "pages", "domains", "page_analytics", "domain_hosts", "notifications"}
+	// TRUNCATE automatically handles foreign key constraints with CASCADE.
+	//
+	// Anything that holds operational state (jobs, tasks, usage counters,
+	// integration connections) is cleared. users, organisations,
+	// organisation_members and plans are deliberately preserved so the
+	// admin operator stays signed in and reference data survives.
+	tables := []string{
+		"tasks",
+		"jobs",
+		"job_share_links",
+		"schedulers",
+		"pages",
+		"domains",
+		"page_analytics",
+		"domain_hosts",
+		"notifications",
+		"daily_usage",
+		"organisation_domains",
+		"platform_org_mappings",
+		"google_analytics_accounts",
+		"google_analytics_connections",
+		"slack_connections",
+		"slack_user_links",
+		"webflow_connections",
+		"webflow_site_settings",
+	}
 	totalRowsDeleted := int64(0)
 
 	dbLog.Info("Step 1/2: Truncating all data from tables")


### PR DESCRIPTION
## Summary
- Adds `daily_usage`, `organisation_domains`, `platform_org_mappings`, `google_analytics_accounts`, `google_analytics_connections`, `slack_connections`, `slack_user_links`, `webflow_connections`, `webflow_site_settings` to the `ResetDataOnly` TRUNCATE list.
- Operator-visible follow-up to #354 / 1d1b9bd3 (the Redis-clear change): the admin "Reset data" button now also wipes usage counters (the `796,055/1,000,000` daily figure) and integration state, so a fresh slate is genuinely fresh.
- `users`, `organisations`, `organisation_members`, and `plans` are deliberately preserved so the operator stays signed in and reference data survives.

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./internal/db ./internal/api` pass
- [ ] Manual end-to-end on a review app: hit `POST /v1/admin/reset-data` and confirm the daily-usage chip resets to 0 and integrations show as disconnected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced data reset functionality to clear more operational data, including usage analytics counters and integration connection mappings, while preserving user accounts, organizations, and subscription plans.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->