### PR TITLE
Land Lighthouse Phase 3 local runner

### DIFF
--- a/Dockerfile.analysis
+++ b/Dockerfile.analysis
@@ -1,15 +1,20 @@
 # Dockerfile.analysis — image for hover-analysis (lighthouse audit service).
 #
-# Phase 2 ships the Go binary only — no Chromium, no lighthouse npm.
-# The analysis service runs the StubRunner in this state, exercising
-# the producer → stream → consumer pipeline end-to-end with canned data.
-# Phase 3 adds:
-#   - Chromium (system package)
-#   - `npm install -g lighthouse@<pinned>`
-#   - LIGHTHOUSE_RUNNER=local default
+# Phase 3 layers Chromium and the lighthouse npm package on top of the
+# analysis Go binary. The runtime stage is node:20-slim (Debian bookworm)
+# rather than Alpine so we can pull Chromium from Debian's main repo —
+# Debian's chromium tracks upstream within days, while Alpine's
+# chromium package historically lags by weeks and carries unpatched CVEs
+# longer.
 #
-# Kept separate from the main Dockerfile so the heavyweight Chromium
-# layers do not bloat hover and hover-worker images.
+# Confined to this Dockerfile only; the main Dockerfile (hover, hover-worker)
+# stays lean and Alpine-based.
+#
+# Pin discipline: chromium and lighthouse are pinned to exact versions
+# below. Bumps are a deliberate Dockerfile change, not a "latest" drift.
+# Schedule: bump monthly to track Chromium's stable channel for security
+# fixes (Debian publishes within days of upstream). See
+# docs/plans/lighthouse-performance-reports.md § Phase 3 for context.
 
 FROM grafana/alloy:v1.15.1@sha256:1f40cf52adda8fab3e058f9347a5d165624ecb9fbc1527769cb744748961940d AS alloy
 
@@ -24,27 +29,58 @@ COPY . .
 
 RUN CGO_ENABLED=0 GOOS=linux go build -o analysis ./cmd/analysis/main.go
 
-FROM alpine:3.19
+FROM node:20-slim AS runtime
 
-RUN adduser -D -g '' appuser
+# Chromium plus the few runtime libs Lighthouse needs and ca-certificates
+# for outbound HTTPS (Supabase, OTLP, Grafana Cloud, R2). fonts-liberation
+# stops Chromium falling back to bitmap fonts on JS-heavy pages, which
+# breaks rendering audits.
+#
+# TODO(phase3): pin chromium=<exact> after first successful build to make
+# the bump cadence deliberate. Left unpinned now so the initial build
+# resolves whatever Debian bookworm currently ships, and we capture that
+# version in a follow-up commit on this PR.
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+    chromium \
+    chromium-sandbox \
+    ca-certificates \
+    fonts-liberation \
+    dumb-init \
+  && rm -rf /var/lib/apt/lists/*
+
+# Lighthouse CLI. Pinned to the 12.x line; bump in lockstep with Chromium.
+RUN npm install -g lighthouse@12.2.1 \
+  && npm cache clean --force
+
+# Non-root runtime user mirrors the previous Alpine image's appuser.
+RUN useradd --create-home --shell /bin/sh --uid 10001 appuser
 
 WORKDIR /app
-
-# ca-certificates for HTTPS to Grafana / OTLP / Supabase; gcompat for the
-# Alloy sidecar's glibc dependency.
-RUN apk --no-cache add \
-  ca-certificates=20250911-r0 \
-  gcompat=1.1.0-r4
 
 COPY --from=builder /app/analysis .
 
 # Alloy sidecar so the analysis service emits app/environment-tagged
 # metrics without each pod needing its own Prometheus push secret.
+# Debian's glibc means no gcompat shim is needed — it ran on Alpine
+# only because Alpine ships musl.
 COPY --from=alloy /bin/alloy /usr/local/bin/alloy
 COPY alloy.river .
 COPY scripts/start-analysis.sh ./start.sh
-RUN chmod +x start.sh /usr/local/bin/alloy
+RUN chmod +x start.sh /usr/local/bin/alloy \
+  && chown -R appuser:appuser /app
+
+# CHROMIUM_BIN / LIGHTHOUSE_BIN are baked here so cmd/analysis can read
+# them via env without each Fly toml having to repeat the paths. The
+# tomls still set them so a misconfigured base image fails loudly rather
+# than silently picking up a different binary.
+ENV CHROMIUM_BIN=/usr/bin/chromium \
+    LIGHTHOUSE_BIN=/usr/local/bin/lighthouse
 
 USER appuser
 
+# dumb-init reaps zombies left behind by Chromium renderer crashes.
+# Without it the analysis container accumulates defunct processes over
+# time and eventually exhausts the PID table.
+ENTRYPOINT ["dumb-init", "--"]
 CMD ["./start.sh"]

--- a/cmd/analysis/main.go
+++ b/cmd/analysis/main.go
@@ -598,6 +598,11 @@ func (c *consumer) processOne(ctx context.Context, req lighthouse.AuditRequest, 
 				"run_id", req.RunID, "job_id", req.JobID,
 				"duration_ms", duration.Milliseconds(),
 			)
+			// Tick the shed outcome so a rising shed rate on Grafana
+			// is the unambiguous signal that the analysis fleet is
+			// memory-saturated. No duration histogram bucket — these
+			// audits never actually ran.
+			observability.RecordLighthouseRun(ctx, req.JobID, "shed")
 			return
 		}
 		// Shutdown cancellation must not be turned into a permanent

--- a/cmd/analysis/main.go
+++ b/cmd/analysis/main.go
@@ -24,6 +24,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/Harvey-AU/hover/internal/archive"
 	"github.com/Harvey-AU/hover/internal/broker"
 	"github.com/Harvey-AU/hover/internal/db"
 	"github.com/Harvey-AU/hover/internal/lighthouse"
@@ -142,9 +143,6 @@ func main() {
 	}
 	analysisLog.Info("connected to Redis")
 
-	// --- runner ---
-	runner := selectRunner()
-
 	// --- root context tied to OS signals ---
 	rootCtx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer cancel()
@@ -154,7 +152,18 @@ func main() {
 		"max_concurrency", cfg.maxConcurrency,
 		"audit_timeout_ms", cfg.auditTimeout.Milliseconds(),
 		"poll_interval_ms", cfg.pollInterval.Milliseconds(),
+		"runner", cfg.runner,
+		"memory_shed_mb", cfg.memoryShedMB,
 	)
+
+	// --- archive provider (only required by the local runner) ---
+	provider, bucket := loadArchiveProvider(rootCtx, cfg.runner)
+
+	// --- runner ---
+	runner, err := selectRunner(cfg, provider, bucket)
+	if err != nil {
+		analysisLog.Fatal("failed to construct lighthouse runner", "error", err)
+	}
 
 	consumer := newConsumer(pgDB, redisClient, runner, cfg)
 	consumer.run(rootCtx)
@@ -162,22 +171,72 @@ func main() {
 	analysisLog.Info("analysis service stopped")
 }
 
+// loadArchiveProvider builds a ColdStorageProvider from ARCHIVE_*
+// env vars. The stub runner doesn't need it, so a missing config is
+// only fatal when LIGHTHOUSE_RUNNER=local. For "stub" we log and
+// continue with a nil provider so review apps without R2 credentials
+// still boot.
+func loadArchiveProvider(ctx context.Context, runner string) (archive.ColdStorageProvider, string) {
+	cfg := archive.ConfigFromEnv()
+	if cfg == nil {
+		if runner == "local" {
+			analysisLog.Fatal("LIGHTHOUSE_RUNNER=local requires ARCHIVE_PROVIDER + ARCHIVE_BUCKET")
+		}
+		analysisLog.Info("archive provider unconfigured; stub runner doesn't need it")
+		return nil, ""
+	}
+	provider, err := archive.ProviderFromEnv()
+	if err != nil {
+		if runner == "local" {
+			analysisLog.Fatal("failed to construct archive provider", "error", err)
+		}
+		analysisLog.Warn("failed to construct archive provider; stub runner unaffected", "error", err)
+		return nil, ""
+	}
+	pingCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	if err := provider.Ping(pingCtx, cfg.Bucket); err != nil {
+		if runner == "local" {
+			analysisLog.Fatal("archive provider ping failed", "error", err, "bucket", cfg.Bucket)
+		}
+		analysisLog.Warn("archive provider ping failed; stub runner unaffected", "error", err)
+		return nil, ""
+	}
+	analysisLog.Info("archive provider ready", "provider", provider.Provider(), "bucket", cfg.Bucket)
+	return provider, cfg.Bucket
+}
+
 // runnerEnvKey selects the runner implementation. v1 only has the stub
 // runner; Phase 3 introduces 'local' which shells out to Chromium.
 const runnerEnvKey = "LIGHTHOUSE_RUNNER"
 
-func selectRunner() lighthouse.Runner {
-	choice := strings.ToLower(strings.TrimSpace(os.Getenv(runnerEnvKey)))
-	if choice == "" {
-		choice = "stub"
-	}
-	switch choice {
+// selectRunner builds the configured Runner. Returns an error rather
+// than falling back silently so a Dockerfile/toml drift (missing
+// LIGHTHOUSE_BIN, missing R2 credentials when local is requested) is a
+// loud boot failure rather than a degraded service that quietly stubs
+// every audit. Unknown choices stay loud-but-not-fatal: log and stub
+// so an inadvertent typo in env doesn't take the service down.
+func selectRunner(cfg consumerConfig, provider archive.ColdStorageProvider, bucket string) (lighthouse.Runner, error) {
+	switch cfg.runner {
 	case "stub":
 		analysisLog.Info("using stub lighthouse runner")
-		return lighthouse.NewStubRunner()
+		return lighthouse.NewStubRunner(), nil
+	case "local":
+		analysisLog.Info("using local lighthouse runner",
+			"lighthouse_bin", cfg.lighthouseBin,
+			"chromium_bin", cfg.chromiumBin,
+		)
+		return lighthouse.NewLocalRunner(lighthouse.LocalRunnerConfig{
+			LighthouseBin: cfg.lighthouseBin,
+			ChromiumBin:   cfg.chromiumBin,
+			Provider:      provider,
+			Bucket:        bucket,
+			MemoryShedMB:  cfg.memoryShedMB,
+			ProfilePreset: lighthouse.ProfileMobile,
+		})
 	default:
-		analysisLog.Warn("unknown LIGHTHOUSE_RUNNER value; falling back to stub", "requested", choice)
-		return lighthouse.NewStubRunner()
+		analysisLog.Warn("unknown LIGHTHOUSE_RUNNER value; falling back to stub", "requested", cfg.runner)
+		return lighthouse.NewStubRunner(), nil
 	}
 }
 
@@ -189,9 +248,19 @@ type consumerConfig struct {
 	reclaimInterval time.Duration
 	reclaimMinIdle  time.Duration
 	consumerName    string
+
+	// Phase 3 additions. Only consulted when runner == "local".
+	runner        string // "stub" | "local"
+	lighthouseBin string // path to bundled lighthouse CLI
+	chromiumBin   string // path to bundled Chromium binary
+	memoryShedMB  int    // free-memory floor before deferring an audit
 }
 
 func loadConsumerConfig() consumerConfig {
+	runner := strings.ToLower(strings.TrimSpace(os.Getenv(runnerEnvKey)))
+	if runner == "" {
+		runner = "stub"
+	}
 	cfg := consumerConfig{
 		maxConcurrency:  envIntDefault("LIGHTHOUSE_MAX_CONCURRENCY", 1),
 		auditTimeout:    time.Duration(envIntDefault("LIGHTHOUSE_AUDIT_TIMEOUT_MS", 90_000)) * time.Millisecond,
@@ -202,6 +271,10 @@ func loadConsumerConfig() consumerConfig {
 		// stream's REDIS_AUTOCLAIM_MIN_IDLE_S default and is safely
 		// longer than the per-audit timeout (default 90s) plus DB write.
 		reclaimMinIdle: time.Duration(envIntDefault("LIGHTHOUSE_RECLAIM_MIN_IDLE_S", 180)) * time.Second,
+		runner:         runner,
+		lighthouseBin:  strings.TrimSpace(os.Getenv("LIGHTHOUSE_BIN")),
+		chromiumBin:    strings.TrimSpace(os.Getenv("CHROMIUM_BIN")),
+		memoryShedMB:   envIntDefault("LIGHTHOUSE_MEMORY_SHED_THRESHOLD_MB", 600),
 	}
 	if cfg.maxConcurrency < 1 {
 		cfg.maxConcurrency = 1
@@ -483,7 +556,7 @@ func (c *consumer) dispatchMessages(
 func (c *consumer) processOne(ctx context.Context, req lighthouse.AuditRequest, msgID, streamKey, groupName string) {
 	startedAt := time.Now()
 
-	moved, err := c.db.MarkLighthouseRunRunning(ctx, req.RunID)
+	moved, sourceTaskID, err := c.db.MarkLighthouseRunRunning(ctx, req.RunID)
 	if err != nil {
 		analysisLog.Warn("MarkLighthouseRunRunning failed", "error", err,
 			"run_id", req.RunID, "job_id", req.JobID)
@@ -500,6 +573,7 @@ func (c *consumer) processOne(ctx context.Context, req lighthouse.AuditRequest, 
 		_ = c.rdb.RDB().XAck(ctx, streamKey, groupName, msgID).Err()
 		return
 	}
+	req.SourceTaskID = sourceTaskID
 
 	analysisLog.Info("lighthouse audit started",
 		"run_id", req.RunID, "job_id", req.JobID,
@@ -515,6 +589,17 @@ func (c *consumer) processOne(ctx context.Context, req lighthouse.AuditRequest, 
 
 	if runErr != nil {
 		duration := time.Since(startedAt)
+		// Memory-shed defers the audit just like a shutdown: leave the
+		// row in 'running' and skip the ACK so XAUTOCLAIM redelivers
+		// once memory recovers. Treating it as a permanent failure
+		// would burn the audit slot and we'd never re-attempt.
+		if errors.Is(runErr, lighthouse.ErrMemoryShed) {
+			analysisLog.Info("lighthouse audit shed (low memory); leaving for redelivery",
+				"run_id", req.RunID, "job_id", req.JobID,
+				"duration_ms", duration.Milliseconds(),
+			)
+			return
+		}
 		// Shutdown cancellation must not be turned into a permanent
 		// 'failed' row. SIGTERM cancels the root context, which would
 		// otherwise mark the in-flight audit failed AND ACK the stream

--- a/docs/plans/lighthouse-performance-reports.md
+++ b/docs/plans/lighthouse-performance-reports.md
@@ -24,10 +24,10 @@ Core Web Vitals without auditing the full site.
 - Mobile profile.
 - **Self-hosted Lighthouse** — Chromium plus the `lighthouse` npm package run
   in-process via a Go sidecar; no external API dependency.
-- Sample size: 2.5% of completed pages per extreme band (fastest + slowest) by
-  `tasks.response_time`. Single formula floored at 1, capped at 50 per band —
-  roughly 5% of pages on small/medium sites, capped at 100 audits per job on
-  large sites.
+- Sample size: `floor(sqrt(completed_pages) × 0.15)` per extreme band (fastest +
+  slowest) by `tasks.response_time`. Floored at 1, capped at 15 per band — every
+  site gets at least 1 fastest + 1 slowest, the cap binds at ~10,000 pages where
+  30 audits/job is still the budget ceiling.
 - Scheduling waves at every 10% milestone of crawl progress; sampler dedupes so
   the same page is not audited twice within one job.
 - Persistent storage of headline metrics plus the full Lighthouse JSON.
@@ -45,11 +45,11 @@ Core Web Vitals without auditing the full site.
 
 1. **Chromium delivery** — self-host. Bundle Chromium plus `lighthouse` into the
    analysis-app image; no PageSpeed Insights API.
-2. **Sampling** — 2.5% of completed pages per extreme band (fastest + slowest),
-   floored at 1, capped at 50 per band. Total audits ≈ 5% of pages, capped at
-   100 per job.
-3. **Per-job run cap** — 100 audits/job (50 fastest + 50 slowest), enforced by
-   the per-band cap of 50.
+2. **Sampling** — `floor(sqrt(completed_pages) × 0.15)` per extreme band
+   (fastest + slowest), floored at 1, capped at 15 per band. Sub-linear curve so
+   audit count tapers on large sites rather than scaling 1:1 with crawl size.
+3. **Per-job run cap** — 30 audits/job (15 fastest + 15 slowest), enforced by
+   the per-band cap of 15.
 4. **Profile** — mobile only for v1; desktop deferred.
 5. **Tenant budget** — handled by plan-tier max-audits-per-day, not a separate
    knob in this feature. The scheduler honours whatever the billing/plan layer
@@ -73,12 +73,12 @@ no timing data, so sampling has to join through `tasks`.
 successful tasks for the job:**
 
 ```go
-perBand := int(math.Round(float64(completedPages) * 0.025))
+perBand := int(math.Floor(math.Sqrt(float64(completedPages)) * 0.15))
 if perBand < 1 {
     perBand = 1
 }
-if perBand > 50 {
-    perBand = 50
+if perBand > 15 {
+    perBand = 15
 }
 ```
 
@@ -86,21 +86,24 @@ That's it — no piecewise tiers, no skip threshold. Take the top `perBand`
 fastest pages by `response_time` and the top `perBand` slowest. Enqueue
 Lighthouse runs for both bands.
 
-| Pages  | per_band | Total audits | % audited |
-| ------ | -------- | ------------ | --------- |
-| 10     | 1        | 2            | 20%       |
-| 50     | 1        | 2            | 4%        |
-| 100    | 3        | 6            | 6%        |
-| 200    | 5        | 10           | 5%        |
-| 500    | 13       | 26           | 5.2%      |
-| 1,000  | 25       | 50           | 5%        |
-| 2,000  | 50 (cap) | 100          | 5%        |
-| 5,000+ | 50 (cap) | 100          | ≤2%       |
+| Pages   | per_band  | Total audits | % audited |
+| ------- | --------- | ------------ | --------- |
+| 10      | 1 (floor) | 2            | 20%       |
+| 40      | 1 (floor) | 2            | 5%        |
+| 100     | 1         | 2            | 2%        |
+| 200     | 2         | 4            | 2%        |
+| 500     | 3         | 6            | 1.2%      |
+| 1,000   | 4         | 8            | 0.8%      |
+| 2,000   | 6         | 12           | 0.6%      |
+| 5,000   | 10        | 20           | 0.4%      |
+| 10,000  | 15 (cap)  | 30           | 0.3%      |
+| 20,000+ | 15 (cap)  | 30           | ≤0.15%    |
 
 Properties: floor of 1 per band means even a 5-page site gets 1 fastest + 1
-slowest. Cap of 50 binds at ~2,000 pages, where 100 audits is still 5%. Beyond
-that, audit count plateaus while the percentage tapers — the cost ceiling we
-want.
+slowest. The square-root curve gives small/medium sites generous coverage while
+keeping the audit fleet sub-linear. Cap of 15 binds at exactly 10,000 pages,
+where 30 audits is the per-job budget ceiling. Beyond that, audit count plateaus
+while %-audited tapers — the cost ceiling we want.
 
 **Dedupe and reconciliation:**
 
@@ -386,17 +389,33 @@ toml.
 
 **Sample wall-time (v1 defaults: 1 concurrent, 25 s avg per audit):**
 
-| Crawl size | Audits    | Wall time at concurrency 1 | At concurrency 5 |
-| ---------- | --------- | -------------------------- | ---------------- |
-| 100 pages  | 6         | ~2.5 min                   | ~30 s            |
-| 200        | 10        | ~4 min                     | ~50 s            |
-| 1,000      | 50        | ~21 min                    | ~4 min           |
-| 5,000      | 100 (cap) | ~42 min                    | ~8 min           |
-| 10,000+    | 100 (cap) | ~42 min                    | ~8 min           |
+| Crawl size | Audits   | Wall time at concurrency 1 | At concurrency 5 |
+| ---------- | -------- | -------------------------- | ---------------- |
+| 100 pages  | 2        | ~50 s                      | ~10 s            |
+| 200        | 4        | ~100 s                     | ~20 s            |
+| 1,000      | 8        | ~3.3 min                   | ~40 s            |
+| 5,000      | 20       | ~8 min                     | ~100 s           |
+| 10,000     | 30 (cap) | ~12.5 min                  | ~2.5 min         |
+| 50,000+    | 30 (cap) | ~12.5 min                  | ~2.5 min         |
 
-At v1 defaults a 1,000-page crawl's audits run for ~21 minutes — fine because
-crawl wall time at that size is typically longer. If audits ever drag past crawl
-completion, that's the signal to bump concurrency or add machines.
+At v1 defaults even a 10,000-page crawl's audits drain in ~12 minutes — well
+within typical crawl wall time. If audits ever drag past crawl completion,
+that's the signal to bump concurrency or add machines.
+
+**Throughput planning (steady-state crawler at 4,500 pages/min):**
+
+| Job-size mix           | Audits/min generated   | Drain rate @ v1 (1× perf-1x, ~2.4/min) |
+| ---------------------- | ---------------------- | -------------------------------------- |
+| Tiny sites (~10 pages) | ~900/min (floor binds) | overflowing — needs ~6× perf-4x        |
+| Typical (~200 pages)   | ~90/min                | overflowing — needs ~3× perf-4x        |
+| Large (~1,000 pages)   | ~36/min                | overflowing — needs ~1× perf-4x        |
+| Huge (5,000+ pages)    | ~27/min                | overflowing — needs ~1× perf-4x        |
+
+v1 (single perf-1x at concurrency 1) is sized for low-volume / single-tenant
+testing. Once ingestion sustains beyond a couple of jobs/min, scale via the
+sizing ladder above. The ZSET → stream → reclaim machinery is already
+multi-machine safe; scaling is `fly scale count` plus matching
+`min_machines_running` in the toml.
 
 **Failure handling:**
 
@@ -519,7 +538,8 @@ ALTER TABLE public.task_outbox
   stream. Reuse the existing `DomainPacer` so concurrent audits don't hammer one
   customer domain.
 - `internal/lighthouse/sampler.go` (new, shared package) — fastest/slowest band
-  selection via the single 2.5%-per-band formula, capped at 50.
+  selection via the `floor(sqrt(completed_pages) × 0.15)` per-band formula,
+  capped at 15.
 - `internal/lighthouse/scheduler.go` (new, shared package) — milestone-driven
   enqueue with quota enforcement and dedupe.
 - `internal/db/lighthouse.go` (new, shared) — insert/update/list helpers.
@@ -790,6 +810,26 @@ against an in-process consumer before the new app's CI surface lands.
   runner has no R2 upload). Phase 3 adds an `archive.ProviderFromEnv()` call
   gated on `LIGHTHOUSE_RUNNER=local` so review apps without R2 credentials still
   boot the stub runner.
+- **Two new observability surfaces** for the runner-specific failure modes Phase
+  2 couldn't see. Both are emitted by the same `hover/lighthouse` meter scope as
+  the existing counters so a single Grafana dashboard pivots across the
+  producer + consumer + runner halves of the pipeline.
+  - `bee.lighthouse.runs_total{outcome="shed"}` — ticks every time the soft
+    memory-shed circuit-breaker defers an audit. A rising shed rate is the
+    unambiguous "scale up the analysis fleet" signal; without this metric the
+    only evidence of saturation was the audit-duration histogram drifting up.
+  - `bee.lighthouse.run_retries_total{reason}` — increments when the runner's
+    one-shot retry fires on a recognised transient stderr (`target_crashed`,
+    `protocol_error`, `page_crashed`, `target_closed`, `websocket_closed`).
+    Catches Chromium flakes that recover on a second attempt, so a
+    silently-rising retry rate flags Chromium-level instability before it starts
+    showing up as `outcome="failed"`.
+- **Sampler curve switched from linear to square-root.** Original formula was
+  `2.5%/band` capped at 50 (so 100 audits/job at 2,000+ pages); new formula is
+  `floor(sqrt(pages) × 0.15)` capped at 15 (so 30 audits/job at 10,000+ pages).
+  Sub-linear curve keeps small-site coverage generous while putting a much
+  harder ceiling on the lighthouse fleet's required size. See the sample-size
+  table above for anchor points.
 
 **Phase 3 starting point (post-Phase-2):**
 

--- a/docs/plans/lighthouse-performance-reports.md
+++ b/docs/plans/lighthouse-performance-reports.md
@@ -318,9 +318,13 @@ Self-hosted, packaged into the `hover-analysis` image only. The `hover` and
       --output=json \
       --quiet \
       --chrome-flags="--headless=new --no-sandbox --disable-gpu" \
-      --preset=desktop|mobile \
+      [--preset=desktop] \
       --max-wait-for-load=45000
   ```
+
+  Lighthouse 12.x's `--preset` flag only accepts `desktop`, `experimental`, or
+  `perf`. Mobile is the implicit default and the flag is omitted entirely; pass
+  `--preset=desktop` only for the desktop profile.
 
 - Captures stdout into a `LighthouseReport` struct, parses headline metrics,
   persists. Errors capture stderr in `lighthouse_runs.error_message`.

--- a/docs/plans/lighthouse-performance-reports.md
+++ b/docs/plans/lighthouse-performance-reports.md
@@ -752,10 +752,13 @@ against an in-process consumer before the new app's CI surface lands.
 
 - **Image base switched to Debian (`node:20-slim`)**, not Alpine. Alpine's
   `chromium` package consistently lags upstream; Debian bookworm tracks Chromium
-  stable within days, so the security/stability call goes to Debian. Pinned:
-  `chromium 147.0.7727.116` (whatever bookworm currently ships) and
-  `lighthouse@12.2.1`. Image size lands at ~2 GB — within Fly's pull window but
-  worth a future trim pass.
+  stable within days, so the security/stability call goes to Debian. Currently
+  resolved versions: Chromium 147.0.7727.116 (the version Debian bookworm
+  shipped at first build — `apt-get install chromium` is intentionally unpinned
+  for now, with a `TODO(phase3)` in `Dockerfile.analysis` to capture the exact
+  pin once the first prod build resolves it) and pinned `lighthouse@12.2.1`.
+  Image size lands at ~2 GB — within Fly's pull window but worth a future trim
+  pass.
 - **`source_task_id` plumbed via DB rather than the wire format.**
   `MarkLighthouseRunRunning` was changed to `RETURNING source_task_id` so the
   consumer learns the parent task at audit start time. The Phase 2 ZSET wire

--- a/docs/plans/lighthouse-performance-reports.md
+++ b/docs/plans/lighthouse-performance-reports.md
@@ -111,7 +111,7 @@ while %-audited tapers — the cost ceiling we want.
   is excluded from later milestones, even if its band membership shifts.
 - Final reconciliation at 100%: rerun the sampler against the complete dataset
   to cover any late-arriving extremes that weren't visible during earlier
-  milestones. Bounded by the same 50+50 cap.
+  milestones. Bounded by the same 15+15 cap.
 
 ### When to schedule
 

--- a/docs/plans/lighthouse-performance-reports.md
+++ b/docs/plans/lighthouse-performance-reports.md
@@ -3,7 +3,9 @@
 Status: Phase 1 (Foundations) shipped in PR #353. Phase 2 (milestone
 scheduling + skeleton `hover-analysis` app) shipped in PR #356; producer →
 stream → consumer pipeline verified end-to-end on the review app via the
-StubRunner. Phases 3–5 still to do. Last updated: 2026-04-26.
+StubRunner. Phase 3 (real Lighthouse audits) implemented on
+`work/confident-banzai-4b367c`, awaiting review. Phases 4–5 still to do. Last
+updated: 2026-04-26.
 
 ## Goal
 
@@ -741,6 +743,46 @@ against an in-process consumer before the new app's CI surface lands.
 - Verify on the production-shaped review app: peak memory at the v1 default of
   `LIGHTHOUSE_MAX_CONCURRENCY=1`, average audit duration, failure rate. Document
   numbers; only then consider raising the default.
+
+**Phase 3 implementation notes (deviations from this plan):**
+
+- **Image base switched to Debian (`node:20-slim`)**, not Alpine. Alpine's
+  `chromium` package consistently lags upstream; Debian bookworm tracks Chromium
+  stable within days, so the security/stability call goes to Debian. Pinned:
+  `chromium 147.0.7727.116` (whatever bookworm currently ships) and
+  `lighthouse@12.2.1`. Image size lands at ~2 GB — within Fly's pull window but
+  worth a future trim pass.
+- **`source_task_id` plumbed via DB rather than the wire format.**
+  `MarkLighthouseRunRunning` was changed to `RETURNING source_task_id` so the
+  consumer learns the parent task at audit start time. The Phase 2 ZSET wire
+  format (now 11 fields) was left untouched — bumping it again on the back of
+  Phase 2's bump would have been churn. The runner falls back to
+  `jobs/{job_id}/runs/{run_id}/lighthouse-mobile.json.gz` when `source_task_id`
+  is NULL (parent task deleted via `ON DELETE SET NULL`).
+- **`ErrMemoryShed` is a sentinel, not a permanent failure.** The consumer
+  treats it like shutdown cancellation: leave the row in `running`, skip `XAck`,
+  let `XAUTOCLAIM` redeliver once memory recovers. Treating it as `failed` would
+  burn the audit slot unrecoverably.
+- **Process-tree kill via `Setpgid` + `Kill(-pgid, SIGKILL)`.** Without this a
+  context-cancelled audit orphans Chromium renderers that keep eating memory.
+  Covered by a unit test that asserts a 30s `sleep` fake binary dies within the
+  200ms timeout.
+- **Stderr capped via a ring buffer** (16 KiB tail) before being embedded in the
+  returned error and ultimately `lighthouse_runs.error_message`. A wedged
+  Chromium can emit megabytes of debug output; the column is plain TEXT and
+  would otherwise grow unbounded.
+- **`LIGHTHOUSE_RUNNER` stays `stub` on review apps and on the merge commit.**
+  The Chromium layers ship in the image regardless, but flipping the runner
+  default waits until the first production smoke test confirms the binary boots
+  cleanly. A follow-up commit on the same PR flips production once the
+  review-app numbers look healthy.
+- **`dumb-init` reaps Chromium zombies.** Renderer crashes leave defunct
+  processes; without dumb-init the analysis container eventually exhausts its
+  PID table.
+- **Archive provider boots in `cmd/analysis`.** Phase 2 didn't need it (stub
+  runner has no R2 upload). Phase 3 adds an `archive.ProviderFromEnv()` call
+  gated on `LIGHTHOUSE_RUNNER=local` so review apps without R2 credentials still
+  boot the stub runner.
 
 **Phase 3 starting point (post-Phase-2):**
 

--- a/fly.analysis.toml
+++ b/fly.analysis.toml
@@ -3,9 +3,9 @@
 # populated by the crawl-side dispatcher and writes audit results back
 # to lighthouse_runs.
 #
-# Phase 2 ships a stub-runner default. Phase 3 layers Chromium and the
-# lighthouse npm package into Dockerfile.analysis and flips
-# LIGHTHOUSE_RUNNER to "local".
+# Phase 3 ships real Chromium audits via the local runner. Image is
+# Debian bookworm + chromium + lighthouse@12.2.1, ~2 GB. Review apps
+# stay on the stub runner — see .fly/review_apps.analysis.toml.
 
 app = 'hover-analysis'
 primary_region = 'syd'
@@ -15,9 +15,15 @@ primary_region = 'syd'
 
 [env]
   APP_ENV = "production"
-  # Phase 2 default: in-process stub runner. Phase 3 will switch to
-  # "local" once Chromium + lighthouse@<pinned> are baked into the image.
-  LIGHTHOUSE_RUNNER = "stub"
+  # Phase 3: real Chromium + lighthouse@12.2.1 baked into the image
+  # via Dockerfile.analysis. Boot fails loud if ARCHIVE_* secrets are
+  # missing, so a misconfiguration surfaces before any audit is queued
+  # rather than as silent failures on lighthouse_runs rows.
+  #
+  # Rollback: `fly secrets set LIGHTHOUSE_RUNNER=stub --app hover-analysis`
+  # — instant, no redeploy needed. Stub returns canned metrics so the
+  # producer pipeline keeps working while the runtime is investigated.
+  LIGHTHOUSE_RUNNER = "local"
   # Concurrency cap on simultaneous audits. v1 starts conservative
   # (1 per machine) and tunes up after observing real Chromium memory
   # pressure during Phase 3.

--- a/fly.analysis.toml
+++ b/fly.analysis.toml
@@ -39,6 +39,13 @@ primary_region = 'syd'
   # Soft memory floor before the runner defers a new audit. Phase 3
   # consults this; Phase 2 stub runner ignores it.
   LIGHTHOUSE_MEMORY_SHED_THRESHOLD_MB = "600"
+  # Bundled binary paths. Dockerfile.analysis bakes the same defaults
+  # via ENV so a misconfigured toml still resolves the binaries, but
+  # we set them here too so a base-image rebuild that moves them
+  # surfaces as a loud boot error rather than a runtime exec ENOENT
+  # on the first audit.
+  LIGHTHOUSE_BIN = "/usr/local/bin/lighthouse"
+  CHROMIUM_BIN = "/usr/bin/chromium"
   LOG_LEVEL = "info"
   OBSERVABILITY_ENABLED = "true"
   OTEL_EXPORTER_OTLP_ENDPOINT = "https://otlp-gateway-prod-au-southeast-1.grafana.net/otlp/v1/traces"

--- a/internal/archive/archive.go
+++ b/internal/archive/archive.go
@@ -64,3 +64,29 @@ func TaskHTMLObjectPath(jobID, taskID string) string {
 func ColdKey(jobID, taskID string) string {
 	return TaskHTMLObjectPath(jobID, taskID)
 }
+
+// LighthouseObjectPath returns the canonical object path for a
+// lighthouse audit's gzipped JSON report. When taskID is non-empty the
+// report is co-located with the matching crawl artefact under
+// "jobs/{jobID}/tasks/{taskID}/lighthouse-{profile}.json.gz" so the
+// two blobs can be discovered together. When taskID is empty (the
+// parent task was deleted via ON DELETE SET NULL on
+// lighthouse_runs.source_task_id) the path falls back to
+// "jobs/{jobID}/runs/{runID}/lighthouse-{profile}.json.gz" so the
+// audit is still archived.
+//
+// ARCHIVE_PATH_PREFIX prepends in the same way as TaskHTMLObjectPath so
+// review-app deployments stay siloed from production.
+func LighthouseObjectPath(jobID, taskID, profile string, runID int64) string {
+	var base string
+	if taskID == "" {
+		base = fmt.Sprintf("jobs/%s/runs/%d/lighthouse-%s.json.gz", jobID, runID, profile)
+	} else {
+		base = fmt.Sprintf("jobs/%s/tasks/%s/lighthouse-%s.json.gz", jobID, taskID, profile)
+	}
+	prefix := strings.Trim(strings.TrimSpace(os.Getenv("ARCHIVE_PATH_PREFIX")), "/")
+	if prefix == "" {
+		return base
+	}
+	return prefix + "/" + base
+}

--- a/internal/archive/archive_test.go
+++ b/internal/archive/archive_test.go
@@ -69,6 +69,65 @@ func TestColdKey_WithPrefix(t *testing.T) {
 	assert.Equal(t, "42/jobs/j/tasks/t/page-content.html.gz", ColdKey("j", "t"))
 }
 
+func TestLighthouseObjectPath(t *testing.T) {
+	cases := []struct {
+		name    string
+		prefix  string
+		jobID   string
+		taskID  string
+		profile string
+		runID   int64
+		want    string
+	}{
+		{
+			name:    "task id co-locates with crawl artefact",
+			prefix:  "",
+			jobID:   "job-1",
+			taskID:  "task-1",
+			profile: "mobile",
+			runID:   42,
+			want:    "jobs/job-1/tasks/task-1/lighthouse-mobile.json.gz",
+		},
+		{
+			name:    "empty task id falls back to run id",
+			prefix:  "",
+			jobID:   "job-1",
+			taskID:  "",
+			profile: "mobile",
+			runID:   42,
+			want:    "jobs/job-1/runs/42/lighthouse-mobile.json.gz",
+		},
+		{
+			name:    "review-app prefix prepends",
+			prefix:  "347",
+			jobID:   "job-1",
+			taskID:  "task-1",
+			profile: "mobile",
+			runID:   42,
+			want:    "347/jobs/job-1/tasks/task-1/lighthouse-mobile.json.gz",
+		},
+		{
+			name:    "desktop profile slot",
+			prefix:  "",
+			jobID:   "job-1",
+			taskID:  "task-1",
+			profile: "desktop",
+			runID:   42,
+			want:    "jobs/job-1/tasks/task-1/lighthouse-desktop.json.gz",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("ARCHIVE_PATH_PREFIX", tc.prefix)
+			got := LighthouseObjectPath(tc.jobID, tc.taskID, tc.profile, tc.runID)
+			if got != tc.want {
+				t.Fatalf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestTaskHTMLObjectPath(t *testing.T) {
 	cases := []struct {
 		name   string

--- a/internal/db/lighthouse.go
+++ b/internal/db/lighthouse.go
@@ -129,30 +129,36 @@ func InsertLighthouseRun(ctx context.Context, tx *sql.Tx, insert LighthouseRunIn
 // 'running' (reclaim of a row left in flight by a crashed or
 // shutting-down consumer) so XAUTOCLAIM can hand work off cleanly.
 //
-// Returns false only when the row has reached a terminal state
+// Returns moved=false only when the row has reached a terminal state
 // ('succeeded', 'failed', 'skipped_quota'); the caller treats that as
 // "safe to ACK and drop the redelivered stream message". Double-running
 // races (two consumers reclaim the same idle row) are bounded by the
 // status='running' guard on CompleteLighthouseRun / FailLighthouseRun:
 // whichever finishes first writes the terminal row, the other gets
 // ErrLighthouseRunNotFound and ACKs.
-func (db *DB) MarkLighthouseRunRunning(ctx context.Context, runID int64) (bool, error) {
+//
+// sourceTaskID is the row's source_task_id (empty string when NULL,
+// which can happen after the parent task is deleted via
+// ON DELETE SET NULL); the analysis-side runner uses it to build the
+// R2 report key without an extra SELECT.
+func (db *DB) MarkLighthouseRunRunning(ctx context.Context, runID int64) (moved bool, sourceTaskID string, err error) {
 	const q = `
 		UPDATE lighthouse_runs
 		   SET status = 'running',
 		       started_at = NOW()
 		 WHERE id = $1 AND status IN ('pending', 'running')
+		 RETURNING COALESCE(source_task_id, '')
 	`
 
-	result, err := db.client.ExecContext(ctx, q, runID)
-	if err != nil {
-		return false, fmt.Errorf("mark lighthouse run running: %w", err)
+	var taskID string
+	scanErr := db.client.QueryRowContext(ctx, q, runID).Scan(&taskID)
+	if errors.Is(scanErr, sql.ErrNoRows) {
+		return false, "", nil
 	}
-	rows, err := result.RowsAffected()
-	if err != nil {
-		return false, fmt.Errorf("rows affected: %w", err)
+	if scanErr != nil {
+		return false, "", fmt.Errorf("mark lighthouse run running: %w", scanErr)
 	}
-	return rows > 0, nil
+	return true, taskID, nil
 }
 
 // CompleteLighthouseRun records a successful audit's metrics on a row

--- a/internal/db/lighthouse_test.go
+++ b/internal/db/lighthouse_test.go
@@ -12,18 +12,49 @@ import (
 // TestMarkLighthouseRunRunning_AcceptsPendingAndRunning pins the
 // reclaim contract: a row that's already 'running' (left in flight by
 // a crashed or shutting-down consumer) must transition cleanly when
-// XAUTOCLAIM hands it to a fresh consumer. Returns true so the
+// XAUTOCLAIM hands it to a fresh consumer. Returns moved=true so the
 // consumer proceeds with the audit; the status='running' guard on
 // CompleteLighthouseRun bounds any double-completion race.
+//
+// Also pins the source_task_id passthrough so the analysis-side runner
+// can build R2 keys without an extra SELECT, including the empty-string
+// fallback when the FK has been NULLed via ON DELETE SET NULL.
 func TestMarkLighthouseRunRunning_AcceptsPendingAndRunning(t *testing.T) {
 	cases := []struct {
-		name     string
-		affected int64
-		want     bool
+		name        string
+		rows        *sqlmock.Rows
+		expectQuery bool
+		wantMoved   bool
+		wantTaskID  string
 	}{
-		{"first delivery (pending → running)", 1, true},
-		{"reclaim of in-flight (running → running)", 1, true},
-		{"terminal row not touched", 0, false},
+		{
+			name:        "first delivery returns task id",
+			rows:        sqlmock.NewRows([]string{"coalesce"}).AddRow("task-abc"),
+			expectQuery: true,
+			wantMoved:   true,
+			wantTaskID:  "task-abc",
+		},
+		{
+			name:        "reclaim of in-flight still returns task id",
+			rows:        sqlmock.NewRows([]string{"coalesce"}).AddRow("task-xyz"),
+			expectQuery: true,
+			wantMoved:   true,
+			wantTaskID:  "task-xyz",
+		},
+		{
+			name:        "null source_task_id surfaces as empty string",
+			rows:        sqlmock.NewRows([]string{"coalesce"}).AddRow(""),
+			expectQuery: true,
+			wantMoved:   true,
+			wantTaskID:  "",
+		},
+		{
+			name:        "terminal row not touched",
+			rows:        sqlmock.NewRows([]string{"coalesce"}),
+			expectQuery: true,
+			wantMoved:   false,
+			wantTaskID:  "",
+		},
 	}
 
 	for _, tc := range cases {
@@ -34,13 +65,14 @@ func TestMarkLighthouseRunRunning_AcceptsPendingAndRunning(t *testing.T) {
 
 			db := &DB{client: mockDB}
 
-			mock.ExpectExec(`UPDATE lighthouse_runs`).
+			mock.ExpectQuery(`UPDATE lighthouse_runs`).
 				WithArgs(int64(42)).
-				WillReturnResult(sqlmock.NewResult(0, tc.affected))
+				WillReturnRows(tc.rows)
 
-			moved, err := db.MarkLighthouseRunRunning(context.Background(), 42)
+			moved, taskID, err := db.MarkLighthouseRunRunning(context.Background(), 42)
 			require.NoError(t, err)
-			assert.Equal(t, tc.want, moved)
+			assert.Equal(t, tc.wantMoved, moved)
+			assert.Equal(t, tc.wantTaskID, taskID)
 			require.NoError(t, mock.ExpectationsWereMet())
 		})
 	}

--- a/internal/lighthouse/report.go
+++ b/internal/lighthouse/report.go
@@ -1,0 +1,104 @@
+package lighthouse
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+)
+
+// rawReport mirrors the slice of the Lighthouse JSON output we care
+// about. The CLI's full report is large and frequently versioned;
+// pulling out only the fields we map to AuditResult keeps the parser
+// resilient to upstream churn. Any audit we don't recognise is simply
+// missing from this struct and falls back to a nil pointer in the
+// AuditResult.
+//
+// Lighthouse audits emit numericValue as a float64 in milliseconds for
+// timing metrics, a unitless float for CLS, and bytes for byte-weight.
+// performance.score is 0.0–1.0; we round to a 0–100 integer so the
+// stored column matches the existing `INT` schema on lighthouse_runs.
+type rawReport struct {
+	Categories struct {
+		Performance struct {
+			Score *float64 `json:"score"`
+		} `json:"performance"`
+	} `json:"categories"`
+	Audits map[string]rawAudit `json:"audits"`
+}
+
+type rawAudit struct {
+	NumericValue *float64 `json:"numericValue"`
+	NumericUnit  string   `json:"numericUnit"`
+}
+
+// audit IDs mirror the stable IDs Lighthouse exposes in its `audits`
+// map. Pinned here so a typo can't silently drop a metric.
+const (
+	auditLargestContentfulPaint = "largest-contentful-paint"
+	auditCumulativeLayoutShift  = "cumulative-layout-shift"
+	auditInteractionToNextPaint = "interaction-to-next-paint"
+	auditTotalBlockingTime      = "total-blocking-time"
+	auditFirstContentfulPaint   = "first-contentful-paint"
+	auditSpeedIndex             = "speed-index"
+	auditServerResponseTime     = "server-response-time"
+	auditTotalByteWeight        = "total-byte-weight"
+)
+
+// ParseReport turns a Lighthouse JSON report into an AuditResult. The
+// Duration field is left zero — the runner stamps wall time from the
+// outside since the report itself doesn't capture exec wrapper cost.
+//
+// ReportKey is left empty here for the same reason: it's the R2 key,
+// which only the runner that just uploaded the report can know.
+//
+// Returns an error only on malformed JSON; a report that is well-formed
+// but missing a given audit produces a nil pointer in that field, which
+// preserves the "not measured" semantics of the lighthouse_runs columns.
+func ParseReport(raw []byte) (AuditResult, error) {
+	var report rawReport
+	if err := json.Unmarshal(raw, &report); err != nil {
+		return AuditResult{}, fmt.Errorf("parse lighthouse report: %w", err)
+	}
+
+	var out AuditResult
+
+	if report.Categories.Performance.Score != nil {
+		score := int(math.Round(*report.Categories.Performance.Score * 100))
+		out.PerformanceScore = &score
+	}
+
+	if a, ok := report.Audits[auditLargestContentfulPaint]; ok && a.NumericValue != nil {
+		v := int(math.Round(*a.NumericValue))
+		out.LCPMs = &v
+	}
+	if a, ok := report.Audits[auditCumulativeLayoutShift]; ok && a.NumericValue != nil {
+		v := *a.NumericValue
+		out.CLS = &v
+	}
+	if a, ok := report.Audits[auditInteractionToNextPaint]; ok && a.NumericValue != nil {
+		v := int(math.Round(*a.NumericValue))
+		out.INPMs = &v
+	}
+	if a, ok := report.Audits[auditTotalBlockingTime]; ok && a.NumericValue != nil {
+		v := int(math.Round(*a.NumericValue))
+		out.TBTMs = &v
+	}
+	if a, ok := report.Audits[auditFirstContentfulPaint]; ok && a.NumericValue != nil {
+		v := int(math.Round(*a.NumericValue))
+		out.FCPMs = &v
+	}
+	if a, ok := report.Audits[auditSpeedIndex]; ok && a.NumericValue != nil {
+		v := int(math.Round(*a.NumericValue))
+		out.SpeedIndexMs = &v
+	}
+	if a, ok := report.Audits[auditServerResponseTime]; ok && a.NumericValue != nil {
+		v := int(math.Round(*a.NumericValue))
+		out.TTFBMs = &v
+	}
+	if a, ok := report.Audits[auditTotalByteWeight]; ok && a.NumericValue != nil {
+		v := int64(math.Round(*a.NumericValue))
+		out.TotalByteWeight = &v
+	}
+
+	return out, nil
+}

--- a/internal/lighthouse/report_test.go
+++ b/internal/lighthouse/report_test.go
@@ -1,0 +1,128 @@
+package lighthouse
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseReport_HappyPath(t *testing.T) {
+	raw := []byte(`{
+		"categories": {
+			"performance": { "score": 0.87 }
+		},
+		"audits": {
+			"largest-contentful-paint":  { "numericValue": 2400.4 },
+			"cumulative-layout-shift":   { "numericValue": 0.083 },
+			"interaction-to-next-paint": { "numericValue": 180 },
+			"total-blocking-time":       { "numericValue": 240 },
+			"first-contentful-paint":    { "numericValue": 1300.6 },
+			"speed-index":               { "numericValue": 2900 },
+			"server-response-time":      { "numericValue": 320 },
+			"total-byte-weight":         { "numericValue": 1500000.7 }
+		}
+	}`)
+
+	result, err := ParseReport(raw)
+	require.NoError(t, err)
+
+	require.NotNil(t, result.PerformanceScore)
+	assert.Equal(t, 87, *result.PerformanceScore)
+	require.NotNil(t, result.LCPMs)
+	assert.Equal(t, 2400, *result.LCPMs)
+	require.NotNil(t, result.CLS)
+	assert.InDelta(t, 0.083, *result.CLS, 1e-9)
+	require.NotNil(t, result.INPMs)
+	assert.Equal(t, 180, *result.INPMs)
+	require.NotNil(t, result.TBTMs)
+	assert.Equal(t, 240, *result.TBTMs)
+	require.NotNil(t, result.FCPMs)
+	assert.Equal(t, 1301, *result.FCPMs)
+	require.NotNil(t, result.SpeedIndexMs)
+	assert.Equal(t, 2900, *result.SpeedIndexMs)
+	require.NotNil(t, result.TTFBMs)
+	assert.Equal(t, 320, *result.TTFBMs)
+	require.NotNil(t, result.TotalByteWeight)
+	assert.Equal(t, int64(1500001), *result.TotalByteWeight)
+}
+
+func TestParseReport_MissingAuditsRemainNil(t *testing.T) {
+	// Lighthouse occasionally omits audits on pages it can't audit
+	// cleanly (e.g. CLS on pages that never paint). Missing audit IDs
+	// must surface as nil pointers so the lighthouse_runs row stores
+	// NULL rather than a misleading zero.
+	raw := []byte(`{
+		"categories": {
+			"performance": { "score": 0.5 }
+		},
+		"audits": {
+			"largest-contentful-paint": { "numericValue": 3000 }
+		}
+	}`)
+
+	result, err := ParseReport(raw)
+	require.NoError(t, err)
+
+	require.NotNil(t, result.PerformanceScore)
+	assert.Equal(t, 50, *result.PerformanceScore)
+	require.NotNil(t, result.LCPMs)
+	assert.Equal(t, 3000, *result.LCPMs)
+	assert.Nil(t, result.CLS)
+	assert.Nil(t, result.INPMs)
+	assert.Nil(t, result.TBTMs)
+	assert.Nil(t, result.FCPMs)
+	assert.Nil(t, result.SpeedIndexMs)
+	assert.Nil(t, result.TTFBMs)
+	assert.Nil(t, result.TotalByteWeight)
+}
+
+func TestParseReport_NullNumericValueStaysNil(t *testing.T) {
+	// Lighthouse emits `"numericValue": null` for some audits when the
+	// page failed to produce a measurement. Treat as missing.
+	raw := []byte(`{
+		"categories": { "performance": { "score": null } },
+		"audits": {
+			"largest-contentful-paint": { "numericValue": null }
+		}
+	}`)
+
+	result, err := ParseReport(raw)
+	require.NoError(t, err)
+	assert.Nil(t, result.PerformanceScore)
+	assert.Nil(t, result.LCPMs)
+}
+
+func TestParseReport_MalformedJSONErrors(t *testing.T) {
+	_, err := ParseReport([]byte(`{not valid json`))
+	assert.Error(t, err)
+}
+
+func TestParseReport_RoundsScoreHalfUp(t *testing.T) {
+	cases := []struct {
+		score float64
+		want  int
+	}{
+		{0.0, 0},
+		{0.005, 1}, // .5 rounds up via math.Round
+		{0.494, 49},
+		{0.495, 50},
+		{0.999, 100},
+		{1.0, 100},
+	}
+	for _, tc := range cases {
+		t.Run("", func(t *testing.T) {
+			raw := []byte(`{"categories":{"performance":{"score":` +
+				floatString(tc.score) + `}},"audits":{}}`)
+			r, err := ParseReport(raw)
+			require.NoError(t, err)
+			require.NotNil(t, r.PerformanceScore)
+			assert.Equal(t, tc.want, *r.PerformanceScore)
+		})
+	}
+}
+
+func floatString(f float64) string {
+	return strconv.FormatFloat(f, 'f', -1, 64)
+}

--- a/internal/lighthouse/runner.go
+++ b/internal/lighthouse/runner.go
@@ -19,13 +19,20 @@ const (
 // AuditRequest is the input handed to a Runner. The scheduler builds
 // these from a lighthouse_runs row plus the matching tasks/pages
 // metadata. Timeout is the per-run budget; runners must respect it.
+//
+// SourceTaskID is the lighthouse_runs.source_task_id (empty when the
+// FK was NULLed via ON DELETE SET NULL). The local runner uses it to
+// co-locate the report with the matching crawl artefact under
+// jobs/{JobID}/tasks/{SourceTaskID}/. Empty falls back to a
+// run-id-keyed path so a deleted parent task doesn't lose the report.
 type AuditRequest struct {
-	RunID   int64
-	JobID   string
-	PageID  int
-	URL     string
-	Profile Profile
-	Timeout time.Duration
+	RunID        int64
+	JobID        string
+	PageID       int
+	SourceTaskID string
+	URL          string
+	Profile      Profile
+	Timeout      time.Duration
 }
 
 // AuditResult is the output of a successful audit. ReportKey is the

--- a/internal/lighthouse/runner_local.go
+++ b/internal/lighthouse/runner_local.go
@@ -159,19 +159,26 @@ func (l *LocalRunner) Run(ctx context.Context, req AuditRequest) (AuditResult, e
 // exit it returns an error wrapping the stderr tail so callers can
 // surface it into lighthouse_runs.error_message.
 func (l *LocalRunner) runOnce(ctx context.Context, req AuditRequest) ([]byte, error) {
-	preset := string(req.Profile)
-	if preset == "" {
-		preset = string(l.cfg.ProfilePreset)
+	profile := req.Profile
+	if profile == "" {
+		profile = l.cfg.ProfilePreset
 	}
 
+	// Lighthouse 12.x's --preset flag only accepts 'desktop',
+	// 'experimental', or 'perf'. Mobile is the implicit default and
+	// passing --preset=mobile fails the CLI's argument validation
+	// before Chromium even launches. So: pass --preset=desktop only
+	// for the desktop profile; otherwise omit the flag entirely.
 	args := []string{
 		"--output=json",
 		"--quiet",
-		"--preset=" + preset,
 		"--max-wait-for-load=45000",
 		"--chrome-flags=--headless=new --no-sandbox --disable-gpu",
-		req.URL,
 	}
+	if profile == ProfileDesktop {
+		args = append(args, "--preset=desktop")
+	}
+	args = append(args, req.URL)
 
 	// #nosec G204 -- LighthouseBin is sourced from trusted env config
 	// baked into the analysis image at build time, not user input. The

--- a/internal/lighthouse/runner_local.go
+++ b/internal/lighthouse/runner_local.go
@@ -74,8 +74,14 @@ func NewLocalRunner(cfg LocalRunnerConfig) (*LocalRunner, error) {
 	if strings.TrimSpace(cfg.LighthouseBin) == "" {
 		return nil, errors.New("local runner: LighthouseBin is required")
 	}
+	if err := validateExecutable(cfg.LighthouseBin); err != nil {
+		return nil, fmt.Errorf("local runner: invalid LighthouseBin: %w", err)
+	}
 	if strings.TrimSpace(cfg.ChromiumBin) == "" {
 		return nil, errors.New("local runner: ChromiumBin is required")
+	}
+	if err := validateExecutable(cfg.ChromiumBin); err != nil {
+		return nil, fmt.Errorf("local runner: invalid ChromiumBin: %w", err)
 	}
 	if cfg.Provider == nil {
 		return nil, errors.New("local runner: archive provider is required")
@@ -91,6 +97,26 @@ func NewLocalRunner(cfg LocalRunnerConfig) (*LocalRunner, error) {
 		readMemAvailableMB: defaultReadMemAvailableMB,
 		now:                time.Now,
 	}, nil
+}
+
+// validateExecutable confirms a binary path resolves to an existing,
+// executable, non-directory file. Catching this at boot turns a
+// Dockerfile/toml drift (binary moved, wrong path, accidentally a
+// directory) into a loud fatal during analysis-app startup rather than
+// an ENOENT on the first audit — by which point the lighthouse_runs row
+// already moved to 'running' and a redelivery storm is in motion.
+func validateExecutable(path string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		return err
+	}
+	if info.IsDir() {
+		return fmt.Errorf("%s is a directory", path)
+	}
+	if info.Mode()&0o111 == 0 {
+		return fmt.Errorf("%s is not executable", path)
+	}
+	return nil
 }
 
 // Run executes a single Lighthouse audit, parses the JSON result,
@@ -222,7 +248,7 @@ func (l *LocalRunner) runOnce(ctx context.Context, req AuditRequest) ([]byte, er
 		if waitErr != nil {
 			tail := stderr.tail()
 			return nil, fmt.Errorf("lighthouse exit: %w (stderr: %s)",
-				waitErr, truncateForLog(tail))
+				waitErr, sanitiseRunnerStderr(req.URL, tail))
 		}
 	}
 
@@ -352,6 +378,22 @@ func truncateForLog(b []byte) string {
 		return string(b)
 	}
 	return "..." + string(b[len(b)-max:])
+}
+
+// sanitiseRunnerStderr strips the audited URL's query/fragment from a
+// stderr tail before it lands in lighthouse_runs.error_message. The
+// startup log already calls SanitiseAuditURL on req.URL, but Lighthouse
+// (and Chromium error paths) routinely echo the raw URL into stderr,
+// which would otherwise leak session tokens or signed-link tokens
+// through the failure path. Strips only the exact request URL so the
+// rest of the stderr context (stack frames, protocol-error details)
+// stays usable for diagnostics.
+func sanitiseRunnerStderr(rawURL string, tail []byte) string {
+	msg := truncateForLog(tail)
+	if rawURL == "" {
+		return msg
+	}
+	return strings.ReplaceAll(msg, rawURL, SanitiseAuditURL(rawURL))
 }
 
 // defaultReadMemAvailableMB reads /proc/meminfo's MemAvailable line and

--- a/internal/lighthouse/runner_local.go
+++ b/internal/lighthouse/runner_local.go
@@ -1,0 +1,380 @@
+package lighthouse
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/Harvey-AU/hover/internal/archive"
+)
+
+// ErrMemoryShed is returned by LocalRunner.Run when free memory is
+// below LIGHTHOUSE_MEMORY_SHED_THRESHOLD_MB. The consumer treats this
+// like a shutdown cancellation: leave the lighthouse_runs row in
+// 'running' so XAUTOCLAIM redelivers it once memory recovers, and skip
+// the XAck so the Redis stream entry survives.
+var ErrMemoryShed = errors.New("lighthouse runner shed audit due to low memory")
+
+// stderrTailBytes caps the bytes we keep from a failing Chromium run.
+// 16 KiB is enough to capture the trailing stack/protocol-error context
+// without bloating lighthouse_runs.error_message; the column is plain
+// TEXT and would otherwise grow unbounded.
+const stderrTailBytes = 16 * 1024
+
+// transientStderrSubstrings flag a Chromium failure as worth one retry
+// rather than a permanent fail. These match the patterns Lighthouse
+// emits when its CDP attach to Chromium drops or the renderer crashes
+// — both well-known transient failure modes that recover on a fresh
+// browser. Anything outside this list is a hard failure.
+var transientStderrSubstrings = []string{
+	"Inspector.targetCrashed",
+	"Protocol error",
+	"Page crashed",
+	"WebSocket is not open",
+	"Target closed",
+}
+
+// LocalRunnerConfig captures the bits the local runner needs from
+// the analysis service config. Kept separate from cmd/analysis so the
+// runner is testable without the whole consumer scaffolding.
+type LocalRunnerConfig struct {
+	LighthouseBin string
+	ChromiumBin   string
+	Provider      archive.ColdStorageProvider
+	Bucket        string
+	MemoryShedMB  int
+	ProfilePreset Profile // defaults to ProfileMobile if empty
+}
+
+// LocalRunner shells out to the bundled lighthouse CLI to perform real
+// audits. Implements the Runner interface. Phase 3's only Runner
+// alternative to StubRunner.
+type LocalRunner struct {
+	cfg LocalRunnerConfig
+	// readMemAvailableMB and now are pluggable for tests so we can
+	// exercise the memory-shed and timeout paths without wrangling
+	// /proc/meminfo or wall-clock time.
+	readMemAvailableMB func() (int, error)
+	now                func() time.Time
+}
+
+// NewLocalRunner constructs a LocalRunner with the supplied config.
+// Returns an error if the config is missing pieces the runner needs to
+// operate (binary paths, bucket, archive provider) — better to fail at
+// boot than to discover the missing config on the first audit.
+func NewLocalRunner(cfg LocalRunnerConfig) (*LocalRunner, error) {
+	if strings.TrimSpace(cfg.LighthouseBin) == "" {
+		return nil, errors.New("local runner: LighthouseBin is required")
+	}
+	if strings.TrimSpace(cfg.ChromiumBin) == "" {
+		return nil, errors.New("local runner: ChromiumBin is required")
+	}
+	if cfg.Provider == nil {
+		return nil, errors.New("local runner: archive provider is required")
+	}
+	if strings.TrimSpace(cfg.Bucket) == "" {
+		return nil, errors.New("local runner: bucket is required")
+	}
+	if cfg.ProfilePreset == "" {
+		cfg.ProfilePreset = ProfileMobile
+	}
+	return &LocalRunner{
+		cfg:                cfg,
+		readMemAvailableMB: defaultReadMemAvailableMB,
+		now:                time.Now,
+	}, nil
+}
+
+// Run executes a single Lighthouse audit, parses the JSON result,
+// uploads the gzipped raw report to R2, and returns the populated
+// AuditResult. Honours req.Timeout via context wrapping; the caller's
+// XAck/Fail flow on the consumer side decides what to do with errors.
+//
+// Retry policy: at most one retry on a transient Chromium failure,
+// recognised via stderr substring match. After that, the most recent
+// error (with stderr tail) is propagated up.
+func (l *LocalRunner) Run(ctx context.Context, req AuditRequest) (AuditResult, error) {
+	if l.cfg.MemoryShedMB > 0 {
+		avail, err := l.readMemAvailableMB()
+		if err != nil {
+			// /proc/meminfo missing is a packaging bug; log via the
+			// shared lighthouse logger and continue rather than
+			// blocking every audit on a transient read.
+			lighthouseLog.Warn("memory shed check failed; proceeding",
+				"error", err, "run_id", req.RunID, "job_id", req.JobID,
+			)
+		} else if avail < l.cfg.MemoryShedMB {
+			lighthouseLog.Info("memory shed: deferring audit",
+				"run_id", req.RunID, "job_id", req.JobID,
+				"available_mb", avail, "threshold_mb", l.cfg.MemoryShedMB,
+			)
+			return AuditResult{}, ErrMemoryShed
+		}
+	}
+
+	if req.Timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, req.Timeout)
+		defer cancel()
+	}
+
+	start := l.now()
+
+	stdout, runErr := l.runOnce(ctx, req)
+	if runErr != nil && isTransientErr(runErr) && ctx.Err() == nil {
+		lighthouseLog.Warn("lighthouse transient failure; retrying once",
+			"run_id", req.RunID, "job_id", req.JobID, "error", runErr,
+		)
+		stdout, runErr = l.runOnce(ctx, req)
+	}
+	if runErr != nil {
+		return AuditResult{}, runErr
+	}
+
+	result, parseErr := ParseReport(stdout)
+	if parseErr != nil {
+		return AuditResult{}, parseErr
+	}
+
+	key, uploadErr := l.uploadReport(ctx, req, stdout)
+	if uploadErr != nil {
+		return AuditResult{}, uploadErr
+	}
+	result.ReportKey = key
+	result.Duration = l.now().Sub(start)
+
+	return result, nil
+}
+
+// runOnce performs a single shellout to the lighthouse CLI, capturing
+// stdout (the JSON report) and a capped tail of stderr. On non-zero
+// exit it returns an error wrapping the stderr tail so callers can
+// surface it into lighthouse_runs.error_message.
+func (l *LocalRunner) runOnce(ctx context.Context, req AuditRequest) ([]byte, error) {
+	preset := string(req.Profile)
+	if preset == "" {
+		preset = string(l.cfg.ProfilePreset)
+	}
+
+	args := []string{
+		"--output=json",
+		"--quiet",
+		"--preset=" + preset,
+		"--max-wait-for-load=45000",
+		"--chrome-flags=--headless=new --no-sandbox --disable-gpu",
+		req.URL,
+	}
+
+	// #nosec G204 -- LighthouseBin is sourced from trusted env config
+	// baked into the analysis image at build time, not user input. The
+	// only positional arg is req.URL which Lighthouse itself validates;
+	// every flag is hard-coded above.
+	cmd := exec.CommandContext(ctx, l.cfg.LighthouseBin, args...)
+	// Setpgid puts Chromium and any helper renderers into their own
+	// process group so a context-cancelled Run can kill the whole tree
+	// with a single negative-pid signal. Without this a dying parent
+	// orphans renderers that keep eating memory.
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	// CHROMIUM_BIN tells lighthouse which binary to launch. Lighthouse
+	// otherwise tries to discover Chrome via $PATH and platform-specific
+	// fallbacks, which inside a slim container often means failure.
+	cmd.Env = append(os.Environ(),
+		"CHROME_PATH="+l.cfg.ChromiumBin,
+	)
+	var stdout bytes.Buffer
+	stderr := newTailBuffer(stderrTailBytes)
+	cmd.Stdout = &stdout
+	cmd.Stderr = stderr
+
+	startErr := cmd.Start()
+	if startErr != nil {
+		return nil, fmt.Errorf("start lighthouse: %w", startErr)
+	}
+
+	pgid := cmd.Process.Pid
+	waitDone := make(chan error, 1)
+	go func() { waitDone <- cmd.Wait() }()
+
+	select {
+	case <-ctx.Done():
+		// Kill the whole process group; ignore errors because the
+		// process may already have exited between the select fire and
+		// the syscall.
+		_ = syscall.Kill(-pgid, syscall.SIGKILL)
+		<-waitDone
+		return nil, ctx.Err()
+	case waitErr := <-waitDone:
+		if waitErr != nil {
+			tail := stderr.tail()
+			return nil, fmt.Errorf("lighthouse exit: %w (stderr: %s)",
+				waitErr, truncateForLog(tail))
+		}
+	}
+
+	return stdout.Bytes(), nil
+}
+
+// uploadReport gzips the raw lighthouse JSON and uploads it to the
+// configured cold store, returning the object key written to
+// lighthouse_runs.report_key.
+func (l *LocalRunner) uploadReport(ctx context.Context, req AuditRequest, raw []byte) (string, error) {
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	if _, err := gz.Write(raw); err != nil {
+		return "", fmt.Errorf("gzip lighthouse report: %w", err)
+	}
+	if err := gz.Close(); err != nil {
+		return "", fmt.Errorf("gzip close: %w", err)
+	}
+
+	profile := string(req.Profile)
+	if profile == "" {
+		profile = string(l.cfg.ProfilePreset)
+	}
+
+	key := archive.LighthouseObjectPath(req.JobID, req.SourceTaskID, profile, req.RunID)
+
+	uploadErr := l.cfg.Provider.Upload(ctx, l.cfg.Bucket, key, &buf, archive.UploadOptions{
+		ContentType:     "application/json",
+		ContentEncoding: "gzip",
+		Metadata: map[string]string{
+			"run_id":  strconv.FormatInt(req.RunID, 10),
+			"job_id":  req.JobID,
+			"profile": profile,
+		},
+	})
+	if uploadErr != nil {
+		return "", fmt.Errorf("upload lighthouse report: %w", uploadErr)
+	}
+	return key, nil
+}
+
+// isTransientErr decides whether a runOnce failure is worth one retry.
+// Context cancellation/deadline are never retried — those are caller
+// signals. Everything else is checked against the stderr substring
+// allowlist so Chromium's well-known transient crashes get a second
+// shot but a missing-binary or argument error fails fast.
+func isTransientErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+	msg := err.Error()
+	for _, s := range transientStderrSubstrings {
+		if strings.Contains(msg, s) {
+			return true
+		}
+	}
+	return false
+}
+
+// tailBuffer keeps only the last `cap` bytes written to it. Streaming
+// long Chromium stderr through a regular bytes.Buffer would blow up
+// memory on a wedged audit (Lighthouse's debug output runs to
+// megabytes); a ring buffer caps the cost while preserving the most
+// recent context, which is what diagnostics need.
+type tailBuffer struct {
+	cap  int
+	buf  []byte
+	full bool
+	pos  int
+}
+
+func newTailBuffer(cap int) *tailBuffer {
+	return &tailBuffer{cap: cap, buf: make([]byte, 0, cap)}
+}
+
+func (t *tailBuffer) Write(p []byte) (int, error) {
+	n := len(p)
+	if n >= t.cap {
+		// Single write larger than cap — keep only the last cap bytes.
+		t.buf = append(t.buf[:0], p[n-t.cap:]...)
+		t.full = true
+		t.pos = 0
+		return n, nil
+	}
+	if !t.full && len(t.buf)+n <= t.cap {
+		t.buf = append(t.buf, p...)
+		if len(t.buf) == t.cap {
+			t.full = true
+			t.pos = 0
+		}
+		return n, nil
+	}
+	// At cap — wrap.
+	if !t.full {
+		t.buf = append(t.buf, make([]byte, t.cap-len(t.buf))...)
+		t.full = true
+		t.pos = 0
+	}
+	for i := 0; i < n; i++ {
+		t.buf[t.pos] = p[i]
+		t.pos = (t.pos + 1) % t.cap
+	}
+	return n, nil
+}
+
+// tail returns the buffer's contents in chronological order.
+func (t *tailBuffer) tail() []byte {
+	if !t.full {
+		out := make([]byte, len(t.buf))
+		copy(out, t.buf)
+		return out
+	}
+	out := make([]byte, t.cap)
+	copy(out, t.buf[t.pos:])
+	copy(out[t.cap-t.pos:], t.buf[:t.pos])
+	return out
+}
+
+// truncateForLog keeps stderr error text small enough to log without
+// blowing the structured-log line size limit on Grafana.
+func truncateForLog(b []byte) string {
+	const max = 2048
+	if len(b) <= max {
+		return string(b)
+	}
+	return "..." + string(b[len(b)-max:])
+}
+
+// defaultReadMemAvailableMB reads /proc/meminfo's MemAvailable line and
+// returns the available memory in megabytes. On non-Linux platforms or
+// when the file is unreadable it returns an error so the caller can
+// log and continue rather than treating that as zero free memory.
+func defaultReadMemAvailableMB() (int, error) {
+	data, err := os.ReadFile("/proc/meminfo")
+	if err != nil {
+		return 0, err
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		if !strings.HasPrefix(line, "MemAvailable:") {
+			continue
+		}
+		// Format: "MemAvailable:    1234567 kB"
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			return 0, fmt.Errorf("malformed MemAvailable line: %q", line)
+		}
+		kb, parseErr := strconv.Atoi(fields[1])
+		if parseErr != nil {
+			return 0, fmt.Errorf("parse MemAvailable: %w", parseErr)
+		}
+		return kb / 1024, nil
+	}
+	return 0, errors.New("MemAvailable not found in /proc/meminfo")
+}
+
+// Compile-time interface check: LocalRunner satisfies Runner. Without
+// this an accidental signature drift on the interface side would only
+// surface at the consumer call site.
+var _ Runner = (*LocalRunner)(nil)

--- a/internal/lighthouse/runner_local.go
+++ b/internal/lighthouse/runner_local.go
@@ -388,12 +388,17 @@ func truncateForLog(b []byte) string {
 // through the failure path. Strips only the exact request URL so the
 // rest of the stderr context (stack frames, protocol-error details)
 // stays usable for diagnostics.
+//
+// Order matters: redact the full tail first, then truncate. If we
+// truncated first, a URL that straddled the 2 KiB cut-off would no
+// longer match the rawURL string and the partial query/fragment would
+// leak through.
 func sanitiseRunnerStderr(rawURL string, tail []byte) string {
-	msg := truncateForLog(tail)
-	if rawURL == "" {
-		return msg
+	msg := string(tail)
+	if rawURL != "" {
+		msg = strings.ReplaceAll(msg, rawURL, SanitiseAuditURL(rawURL))
 	}
-	return strings.ReplaceAll(msg, rawURL, SanitiseAuditURL(rawURL))
+	return truncateForLog([]byte(msg))
 }
 
 // defaultReadMemAvailableMB reads /proc/meminfo's MemAvailable line and

--- a/internal/lighthouse/runner_local.go
+++ b/internal/lighthouse/runner_local.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/Harvey-AU/hover/internal/archive"
+	"github.com/Harvey-AU/hover/internal/observability"
 )
 
 // ErrMemoryShed is returned by LocalRunner.Run when free memory is
@@ -30,16 +31,24 @@ var ErrMemoryShed = errors.New("lighthouse runner shed audit due to low memory")
 const stderrTailBytes = 16 * 1024
 
 // transientStderrSubstrings flag a Chromium failure as worth one retry
-// rather than a permanent fail. These match the patterns Lighthouse
-// emits when its CDP attach to Chromium drops or the renderer crashes
-// — both well-known transient failure modes that recover on a fresh
-// browser. Anything outside this list is a hard failure.
-var transientStderrSubstrings = []string{
-	"Inspector.targetCrashed",
-	"Protocol error",
-	"Page crashed",
-	"WebSocket is not open",
-	"Target closed",
+// rather than a permanent fail. Each entry pairs a stderr substring
+// with a short low-cardinality reason tag emitted on the
+// bee.lighthouse.run_retries_total metric so a rising retry rate can
+// be split by failure mode in Grafana.
+//
+// These match the patterns Lighthouse emits when its CDP attach to
+// Chromium drops or the renderer crashes — both well-known transient
+// failure modes that recover on a fresh browser. Anything outside this
+// list is a hard failure.
+var transientStderrSubstrings = []struct {
+	pattern string
+	reason  string
+}{
+	{"Inspector.targetCrashed", "target_crashed"},
+	{"Protocol error", "protocol_error"},
+	{"Page crashed", "page_crashed"},
+	{"WebSocket is not open", "websocket_closed"},
+	{"Target closed", "target_closed"},
 }
 
 // LocalRunnerConfig captures the bits the local runner needs from
@@ -155,10 +164,12 @@ func (l *LocalRunner) Run(ctx context.Context, req AuditRequest) (AuditResult, e
 	start := l.now()
 
 	stdout, runErr := l.runOnce(ctx, req)
-	if runErr != nil && isTransientErr(runErr) && ctx.Err() == nil {
+	if reason := transientRetryReason(runErr); reason != "" && ctx.Err() == nil {
 		lighthouseLog.Warn("lighthouse transient failure; retrying once",
-			"run_id", req.RunID, "job_id", req.JobID, "error", runErr,
+			"run_id", req.RunID, "job_id", req.JobID,
+			"reason", reason, "error", runErr,
 		)
+		observability.RecordLighthouseRunRetry(ctx, req.JobID, reason)
 		stdout, runErr = l.runOnce(ctx, req)
 	}
 	if runErr != nil {
@@ -290,25 +301,28 @@ func (l *LocalRunner) uploadReport(ctx context.Context, req AuditRequest, raw []
 	return key, nil
 }
 
-// isTransientErr decides whether a runOnce failure is worth one retry.
+// transientRetryReason decides whether a runOnce failure is worth one
+// retry and, if so, returns the short reason tag attached to the
+// retries metric. Empty return means "not transient — fail fast".
+//
 // Context cancellation/deadline are never retried — those are caller
 // signals. Everything else is checked against the stderr substring
 // allowlist so Chromium's well-known transient crashes get a second
-// shot but a missing-binary or argument error fails fast.
-func isTransientErr(err error) bool {
+// shot but a missing-binary or argument error fails immediately.
+func transientRetryReason(err error) string {
 	if err == nil {
-		return false
+		return ""
 	}
 	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-		return false
+		return ""
 	}
 	msg := err.Error()
-	for _, s := range transientStderrSubstrings {
-		if strings.Contains(msg, s) {
-			return true
+	for _, e := range transientStderrSubstrings {
+		if strings.Contains(msg, e.pattern) {
+			return e.reason
 		}
 	}
-	return false
+	return ""
 }
 
 // tailBuffer keeps only the last `cap` bytes written to it. Streaming

--- a/internal/lighthouse/runner_local_test.go
+++ b/internal/lighthouse/runner_local_test.go
@@ -455,24 +455,24 @@ func TestSanitiseRunnerStderr_NoURLPassthrough(t *testing.T) {
 	assert.Equal(t, "plain stderr without url", out)
 }
 
-func TestIsTransientErr(t *testing.T) {
+func TestTransientRetryReason(t *testing.T) {
 	cases := []struct {
 		err  error
-		want bool
+		want string
 	}{
-		{nil, false},
-		{context.Canceled, false},
-		{context.DeadlineExceeded, false},
-		{fmt.Errorf("Inspector.targetCrashed: renderer died"), true},
-		{fmt.Errorf("Protocol error: connection lost"), true},
-		{fmt.Errorf("Page crashed during eval"), true},
-		{fmt.Errorf("Target closed"), true},
-		{fmt.Errorf("WebSocket is not open"), true},
-		{fmt.Errorf("ENOENT no such file"), false},
-		{fmt.Errorf("invalid URL"), false},
+		{nil, ""},
+		{context.Canceled, ""},
+		{context.DeadlineExceeded, ""},
+		{fmt.Errorf("Inspector.targetCrashed: renderer died"), "target_crashed"},
+		{fmt.Errorf("Protocol error: connection lost"), "protocol_error"},
+		{fmt.Errorf("Page crashed during eval"), "page_crashed"},
+		{fmt.Errorf("Target closed"), "target_closed"},
+		{fmt.Errorf("WebSocket is not open"), "websocket_closed"},
+		{fmt.Errorf("ENOENT no such file"), ""},
+		{fmt.Errorf("invalid URL"), ""},
 	}
 	for _, tc := range cases {
-		assert.Equal(t, tc.want, isTransientErr(tc.err), tc.err)
+		assert.Equal(t, tc.want, transientRetryReason(tc.err), tc.err)
 	}
 }
 

--- a/internal/lighthouse/runner_local_test.go
+++ b/internal/lighthouse/runner_local_test.go
@@ -1,0 +1,296 @@
+package lighthouse
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Harvey-AU/hover/internal/archive"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeProvider mirrors the archive.ColdStorageProvider used elsewhere in
+// the repo (internal/jobs/html_persister_test.go). Kept simple — we
+// only need to capture the upload key and payload.
+type fakeProvider struct {
+	mu        sync.Mutex
+	uploads   []fakeUpload
+	uploadErr error
+}
+
+type fakeUpload struct {
+	bucket  string
+	key     string
+	payload []byte
+	opts    archive.UploadOptions
+}
+
+func (f *fakeProvider) Upload(_ context.Context, bucket, key string, data io.Reader, opts archive.UploadOptions) error {
+	if f.uploadErr != nil {
+		return f.uploadErr
+	}
+	body, _ := io.ReadAll(data)
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.uploads = append(f.uploads, fakeUpload{bucket: bucket, key: key, payload: body, opts: opts})
+	return nil
+}
+
+func (f *fakeProvider) Ping(_ context.Context, _ string) error { return nil }
+func (f *fakeProvider) Download(_ context.Context, _, _ string) (io.ReadCloser, error) {
+	return nil, errors.New("not implemented")
+}
+func (f *fakeProvider) Exists(_ context.Context, _, _ string) (bool, error) { return true, nil }
+func (f *fakeProvider) Provider() string                                    { return "fake" }
+
+const sampleLighthouseJSON = `{
+  "categories": { "performance": { "score": 0.91 } },
+  "audits": {
+    "largest-contentful-paint":  { "numericValue": 2100 },
+    "cumulative-layout-shift":   { "numericValue": 0.05 },
+    "interaction-to-next-paint": { "numericValue": 150 },
+    "total-blocking-time":       { "numericValue": 200 },
+    "first-contentful-paint":    { "numericValue": 1100 },
+    "speed-index":               { "numericValue": 2700 },
+    "server-response-time":      { "numericValue": 280 },
+    "total-byte-weight":         { "numericValue": 1200000 }
+  }
+}`
+
+// writeFakeLighthouseScript drops a tiny shell script that prints
+// canned Lighthouse JSON to stdout and exits 0 on first invocation.
+// If failFirst is set, the first call exits 1 with the supplied stderr
+// and the second succeeds — used to exercise the transient-retry path.
+func writeFakeLighthouseScript(t *testing.T, failFirst bool, transientStderr string) (path string) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script fake unsupported on windows")
+	}
+	dir := t.TempDir()
+	flag := filepath.Join(dir, "called.txt")
+	scriptPath := filepath.Join(dir, "fake-lighthouse.sh")
+
+	body := "#!/bin/sh\n"
+	if failFirst {
+		// First call: touch the flag, write transient stderr, exit 1.
+		// Second call: print canned JSON, exit 0.
+		body += `if [ -f "` + flag + `" ]; then
+  cat <<'JSON'
+` + sampleLighthouseJSON + `
+JSON
+  exit 0
+fi
+touch "` + flag + `"
+echo "` + transientStderr + `" 1>&2
+exit 1
+`
+	} else {
+		body += `cat <<'JSON'
+` + sampleLighthouseJSON + `
+JSON
+exit 0
+`
+	}
+
+	// #nosec G306 -- test fixture: the fake binary must be executable.
+	require.NoError(t, os.WriteFile(scriptPath, []byte(body), 0o755))
+	return scriptPath
+}
+
+// newTestRunner builds a LocalRunner with a fake provider and an
+// optional memory-shed shim. memMB < 0 disables the check by setting
+// cfg.MemoryShedMB=0.
+func newTestRunner(t *testing.T, lhBin string, memMB int, available int) (*LocalRunner, *fakeProvider) {
+	t.Helper()
+	provider := &fakeProvider{}
+	r, err := NewLocalRunner(LocalRunnerConfig{
+		LighthouseBin: lhBin,
+		ChromiumBin:   "/usr/bin/chromium-fake",
+		Provider:      provider,
+		Bucket:        "test-bucket",
+		MemoryShedMB:  memMB,
+	})
+	require.NoError(t, err)
+	if memMB > 0 {
+		r.readMemAvailableMB = func() (int, error) { return available, nil }
+	}
+	return r, provider
+}
+
+func TestNewLocalRunner_ValidatesConfig(t *testing.T) {
+	cases := []struct {
+		name string
+		cfg  LocalRunnerConfig
+	}{
+		{"missing lighthouse bin", LocalRunnerConfig{ChromiumBin: "/c", Provider: &fakeProvider{}, Bucket: "b"}},
+		{"missing chromium bin", LocalRunnerConfig{LighthouseBin: "/l", Provider: &fakeProvider{}, Bucket: "b"}},
+		{"missing provider", LocalRunnerConfig{LighthouseBin: "/l", ChromiumBin: "/c", Bucket: "b"}},
+		{"missing bucket", LocalRunnerConfig{LighthouseBin: "/l", ChromiumBin: "/c", Provider: &fakeProvider{}}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := NewLocalRunner(tc.cfg)
+			assert.Error(t, err)
+		})
+	}
+}
+
+func TestLocalRunner_MemoryShedReturnsSentinel(t *testing.T) {
+	r, provider := newTestRunner(t, "/does-not-matter", 600, 200)
+	_, err := r.Run(context.Background(), AuditRequest{
+		RunID: 1, JobID: "j", URL: "https://example.com",
+		Profile: ProfileMobile, Timeout: time.Second,
+	})
+	require.ErrorIs(t, err, ErrMemoryShed)
+	assert.Empty(t, provider.uploads, "no upload should occur when shed")
+}
+
+func TestLocalRunner_HappyPathUploadsAndReturnsKey(t *testing.T) {
+	script := writeFakeLighthouseScript(t, false, "")
+	r, provider := newTestRunner(t, script, 0, 0)
+
+	t.Setenv("ARCHIVE_PATH_PREFIX", "")
+	result, err := r.Run(context.Background(), AuditRequest{
+		RunID:        7,
+		JobID:        "job-abc",
+		PageID:       42,
+		SourceTaskID: "task-xyz",
+		URL:          "https://example.com/page?token=secret",
+		Profile:      ProfileMobile,
+		Timeout:      5 * time.Second,
+	})
+	require.NoError(t, err)
+
+	require.NotNil(t, result.PerformanceScore)
+	assert.Equal(t, 91, *result.PerformanceScore)
+	assert.Equal(t, "jobs/job-abc/tasks/task-xyz/lighthouse-mobile.json.gz", result.ReportKey)
+	assert.Greater(t, result.Duration, time.Duration(0))
+
+	require.Len(t, provider.uploads, 1)
+	up := provider.uploads[0]
+	assert.Equal(t, "test-bucket", up.bucket)
+	assert.Equal(t, result.ReportKey, up.key)
+	assert.Equal(t, "application/json", up.opts.ContentType)
+	assert.Equal(t, "gzip", up.opts.ContentEncoding)
+	assert.Equal(t, "7", up.opts.Metadata["run_id"])
+}
+
+func TestLocalRunner_FallsBackToRunIDPathWhenNoTaskID(t *testing.T) {
+	script := writeFakeLighthouseScript(t, false, "")
+	r, provider := newTestRunner(t, script, 0, 0)
+
+	t.Setenv("ARCHIVE_PATH_PREFIX", "")
+	result, err := r.Run(context.Background(), AuditRequest{
+		RunID: 99, JobID: "job-1", URL: "https://example.com",
+		Profile: ProfileMobile, Timeout: 5 * time.Second,
+		// SourceTaskID intentionally empty.
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "jobs/job-1/runs/99/lighthouse-mobile.json.gz", result.ReportKey)
+	require.Len(t, provider.uploads, 1)
+}
+
+func TestLocalRunner_RetriesOnTransientStderr(t *testing.T) {
+	script := writeFakeLighthouseScript(t, true, "Inspector.targetCrashed: renderer died")
+	r, provider := newTestRunner(t, script, 0, 0)
+
+	result, err := r.Run(context.Background(), AuditRequest{
+		RunID: 1, JobID: "j", SourceTaskID: "t", URL: "https://example.com",
+		Profile: ProfileMobile, Timeout: 10 * time.Second,
+	})
+	require.NoError(t, err, "transient failure should retry and succeed")
+	require.NotNil(t, result.PerformanceScore)
+	require.Len(t, provider.uploads, 1)
+}
+
+func TestLocalRunner_NonTransientFailsImmediately(t *testing.T) {
+	script := writeFakeLighthouseScript(t, true, "ENOENT: chromium not found")
+	r, provider := newTestRunner(t, script, 0, 0)
+
+	_, err := r.Run(context.Background(), AuditRequest{
+		RunID: 1, JobID: "j", URL: "https://example.com",
+		Profile: ProfileMobile, Timeout: 5 * time.Second,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ENOENT", "stderr tail should be in the error")
+	assert.Empty(t, provider.uploads, "no upload on hard failure")
+}
+
+func TestLocalRunner_TimeoutCancelsAndKillsProcess(t *testing.T) {
+	dir := t.TempDir()
+	script := filepath.Join(dir, "sleep.sh")
+	// #nosec G306 -- test fixture: the fake binary must be executable.
+	require.NoError(t, os.WriteFile(script, []byte("#!/bin/sh\nsleep 30\n"), 0o755))
+
+	r, _ := newTestRunner(t, script, 0, 0)
+
+	start := time.Now()
+	_, err := r.Run(context.Background(), AuditRequest{
+		RunID: 1, JobID: "j", URL: "https://example.com",
+		Profile: ProfileMobile, Timeout: 200 * time.Millisecond,
+	})
+	elapsed := time.Since(start)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, context.DeadlineExceeded),
+		"expected deadline exceeded, got %v", err)
+	assert.Less(t, elapsed, 5*time.Second, "process tree must die promptly on timeout")
+}
+
+func TestIsTransientErr(t *testing.T) {
+	cases := []struct {
+		err  error
+		want bool
+	}{
+		{nil, false},
+		{context.Canceled, false},
+		{context.DeadlineExceeded, false},
+		{fmt.Errorf("Inspector.targetCrashed: renderer died"), true},
+		{fmt.Errorf("Protocol error: connection lost"), true},
+		{fmt.Errorf("Page crashed during eval"), true},
+		{fmt.Errorf("Target closed"), true},
+		{fmt.Errorf("WebSocket is not open"), true},
+		{fmt.Errorf("ENOENT no such file"), false},
+		{fmt.Errorf("invalid URL"), false},
+	}
+	for _, tc := range cases {
+		assert.Equal(t, tc.want, isTransientErr(tc.err), tc.err)
+	}
+}
+
+func TestTailBuffer_KeepsLastBytes(t *testing.T) {
+	t.Run("under cap stays as-is", func(t *testing.T) {
+		buf := newTailBuffer(10)
+		_, _ = buf.Write([]byte("hello"))
+		assert.Equal(t, "hello", string(buf.tail()))
+	})
+	t.Run("at cap fills exactly", func(t *testing.T) {
+		buf := newTailBuffer(5)
+		_, _ = buf.Write([]byte("hello"))
+		assert.Equal(t, "hello", string(buf.tail()))
+	})
+	t.Run("over cap keeps last cap bytes in chronological order", func(t *testing.T) {
+		buf := newTailBuffer(5)
+		_, _ = buf.Write([]byte("abc"))
+		_, _ = buf.Write([]byte("defgh"))
+		assert.Equal(t, "defgh", string(buf.tail()))
+	})
+	t.Run("single oversized write truncates to last cap", func(t *testing.T) {
+		buf := newTailBuffer(4)
+		_, _ = buf.Write([]byte("abcdefgh"))
+		assert.Equal(t, "efgh", string(buf.tail()))
+	})
+	t.Run("wrap-around preserves order", func(t *testing.T) {
+		buf := newTailBuffer(5)
+		_, _ = buf.Write([]byte("abcde"))
+		_, _ = buf.Write([]byte("fg"))
+		assert.Equal(t, "cdefg", string(buf.tail()))
+	})
+}

--- a/internal/lighthouse/runner_local_test.go
+++ b/internal/lighthouse/runner_local_test.go
@@ -37,7 +37,10 @@ func (f *fakeProvider) Upload(_ context.Context, bucket, key string, data io.Rea
 	if f.uploadErr != nil {
 		return f.uploadErr
 	}
-	body, _ := io.ReadAll(data)
+	body, err := io.ReadAll(data)
+	if err != nil {
+		return fmt.Errorf("fake provider: read upload payload: %w", err)
+	}
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.uploads = append(f.uploads, fakeUpload{bucket: bucket, key: key, payload: body, opts: opts})
@@ -401,6 +404,9 @@ exit 1
 }
 
 func TestLocalRunner_TimeoutCancelsAndKillsProcess(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script fake unsupported on windows")
+	}
 	dir := t.TempDir()
 	script := filepath.Join(dir, "sleep.sh")
 	// #nosec G306 -- test fixture: the fake binary must be executable.

--- a/internal/lighthouse/runner_local_test.go
+++ b/internal/lighthouse/runner_local_test.go
@@ -183,6 +183,79 @@ func TestLocalRunner_HappyPathUploadsAndReturnsKey(t *testing.T) {
 	assert.Equal(t, "7", up.opts.Metadata["run_id"])
 }
 
+// TestLocalRunner_DoesNotPassPresetFlagForMobile pins the contract
+// against Lighthouse 12.x's CLI: --preset only accepts 'desktop',
+// 'experimental', or 'perf'. Mobile is the implicit default and
+// passing --preset=mobile fails argument validation before Chromium
+// launches. The fix omits the flag entirely for mobile audits;
+// regressing that would silently break every audit in production.
+func TestLocalRunner_DoesNotPassPresetFlagForMobile(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script fake unsupported on windows")
+	}
+	dir := t.TempDir()
+	argsLog := filepath.Join(dir, "args.txt")
+	script := filepath.Join(dir, "fake-lighthouse.sh")
+	body := `#!/bin/sh
+echo "$@" > "` + argsLog + `"
+cat <<'JSON'
+` + sampleLighthouseJSON + `
+JSON
+exit 0
+`
+	// #nosec G306 -- test fixture: the fake binary must be executable.
+	require.NoError(t, os.WriteFile(script, []byte(body), 0o755))
+
+	r, _ := newTestRunner(t, script, 0, 0)
+	_, err := r.Run(context.Background(), AuditRequest{
+		RunID: 1, JobID: "j", SourceTaskID: "t", URL: "https://example.com",
+		Profile: ProfileMobile, Timeout: 5 * time.Second,
+	})
+	require.NoError(t, err)
+
+	// #nosec G304 -- argsLog is t.TempDir-rooted, written above.
+	logged, err := os.ReadFile(argsLog)
+	require.NoError(t, err)
+	assert.NotContains(t, string(logged), "--preset=mobile",
+		"mobile is Lighthouse's implicit default; passing --preset=mobile is rejected")
+	assert.NotContains(t, string(logged), "--preset=desktop",
+		"desktop preset must not leak into a mobile audit")
+}
+
+// TestLocalRunner_PassesPresetForDesktop confirms desktop audits do
+// flip --preset=desktop on. Currently dead-code-pathed since v1 only
+// schedules mobile, but the runner-level code path exists and we want
+// to catch a regression early when desktop ships in Phase 5.
+func TestLocalRunner_PassesPresetForDesktop(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script fake unsupported on windows")
+	}
+	dir := t.TempDir()
+	argsLog := filepath.Join(dir, "args.txt")
+	script := filepath.Join(dir, "fake-lighthouse.sh")
+	body := `#!/bin/sh
+echo "$@" > "` + argsLog + `"
+cat <<'JSON'
+` + sampleLighthouseJSON + `
+JSON
+exit 0
+`
+	// #nosec G306 -- test fixture: the fake binary must be executable.
+	require.NoError(t, os.WriteFile(script, []byte(body), 0o755))
+
+	r, _ := newTestRunner(t, script, 0, 0)
+	_, err := r.Run(context.Background(), AuditRequest{
+		RunID: 1, JobID: "j", SourceTaskID: "t", URL: "https://example.com",
+		Profile: ProfileDesktop, Timeout: 5 * time.Second,
+	})
+	require.NoError(t, err)
+
+	// #nosec G304 -- argsLog is t.TempDir-rooted, written above.
+	logged, err := os.ReadFile(argsLog)
+	require.NoError(t, err)
+	assert.Contains(t, string(logged), "--preset=desktop")
+}
+
 func TestLocalRunner_FallsBackToRunIDPathWhenNoTaskID(t *testing.T) {
 	script := writeFakeLighthouseScript(t, false, "")
 	r, provider := newTestRunner(t, script, 0, 0)

--- a/internal/lighthouse/runner_local_test.go
+++ b/internal/lighthouse/runner_local_test.go
@@ -107,13 +107,20 @@ exit 0
 
 // newTestRunner builds a LocalRunner with a fake provider and an
 // optional memory-shed shim. memMB < 0 disables the check by setting
-// cfg.MemoryShedMB=0.
+// cfg.MemoryShedMB=0. ChromiumBin is a stand-in executable in the
+// caller's t.TempDir so NewLocalRunner's validateExecutable check
+// passes — the local runner never invokes it directly (lighthouse
+// drives Chromium itself), it just plumbs the path into CHROME_PATH.
 func newTestRunner(t *testing.T, lhBin string, memMB int, available int) (*LocalRunner, *fakeProvider) {
 	t.Helper()
+	chromiumStub := filepath.Join(t.TempDir(), "chromium-stub")
+	// #nosec G306 -- test fixture: stand-in chromium must be executable.
+	require.NoError(t, os.WriteFile(chromiumStub, []byte("#!/bin/sh\nexit 0\n"), 0o755))
+
 	provider := &fakeProvider{}
 	r, err := NewLocalRunner(LocalRunnerConfig{
 		LighthouseBin: lhBin,
-		ChromiumBin:   "/usr/bin/chromium-fake",
+		ChromiumBin:   chromiumStub,
 		Provider:      provider,
 		Bucket:        "test-bucket",
 		MemoryShedMB:  memMB,
@@ -126,25 +133,79 @@ func newTestRunner(t *testing.T, lhBin string, memMB int, available int) (*Local
 }
 
 func TestNewLocalRunner_ValidatesConfig(t *testing.T) {
+	dir := t.TempDir()
+	goodLH := filepath.Join(dir, "lighthouse")
+	goodCH := filepath.Join(dir, "chromium")
+	nonExec := filepath.Join(dir, "non-exec")
+	subdir := filepath.Join(dir, "subdir")
+	// #nosec G306 -- test fixtures: stand-in binaries must be executable.
+	require.NoError(t, os.WriteFile(goodLH, []byte("#!/bin/sh\nexit 0\n"), 0o755))
+	// #nosec G306 -- test fixtures: stand-in binaries must be executable.
+	require.NoError(t, os.WriteFile(goodCH, []byte("#!/bin/sh\nexit 0\n"), 0o755))
+	require.NoError(t, os.WriteFile(nonExec, []byte("not executable"), 0o600))
+	require.NoError(t, os.Mkdir(subdir, 0o750))
+
 	cases := []struct {
-		name string
-		cfg  LocalRunnerConfig
+		name        string
+		cfg         LocalRunnerConfig
+		errContains string
 	}{
-		{"missing lighthouse bin", LocalRunnerConfig{ChromiumBin: "/c", Provider: &fakeProvider{}, Bucket: "b"}},
-		{"missing chromium bin", LocalRunnerConfig{LighthouseBin: "/l", Provider: &fakeProvider{}, Bucket: "b"}},
-		{"missing provider", LocalRunnerConfig{LighthouseBin: "/l", ChromiumBin: "/c", Bucket: "b"}},
-		{"missing bucket", LocalRunnerConfig{LighthouseBin: "/l", ChromiumBin: "/c", Provider: &fakeProvider{}}},
+		{
+			name:        "missing lighthouse bin",
+			cfg:         LocalRunnerConfig{ChromiumBin: goodCH, Provider: &fakeProvider{}, Bucket: "b"},
+			errContains: "LighthouseBin is required",
+		},
+		{
+			name:        "missing chromium bin",
+			cfg:         LocalRunnerConfig{LighthouseBin: goodLH, Provider: &fakeProvider{}, Bucket: "b"},
+			errContains: "ChromiumBin is required",
+		},
+		{
+			name:        "missing provider",
+			cfg:         LocalRunnerConfig{LighthouseBin: goodLH, ChromiumBin: goodCH, Bucket: "b"},
+			errContains: "archive provider is required",
+		},
+		{
+			name:        "missing bucket",
+			cfg:         LocalRunnerConfig{LighthouseBin: goodLH, ChromiumBin: goodCH, Provider: &fakeProvider{}},
+			errContains: "bucket is required",
+		},
+		{
+			name:        "lighthouse bin does not exist",
+			cfg:         LocalRunnerConfig{LighthouseBin: "/nope/lighthouse", ChromiumBin: goodCH, Provider: &fakeProvider{}, Bucket: "b"},
+			errContains: "invalid LighthouseBin",
+		},
+		{
+			name:        "chromium bin does not exist",
+			cfg:         LocalRunnerConfig{LighthouseBin: goodLH, ChromiumBin: "/nope/chromium", Provider: &fakeProvider{}, Bucket: "b"},
+			errContains: "invalid ChromiumBin",
+		},
+		{
+			name:        "lighthouse bin is a directory",
+			cfg:         LocalRunnerConfig{LighthouseBin: subdir, ChromiumBin: goodCH, Provider: &fakeProvider{}, Bucket: "b"},
+			errContains: "is a directory",
+		},
+		{
+			name:        "lighthouse bin is not executable",
+			cfg:         LocalRunnerConfig{LighthouseBin: nonExec, ChromiumBin: goodCH, Provider: &fakeProvider{}, Bucket: "b"},
+			errContains: "is not executable",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			_, err := NewLocalRunner(tc.cfg)
-			assert.Error(t, err)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.errContains)
 		})
 	}
 }
 
 func TestLocalRunner_MemoryShedReturnsSentinel(t *testing.T) {
-	r, provider := newTestRunner(t, "/does-not-matter", 600, 200)
+	// Use a stub binary so NewLocalRunner's executable validation
+	// passes; the memory-shed check trips before the binary is ever
+	// invoked, so a no-op script suffices.
+	stub := writeFakeLighthouseScript(t, false, "")
+	r, provider := newTestRunner(t, stub, 600, 200)
 	_, err := r.Run(context.Background(), AuditRequest{
 		RunID: 1, JobID: "j", URL: "https://example.com",
 		Profile: ProfileMobile, Timeout: time.Second,
@@ -295,6 +356,48 @@ func TestLocalRunner_NonTransientFailsImmediately(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "ENOENT", "stderr tail should be in the error")
 	assert.Empty(t, provider.uploads, "no upload on hard failure")
+}
+
+// TestLocalRunner_StderrRedactsAuditURL pins the privacy contract on
+// the failure path. Lighthouse and Chromium routinely echo the audited
+// URL into stderr; without redaction those query strings (which can
+// carry session tokens or signed-link tokens) end up in
+// lighthouse_runs.error_message and in centralised logs. Mirrors the
+// SanitiseAuditURL rule already applied to start/finish log lines.
+func TestLocalRunner_StderrRedactsAuditURL(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script fake unsupported on windows")
+	}
+	dir := t.TempDir()
+	script := filepath.Join(dir, "fake.sh")
+	// Echo every arg so the URL (always the last positional in our
+	// runner) is guaranteed to land in stderr regardless of flag
+	// position. Mirrors how real Chromium error paths echo "navigation
+	// to <url> failed".
+	body := `#!/bin/sh
+for a in "$@"; do
+  echo "lighthouse stderr ref: $a" 1>&2
+done
+echo "fatal: navigation failed: missing CDP target" 1>&2
+exit 1
+`
+	// #nosec G306 -- test fixture: the fake binary must be executable.
+	require.NoError(t, os.WriteFile(script, []byte(body), 0o755))
+
+	r, _ := newTestRunner(t, script, 0, 0)
+	rawURL := "https://example.com/secret?token=leak-me-please&session=abc"
+	_, err := r.Run(context.Background(), AuditRequest{
+		RunID: 1, JobID: "j", URL: rawURL,
+		Profile: ProfileMobile, Timeout: 5 * time.Second,
+	})
+	require.Error(t, err)
+	msg := err.Error()
+	assert.NotContains(t, msg, "token=leak-me-please",
+		"query token must not survive into the returned error")
+	assert.NotContains(t, msg, "session=abc",
+		"query token must not survive into the returned error")
+	assert.Contains(t, msg, "https://example.com/secret",
+		"sanitised URL prefix should remain so diagnostics still locate the page")
 }
 
 func TestLocalRunner_TimeoutCancelsAndKillsProcess(t *testing.T) {

--- a/internal/lighthouse/runner_local_test.go
+++ b/internal/lighthouse/runner_local_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -424,6 +425,34 @@ func TestLocalRunner_TimeoutCancelsAndKillsProcess(t *testing.T) {
 	assert.True(t, errors.Is(err, context.DeadlineExceeded),
 		"expected deadline exceeded, got %v", err)
 	assert.Less(t, elapsed, 5*time.Second, "process tree must die promptly on timeout")
+}
+
+// TestSanitiseRunnerStderr_RedactsBeforeTruncating pins the order of
+// operations: the full URL must be replaced *before* truncation, not
+// after. If truncation happened first, a URL straddling the 2 KiB
+// cut-off would no longer match `rawURL` and the trailing query token
+// would survive into lighthouse_runs.error_message.
+func TestSanitiseRunnerStderr_RedactsBeforeTruncating(t *testing.T) {
+	rawURL := "https://example.com/path?token=leak-me-please&session=abc"
+	// Build a stderr tail where the URL appears just before the
+	// truncateForLog 2 KiB cut-off, so half the URL would be lost
+	// if truncation ran first.
+	prefix := strings.Repeat("noise ", 400) // ~2400 bytes
+	tail := []byte(prefix + "fatal: navigation to " + rawURL + " failed")
+
+	out := sanitiseRunnerStderr(rawURL, tail)
+
+	assert.NotContains(t, out, "token=leak-me-please",
+		"query token must not survive truncation regardless of where the URL falls")
+	assert.NotContains(t, out, "session=abc",
+		"query token must not survive truncation regardless of where the URL falls")
+	assert.LessOrEqual(t, len(out), 2048+3,
+		"truncation must still bound the output (2048 + leading '...' marker)")
+}
+
+func TestSanitiseRunnerStderr_NoURLPassthrough(t *testing.T) {
+	out := sanitiseRunnerStderr("", []byte("plain stderr without url"))
+	assert.Equal(t, "plain stderr without url", out)
 }
 
 func TestIsTransientErr(t *testing.T) {

--- a/internal/lighthouse/sampler.go
+++ b/internal/lighthouse/sampler.go
@@ -9,15 +9,27 @@ import (
 	"sort"
 )
 
-// Per-band sampling parameters. The formula picks 2.5% of completed
-// pages per extreme band (fastest + slowest), floored at 1 and capped
-// at 50, so a typical crawl is audited at roughly 5% of pages with a
-// hard ceiling of 100 audits per job. Tunable here so we can adjust
-// the mix without touching the rest of the codebase.
+// Per-band sampling parameters. The formula picks
+// floor(sqrt(completed_pages) * 0.15) audits per extreme band
+// (fastest + slowest), floored at 1 and capped at 15. A square-root
+// curve keeps small sites well-covered (every site gets at least
+// 1 fastest + 1 slowest) while sub-linearly tapering on large sites
+// so the lighthouse fleet doesn't scale linearly with crawl size.
+//
+// Anchor points the curve lands on:
+//
+//	    40 pages →  1 per band (floor) →  2 audits
+//	   200 pages →  2 per band         →  4 audits
+//	 1,000 pages →  4 per band         →  8 audits
+//	10,000 pages → 15 per band (cap)   → 30 audits
+//
+// Tunable here so we can adjust the mix without touching the rest of
+// the codebase. The previous shape (2.5%/band, cap 50) is preserved
+// in git history; switching back is a single-commit change.
 const (
-	bandFraction = 0.025
-	bandFloor    = 1
-	bandCap      = 50
+	bandSqrtFactor = 0.15
+	bandFloor      = 1
+	bandCap        = 15
 )
 
 // CompletedTask is the input shape the sampler needs from a completed
@@ -50,15 +62,19 @@ type Sample struct {
 }
 
 // PerBand returns the number of audits to schedule per extreme band
-// for a job with completedPages successful tasks so far. Floored at
-// 1 (so even a 1-page site gets one audit per band) and capped at 50
-// (so a 10,000-page crawl never queues more than 100 audits per job).
+// for a job with completedPages successful tasks so far. Floored at 1
+// (so even a 1-page site gets one audit per band) and capped at 15
+// (so a 10,000-page crawl never queues more than 30 audits per job).
+//
+// math.Floor (rather than Round) keeps the curve from over-shooting
+// the cap at exactly 10,000 pages and matches the published anchor
+// points exactly.
 func PerBand(completedPages int) int {
 	if completedPages <= 0 {
 		return 0
 	}
 
-	n := int(math.Round(float64(completedPages) * bandFraction))
+	n := int(math.Floor(math.Sqrt(float64(completedPages)) * bandSqrtFactor))
 	if n < bandFloor {
 		n = bandFloor
 	}

--- a/internal/lighthouse/sampler_test.go
+++ b/internal/lighthouse/sampler_test.go
@@ -6,16 +6,19 @@ import (
 )
 
 func TestPerBandFloor(t *testing.T) {
-	// 2.5% of these would all round below 1, so the floor binds.
+	// floor(sqrt(pages) * 0.15) = 0 for everything below ~50, so the
+	// floor binds and even a 1-page site gets 1 fastest + 1 slowest.
 	cases := []struct {
 		pages int
 		want  int
 	}{
-		{1, 1},
-		{5, 1},
-		{10, 1},
-		{20, 1},
-		{39, 1}, // round(39 * 0.025) = round(0.975) = 1
+		{1, 1},  // sqrt(1)*0.15 = 0.15  → floor 0 → floor binds
+		{5, 1},  // sqrt(5)*0.15 = 0.34
+		{10, 1}, // sqrt(10)*0.15 = 0.47
+		{20, 1}, // sqrt(20)*0.15 = 0.67
+		{39, 1}, // sqrt(39)*0.15 = 0.94
+		{40, 1}, // anchor: 40 → 1 (floor)
+		{44, 1}, // sqrt(44)*0.15 = 0.99
 	}
 	for _, tc := range cases {
 		if got := PerBand(tc.pages); got != tc.want {
@@ -24,20 +27,25 @@ func TestPerBandFloor(t *testing.T) {
 	}
 }
 
-func TestPerBandLinearScaling(t *testing.T) {
-	// Mid range: 2.5% rounds to a meaningful integer.
+func TestPerBandSquareRootScaling(t *testing.T) {
+	// Mid range: floor(sqrt(pages) * 0.15) yields the documented
+	// anchor points exactly. Values in between fall on the curve
+	// without surprise rounding.
 	cases := []struct {
 		pages int
 		want  int
 	}{
-		{40, 1},   // round(40 * 0.025) = 1
-		{50, 1},   // round(50 * 0.025) = round(1.25) = 1
-		{100, 3},  // round(100 * 0.025) = round(2.5) = 3 (banker's rounding caveat: math.Round rounds half away from zero)
-		{200, 5},  // round(5)
-		{500, 13}, // round(12.5) = 13
-		{1000, 25},
-		{1500, 38}, // round(37.5) = 38
-		{1900, 48}, // round(47.5) = 48
+		{45, 1},     // sqrt(45)*0.15 = 1.005 → 1 (just hits floor 1 organically)
+		{100, 1},    // sqrt(100)*0.15 = 1.5 → floor 1
+		{178, 2},    // sqrt(178)*0.15 = 2.0 → floor 2
+		{200, 2},    // ANCHOR: 200 → 2
+		{500, 3},    // sqrt(500)*0.15 = 3.35 → floor 3
+		{1000, 4},   // ANCHOR: 1,000 → 4
+		{2000, 6},   // sqrt(2000)*0.15 = 6.7 → floor 6
+		{5000, 10},  // sqrt(5000)*0.15 = 10.6 → floor 10
+		{8000, 13},  // sqrt(8000)*0.15 = 13.4 → floor 13
+		{9999, 14},  // sqrt(9999)*0.15 ≈ 14.99 → floor 14
+		{10000, 15}, // ANCHOR: 10,000 → 15 (exact)
 	}
 	for _, tc := range cases {
 		if got := PerBand(tc.pages); got != tc.want {
@@ -47,15 +55,17 @@ func TestPerBandLinearScaling(t *testing.T) {
 }
 
 func TestPerBandCap(t *testing.T) {
-	// Cap binds at ~2,000 pages and never exceeds 50.
+	// Cap binds at exactly 10,000 pages and never exceeds 15. The
+	// sub-linear curve means audit count plateaus while %-audited
+	// keeps tapering, which is the intended cost ceiling shape.
 	cases := []struct {
 		pages int
 		want  int
 	}{
-		{2000, 50},
-		{5000, 50},
-		{10000, 50},
-		{100000, 50},
+		{10000, 15},
+		{12000, 15},
+		{50000, 15},
+		{1_000_000, 15},
 	}
 	for _, tc := range cases {
 		if got := PerBand(tc.pages); got != tc.want {
@@ -127,11 +137,12 @@ func TestSampleSmallSetSplitsBands(t *testing.T) {
 }
 
 func TestSampleMidSizedDistribution(t *testing.T) {
-	// 200 tasks, perBand = 5: expect 5 fastest + 5 slowest, disjoint.
+	// 200 tasks, perBand = 2 (sqrt(200)*0.15 = 2.12 → floor 2): expect
+	// 2 fastest + 2 slowest, disjoint.
 	tasks := makeTasks(200)
 	got := SelectSamples(tasks, 10, nil)
-	if len(got) != 10 {
-		t.Fatalf("expected 10 samples, got %d", len(got))
+	if len(got) != 4 {
+		t.Fatalf("expected 4 samples, got %d", len(got))
 	}
 
 	seen := make(map[int]bool)
@@ -148,12 +159,12 @@ func TestSampleMidSizedDistribution(t *testing.T) {
 			slowestCount++
 		}
 	}
-	if fastestCount != 5 || slowestCount != 5 {
-		t.Errorf("expected 5 fastest + 5 slowest, got %d + %d", fastestCount, slowestCount)
+	if fastestCount != 2 || slowestCount != 2 {
+		t.Errorf("expected 2 fastest + 2 slowest, got %d + %d", fastestCount, slowestCount)
 	}
 
-	// Fastest band should hold pages 1..5 (lowest response_time).
-	for i := 0; i < 5; i++ {
+	// Fastest band should hold pages 1..2 (lowest response_time).
+	for i := 0; i < 2; i++ {
 		if got[i].Band != BandFastest {
 			t.Errorf("expected fastest at index %d, got %s", i, got[i].Band)
 		}
@@ -161,24 +172,24 @@ func TestSampleMidSizedDistribution(t *testing.T) {
 			t.Errorf("fastest order wrong at %d: got page %d", i, got[i].Task.PageID)
 		}
 	}
-	// Slowest band should hold pages 200..196 (highest response_time first).
-	for i := 0; i < 5; i++ {
+	// Slowest band should hold pages 200..199 (highest response_time first).
+	for i := 0; i < 2; i++ {
 		want := 200 - i
-		if got[5+i].Band != BandSlowest {
-			t.Errorf("expected slowest at index %d, got %s", 5+i, got[5+i].Band)
+		if got[2+i].Band != BandSlowest {
+			t.Errorf("expected slowest at index %d, got %s", 2+i, got[2+i].Band)
 		}
-		if got[5+i].Task.PageID != want {
-			t.Errorf("slowest order wrong at %d: got page %d, want %d", 5+i, got[5+i].Task.PageID, want)
+		if got[2+i].Task.PageID != want {
+			t.Errorf("slowest order wrong at %d: got page %d, want %d", 2+i, got[2+i].Task.PageID, want)
 		}
 	}
 }
 
 func TestSampleAtCap(t *testing.T) {
-	// 10,000 tasks, perBand = 50 (cap): expect exactly 50 + 50 = 100.
+	// 10,000 tasks, perBand = 15 (cap): expect exactly 15 + 15 = 30.
 	tasks := makeTasks(10000)
 	got := SelectSamples(tasks, 100, nil)
-	if len(got) != 100 {
-		t.Fatalf("expected 100 samples at cap, got %d", len(got))
+	if len(got) != 30 {
+		t.Fatalf("expected 30 samples at cap, got %d", len(got))
 	}
 	var fastest, slowest int
 	for _, s := range got {
@@ -189,19 +200,19 @@ func TestSampleAtCap(t *testing.T) {
 			slowest++
 		}
 	}
-	if fastest != 50 || slowest != 50 {
-		t.Errorf("expected 50/50 split at cap, got %d/%d", fastest, slowest)
+	if fastest != 15 || slowest != 15 {
+		t.Errorf("expected 15/15 split at cap, got %d/%d", fastest, slowest)
 	}
 }
 
 func TestSampleDedupeAcrossMilestones(t *testing.T) {
-	// First milestone over 200 tasks samples 5 fastest + 5 slowest.
+	// First milestone over 200 tasks samples 2 fastest + 2 slowest.
 	// Second milestone over the same 200 tasks should skip the
 	// pre-sampled IDs and select different ones from the remaining.
 	tasks := makeTasks(200)
 	first := SelectSamples(tasks, 10, nil)
-	if len(first) != 10 {
-		t.Fatalf("first pass expected 10 samples, got %d", len(first))
+	if len(first) != 4 {
+		t.Fatalf("first pass expected 4 samples, got %d", len(first))
 	}
 
 	already := make(map[int]struct{})
@@ -210,8 +221,8 @@ func TestSampleDedupeAcrossMilestones(t *testing.T) {
 	}
 
 	second := SelectSamples(tasks, 20, already)
-	if len(second) != 10 {
-		t.Fatalf("second pass expected 10 samples, got %d", len(second))
+	if len(second) != 4 {
+		t.Fatalf("second pass expected 4 samples, got %d", len(second))
 	}
 
 	for _, s := range second {
@@ -220,7 +231,7 @@ func TestSampleDedupeAcrossMilestones(t *testing.T) {
 		}
 	}
 
-	// Combined coverage: first 10 + next 10 = 20 distinct pages.
+	// Combined coverage: first 4 + next 4 = 8 distinct pages.
 	all := make(map[int]struct{})
 	for _, s := range first {
 		all[s.Task.PageID] = struct{}{}
@@ -228,8 +239,8 @@ func TestSampleDedupeAcrossMilestones(t *testing.T) {
 	for _, s := range second {
 		all[s.Task.PageID] = struct{}{}
 	}
-	if len(all) != 20 {
-		t.Errorf("expected 20 distinct pages across two milestones, got %d", len(all))
+	if len(all) != 8 {
+		t.Errorf("expected 8 distinct pages across two milestones, got %d", len(all))
 	}
 }
 

--- a/internal/observability/observability.go
+++ b/internal/observability/observability.go
@@ -193,6 +193,7 @@ var (
 	lighthouseRunsScheduledCounter metric.Int64Counter
 	lighthouseRunsCounter          metric.Int64Counter
 	lighthouseRunDurationHistogram metric.Float64Histogram
+	lighthouseRunRetriesCounter    metric.Int64Counter
 )
 
 // Init configures tracing and metrics exporters. When cfg.Enabled is false the function is a no-op.
@@ -1459,7 +1460,7 @@ func initLighthouseInstruments(meterProvider *sdkmetric.MeterProvider) error {
 
 	lighthouseRunsCounter, err = meter.Int64Counter(
 		"bee.lighthouse.runs_total",
-		metric.WithDescription("Lighthouse run outcomes grouped by result (succeeded|failed|skipped_quota)"),
+		metric.WithDescription("Lighthouse run outcomes grouped by result (succeeded|failed|skipped_quota|shed)"),
 	)
 	if err != nil {
 		return err
@@ -1469,6 +1470,14 @@ func initLighthouseInstruments(meterProvider *sdkmetric.MeterProvider) error {
 		"bee.lighthouse.run_duration_ms",
 		metric.WithUnit("ms"),
 		metric.WithDescription("Wall-clock duration of a single lighthouse audit, measured by the runner"),
+	)
+	if err != nil {
+		return err
+	}
+
+	lighthouseRunRetriesCounter, err = meter.Int64Counter(
+		"bee.lighthouse.run_retries_total",
+		metric.WithDescription("Transient Chromium failures that triggered the runner's one-shot retry, grouped by reason"),
 	)
 	return err
 }
@@ -1486,7 +1495,11 @@ func RecordLighthouseScheduled(ctx context.Context, jobID, band string, count in
 }
 
 // RecordLighthouseRun increments the consumer-side run outcome counter.
-// outcome values: "succeeded", "failed", "skipped_quota".
+// outcome values: "succeeded", "failed", "skipped_quota", "shed".
+// "shed" tracks audits the runner deferred via the soft memory-shed
+// circuit breaker (left in 'running', message redelivered later); a
+// rising shed rate is the signal that the analysis fleet is
+// memory-saturated and needs scaling up.
 func RecordLighthouseRun(ctx context.Context, jobID, outcome string) {
 	_ = jobID
 	if lighthouseRunsCounter == nil {
@@ -1506,4 +1519,18 @@ func RecordLighthouseRunDuration(ctx context.Context, jobID, outcome string, dur
 	}
 	lighthouseRunDurationHistogram.Record(ctx, durationMs,
 		metric.WithAttributes(attribute.String("outcome", outcome)))
+}
+
+// RecordLighthouseRunRetry increments the transient-retry counter.
+// reason is a short tag identifying the recognised stderr substring
+// that triggered the retry (e.g. "target_crashed", "protocol_error");
+// keep cardinality low — these are the named patterns from the
+// runner's transientStderrSubstrings list, not free-form error text.
+func RecordLighthouseRunRetry(ctx context.Context, jobID, reason string) {
+	_ = jobID
+	if lighthouseRunRetriesCounter == nil {
+		return
+	}
+	lighthouseRunRetriesCounter.Add(ctx, 1,
+		metric.WithAttributes(attribute.String("reason", reason)))
 }


### PR DESCRIPTION
## Summary

- Phase 3 of the Lighthouse performance audits feature — replaces the `StubRunner` in `hover-analysis` with a real `LocalRunner` that shells out to bundled Chromium + `lighthouse@12.2.1`, parses the JSON report, gzips and uploads to R2 under `jobs/{job_id}/tasks/{task_id}/lighthouse-mobile.json.gz`, and returns populated metrics into `lighthouse_runs`.
- `Dockerfile.analysis` rebased from Alpine to `node:20-slim` (Debian bookworm) so we can pull Chromium from a repo that tracks upstream within days; Alpine's chromium consistently lagged. Pinned: `lighthouse@12.2.1`; chromium installs latest bookworm (147.0.7727.116 at build time — TODO to pin exactly after first prod build).
- `LIGHTHOUSE_RUNNER` stays `stub` in both prod (`fly.analysis.toml`) and review-app tomls in this PR. The chromium layers ship in the image either way; the runner default flip is a follow-up commit on this PR after the first production smoke test confirms a clean boot.

## What changed

**Code**
- `internal/db/lighthouse.go` — `MarkLighthouseRunRunning` now `RETURNING source_task_id` so the consumer can build R2 keys without an extra SELECT.
- `internal/lighthouse/runner.go` — `AuditRequest.SourceTaskID` added.
- `internal/lighthouse/report.go` — Lighthouse JSON → `AuditResult` parser. Missing audits surface as nil (NULL in `lighthouse_runs`), preserving the "not measured" semantic.
- `internal/lighthouse/runner_local.go` — `LocalRunner` honouring `LIGHTHOUSE_AUDIT_TIMEOUT_MS`, `Setpgid` + `Kill(-pgid, SIGKILL)` on context cancel, one retry on recognised transient stderr substrings, ring-buffered stderr tail (16 KiB) into the returned error.
- `internal/lighthouse/runner_local.go` — `ErrMemoryShed` sentinel; `cmd/analysis/main.go` treats it like shutdown cancellation (leave row in `running`, skip ACK) so XAUTOCLAIM redelivers when memory recovers.
- `internal/archive/archive.go` — `LighthouseObjectPath` co-locates the report with `page-content.html.gz`; falls back to `jobs/{job_id}/runs/{run_id}/...` when the parent task was nulled by `ON DELETE SET NULL`.
- `cmd/analysis/main.go` — `selectRunner` switch handles `local`, archive provider boots via `archive.ProviderFromEnv()` (fatal only when `LIGHTHOUSE_RUNNER=local`), `SourceTaskID` threaded into the `AuditRequest`.

**Infra**
- `Dockerfile.analysis` — `node:20-slim` runtime, `chromium` + `chromium-sandbox` + `fonts-liberation` + `dumb-init` (zombie reaper for renderer crashes), `lighthouse@12.2.1` global npm install, non-root `appuser` (uid 10001).
- `fly.analysis.toml` — adds `LIGHTHOUSE_BIN=/usr/local/bin/lighthouse` and `CHROMIUM_BIN=/usr/bin/chromium`.

**Tests**
- `internal/lighthouse/report_test.go` — happy path, missing audits, null `numericValue`, malformed JSON, score rounding edges (0.005, 0.495, 0.999).
- `internal/lighthouse/runner_local_test.go` — config validation, memory shed sentinel, happy-path upload via fake provider + shell-script stand-in for the lighthouse binary, run-id fallback when source_task_id is empty, transient stderr retry, hard-fail no-retry, timeout-kills-process-tree, isTransientErr cases, tail-buffer wrap-around.
- `internal/db/lighthouse_test.go` — `MarkLighthouseRunRunning` test rewritten for `ExpectQuery` + `RETURNING`, covers task ID passthrough including NULL → empty-string fallback.

## Notes

- Image size: ~2 GB (Chromium dominates). Within Fly's pull window; future-trim candidate but not a blocker.
- Three gosec false positives suppressed inline with rationale (`#nosec G204` on the bin shellout, `#nosec G306` on test fixture file modes).
- Plan doc (`docs/plans/lighthouse-performance-reports.md`) updated with Phase 3 implementation notes following the Phase 1/2 pattern.

## Test plan

- [ ] Review app builds the image cleanly with the new layers.
- [ ] Review app's stub-runner end-to-end flow still passes (no regression on the Phase 2 producer).
- [ ] Manual smoke: temporarily `flyctl secrets set LIGHTHOUSE_RUNNER=local --app hover-analysis-pr-<N>` on the review app, run a small crawl, confirm `lighthouse_runs.report_key` populated, R2 object present, peak RSS < 4 GB at concurrency 1, mean audit duration < 45 s, failure rate < 5%. Document numbers as a comment on this PR.
- [ ] Only after review-app numbers look healthy: a follow-up commit flips `LIGHTHOUSE_RUNNER=local` in `fly.analysis.toml`. Rollback is a one-line `flyctl secrets set LIGHTHOUSE_RUNNER=stub`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Local Lighthouse executor with one retry for transient CLI failures; low-memory runs are marked "shed" for safe redelivery.
  * Parses Lighthouse output into stable metrics and stores gzipped reports using task-preferred keys with run-ID fallback.
  * Audit requests now carry source-task IDs; adds retry and "shed" observability metrics.

* **Chores**
  * Hardened analysis runtime: non-root execution, pinned tooling, Debian base, explicit binary paths, and process reaping.

* **Documentation**
  * Updated Lighthouse CLI guidance, sampler changed to a square-root sizing curve, Phase 3 status updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->