### PR TITLE
Reclaim Redis keys on job completion

### DIFF
--- a/.github/workflows/cleanup-orphaned-apps.yml
+++ b/.github/workflows/cleanup-orphaned-apps.yml
@@ -73,4 +73,35 @@ jobs:
             echo ""
           done
 
+          # The PR-close workflow also destroys the per-PR Upstash Redis
+          # instance, but only if the workflow runs to completion. If a
+          # PR was force-closed during a deploy, or the close-event
+          # workflow failed, the Redis instance survives and continues
+          # accruing PAYG charges. Sweep the orphaned ones here using
+          # the same PR-state check.
+          echo "Listing orphaned Upstash Redis instances..."
+          REDIS_NAMES=$(flyctl redis list --json 2>/dev/null \
+            | jq -r '.[] | select(.Name | startswith("hover-redis-pr-")) | .Name' \
+            || echo "")
+
+          if [ -z "$REDIS_NAMES" ]; then
+            echo "No hover-redis-pr-* instances found"
+          else
+            for REDIS_NAME in $REDIS_NAMES; do
+              PR_NUMBER=$(echo "$REDIS_NAME" | sed -e 's/^hover-redis-pr-//')
+              echo "Checking PR #$PR_NUMBER for Redis $REDIS_NAME..."
+
+              PR_STATE=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json state --jq '.state' 2>/dev/null || echo "NOT_FOUND")
+              echo "  PR state: $PR_STATE"
+
+              if [ "$PR_STATE" = "OPEN" ]; then
+                echo "  PR is open, keeping Redis"
+              else
+                echo "  PR is closed/merged/missing, destroying Redis..."
+                flyctl redis destroy "$REDIS_NAME" --yes || echo "  Failed to destroy $REDIS_NAME"
+              fi
+              echo ""
+            done
+          fi
+
           echo "Cleanup complete"

--- a/.github/workflows/review-apps.yml
+++ b/.github/workflows/review-apps.yml
@@ -214,16 +214,30 @@ jobs:
             # attempt an interactive prompt (which errors in CI with
             # "Error: prompt: non interactive"). Piping stdin is not enough;
             # recent flyctl versions abort rather than read from stdin.
-            # Do not pass --plan: flyctl rejects the documented default
-            # value ("pay-as-you-go") with "plan not found", and the default
-            # is applied automatically when the flag is omitted.
-            if ! flyctl redis create \
-              --name "$REDIS_NAME" \
-              --region syd \
-              --no-replicas \
-              --disable-eviction \
-              --enable-prodpack=false \
-              --org personal; then
+            #
+            # Plan handling: REVIEW_REDIS_PLAN (a repo variable) selects a
+            # Fixed-tier subscription to cap spend (PR-330 accrued $150 of
+            # PAYG charges before cleanup ran). Leave it empty to keep the
+            # historical PAYG default. The documented default value
+            # ("pay-as-you-go") is rejected by flyctl, so the exact slug is
+            # environment-specific and must be confirmed locally with
+            # `flyctl redis create --help` before turning this on in CI.
+            CREATE_ARGS=(
+              redis create
+              --name "$REDIS_NAME"
+              --region syd
+              --no-replicas
+              --disable-eviction
+              --enable-prodpack=false
+              --org personal
+            )
+            if [ -n "$REVIEW_REDIS_PLAN" ]; then
+              echo "Using Fixed plan: $REVIEW_REDIS_PLAN"
+              CREATE_ARGS+=(--plan "$REVIEW_REDIS_PLAN")
+            else
+              echo "REVIEW_REDIS_PLAN not set — defaulting to pay-as-you-go"
+            fi
+            if ! flyctl "${CREATE_ARGS[@]}"; then
               echo "❌ flyctl redis create failed for $REDIS_NAME"
               exit 1
             fi
@@ -258,6 +272,7 @@ jobs:
         env:
           FLY_API_TOKEN: ${{ env.FLY_API_TOKEN }}
           PR_NUMBER: ${{ github.event.number }}
+          REVIEW_REDIS_PLAN: ${{ vars.REVIEW_REDIS_PLAN }}
 
       - name: Build Docker image locally
         run: |

--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -156,7 +156,11 @@ func startJobScheduler(ctx context.Context, wg *sync.WaitGroup, jobsManager *job
 // startHealthMonitoring starts background monitoring for job completion and system health
 // It respects context cancellation for graceful shutdown
 // The WaitGroup must be marked Done when this function exits
-func startHealthMonitoring(ctx context.Context, wg *sync.WaitGroup, pgDB *db.DB) {
+//
+// redisClient may be nil when REDIS_URL is unset; in that case the
+// per-job Redis cleanup on completion is skipped (there is nothing to
+// clean up).
+func startHealthMonitoring(ctx context.Context, wg *sync.WaitGroup, pgDB *db.DB, redisClient *broker.Client) {
 	defer wg.Done() // Signal completion when exiting
 
 	completionTicker := time.NewTicker(completionCheckInterval)
@@ -178,12 +182,32 @@ func startHealthMonitoring(ctx context.Context, wg *sync.WaitGroup, pgDB *db.DB)
 			startupLog.Error("Failed to update completed jobs", "error", err)
 			return
 		}
-		defer rows.Close()
 
+		// Capture the IDs so we can release the rows before issuing
+		// per-job Redis cleanup — Postgres connection holds a row lock
+		// for the duration of an open Rows iterator.
+		var completed []string
 		for rows.Next() {
 			var jobID string
 			if err := rows.Scan(&jobID); err == nil {
 				startupLog.Info("Job marked as completed", "job_id", jobID)
+				completed = append(completed, jobID)
+			}
+		}
+		_ = rows.Close()
+
+		// Drop per-job Redis keys (schedule ZSET, both streams + their
+		// consumer groups, running-counter HASH field). Without this the
+		// active-jobs query filters completed jobs out and their keys
+		// leak into resident data forever. Errors here do not roll the
+		// Postgres status change back — partial cleanup is acceptable
+		// and the one-off reclaim sweeper can reattempt.
+		if redisClient != nil {
+			for _, jobID := range completed {
+				if err := redisClient.RemoveJobKeys(ctx, jobID); err != nil {
+					startupLog.Warn("failed to clean up Redis keys for completed job",
+						"error", err, "job_id", jobID)
+				}
 			}
 		}
 	}
@@ -628,6 +652,17 @@ func main() {
 				}
 			}
 		}
+
+		// Wire the terminal-state cleanup callback so CancelJob releases
+		// the per-job Redis keys. The completion-tick path in
+		// startHealthMonitoring takes the redisClient directly and does
+		// the same cleanup for auto-completed jobs.
+		jobsManager.OnJobTerminated = func(ctx context.Context, jobID string) {
+			if err := redisClient.RemoveJobKeys(ctx, jobID); err != nil {
+				startupLog.Warn("failed to clean up Redis keys for terminated job",
+					"error", err, "job_id", jobID)
+			}
+		}
 	} else {
 		startupLog.Warn("REDIS_URL not set — task dispatch to Redis is disabled; API will still create tasks in Postgres")
 	}
@@ -784,7 +819,7 @@ func main() {
 
 	// Start background health monitoring with cancellable context
 	backgroundWG.Add(1)
-	go startHealthMonitoring(appCtx, &backgroundWG, pgDB)
+	go startHealthMonitoring(appCtx, &backgroundWG, pgDB, redisClient)
 
 	// Start scheduler service
 	backgroundWG.Add(1)

--- a/internal/api/admin.go
+++ b/internal/api/admin.go
@@ -2,13 +2,16 @@ package api
 
 import (
 	"context"
+	"database/sql"
 	"net/http"
 	"os"
 	"time"
 
 	"github.com/Harvey-AU/hover/internal/auth"
+	"github.com/Harvey-AU/hover/internal/broker"
 	"github.com/Harvey-AU/hover/internal/logging"
 	"github.com/getsentry/sentry-go"
+	"github.com/lib/pq"
 )
 
 // organisationIDOrNone returns the organisation ID as a string, or "none"
@@ -269,6 +272,178 @@ func (h *Handler) AdminResetData(w http.ResponseWriter, r *http.Request) {
 		msg = "Data cleared; Redis clear failed - flush manually"
 	}
 	WriteSuccess(w, r, payload, msg)
+}
+
+// AdminReclaimRedis runs the one-off backfill sweeper that drops Redis
+// keys for jobs that have already reached a terminal state (completed,
+// cancelled, failed, archived) but never had their per-job keys cleaned
+// up. Targets the historical leak introduced by RemoveJobSchedule and
+// RemoveJob being defined-but-unused; phase 1 fixes the forward path,
+// this endpoint reclaims data already resident.
+//
+// Idempotent and intentionally simple: no batching, no progress
+// streaming. The expected use is a single curl after deploy. Gated on
+// ALLOW_DB_RESET (already used by the other admin reset endpoints) so
+// the endpoint cannot be hit without explicit operator opt-in.
+func (h *Handler) AdminReclaimRedis(w http.ResponseWriter, r *http.Request) {
+	logger := loggerWithRequest(r)
+
+	if r.Method != http.MethodPost {
+		MethodNotAllowed(w, r)
+		return
+	}
+
+	if os.Getenv("ALLOW_DB_RESET") != "true" {
+		Forbidden(w, r, "Reclaim not enabled. Set ALLOW_DB_RESET=true to enable")
+		return
+	}
+
+	claims, ok := auth.GetUserFromContext(r.Context())
+	if !ok {
+		Unauthorised(w, r, "Authentication required for admin endpoint")
+		return
+	}
+	if !hasSystemAdminRole(claims) {
+		logger.Warn("Non-system-admin user attempted to access reclaim endpoint", "user_id", claims.UserID)
+		Forbidden(w, r, "System administrator privileges required")
+		return
+	}
+
+	if h.Broker == nil {
+		BadRequest(w, r, "Redis broker not configured; nothing to reclaim")
+		return
+	}
+
+	user, err := h.DB.GetUser(claims.UserID)
+	if err != nil {
+		logger.Error("Failed to verify admin user", "error", err, "user_id", claims.UserID)
+		Unauthorised(w, r, "User verification failed")
+		return
+	}
+
+	logger.Warn("Admin Redis reclaim requested",
+		"user_id", user.ID,
+		"organisation_id", organisationIDOrNone(user.OrganisationID),
+		"remote_addr", r.RemoteAddr,
+	)
+
+	sqlDB := h.DB.GetDB()
+	filter := terminalJobFilter(sqlDB)
+
+	report, err := h.Broker.ReclaimTerminalJobKeys(r.Context(), filter)
+	if err != nil {
+		logger.Error("Reclaim sweep failed", "error", err, "user_id", user.ID)
+		sentry.CaptureException(err)
+		InternalError(w, r, err)
+		return
+	}
+
+	logger.Warn("Redis reclaim completed",
+		"user_id", user.ID,
+		"candidates", report.CandidatesScanned,
+		"terminal", report.TerminalJobs,
+		"cleaned", report.Cleaned,
+		"failed", report.Failed,
+	)
+
+	payload := map[string]any{
+		"candidates_scanned": report.CandidatesScanned,
+		"terminal_jobs":      report.TerminalJobs,
+		"cleaned":            report.Cleaned,
+		"failed":             report.Failed,
+	}
+	if report.FirstError != nil {
+		payload["first_error"] = report.FirstError.Error()
+	}
+	WriteSuccess(w, r, payload, "Redis reclaim sweep completed")
+}
+
+// terminalJobFilter returns a broker.TerminalFilter that selects job
+// IDs whose Postgres status is in the terminal set (completed, failed,
+// cancelled, archived). Jobs missing from the jobs table are also
+// treated as terminal — their Redis state is orphaned by definition.
+func terminalJobFilter(sqlDB interface {
+	QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error)
+}) broker.TerminalFilter {
+	return func(ctx context.Context, jobIDs []string) ([]string, error) {
+		if len(jobIDs) == 0 {
+			return nil, nil
+		}
+
+		rows, err := sqlDB.QueryContext(ctx,
+			`SELECT id FROM jobs
+			   WHERE id = ANY($1)
+			     AND status IN ('completed', 'failed', 'cancelled', 'archived')`,
+			pq.Array(jobIDs))
+		if err != nil {
+			return nil, err
+		}
+		defer rows.Close()
+
+		alive := make(map[string]struct{}, len(jobIDs))
+		known := make(map[string]struct{})
+		var terminal []string
+		for rows.Next() {
+			var id string
+			if err := rows.Scan(&id); err != nil {
+				return nil, err
+			}
+			terminal = append(terminal, id)
+			known[id] = struct{}{}
+		}
+		if err := rows.Err(); err != nil {
+			return nil, err
+		}
+
+		// Find any candidates that did not appear in the result — those
+		// are either still active or no longer in the jobs table at
+		// all. A second query bounds 'still active' so deletion-by-
+		// missing-row only fires for genuine orphans.
+		stillActive, err := lookupActiveJobs(ctx, sqlDB, jobIDs)
+		if err != nil {
+			return nil, err
+		}
+		for _, id := range stillActive {
+			alive[id] = struct{}{}
+		}
+		for _, id := range jobIDs {
+			if _, t := known[id]; t {
+				continue
+			}
+			if _, a := alive[id]; a {
+				continue
+			}
+			terminal = append(terminal, id)
+		}
+		return terminal, nil
+	}
+}
+
+// lookupActiveJobs returns the subset of jobIDs whose row in the jobs
+// table is still in a non-terminal state. Used by terminalJobFilter to
+// distinguish "row missing — orphan" from "row present and running".
+func lookupActiveJobs(ctx context.Context, sqlDB interface {
+	QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error)
+}, jobIDs []string) ([]string, error) {
+	rows, err := sqlDB.QueryContext(ctx,
+		`SELECT id FROM jobs
+		   WHERE id = ANY($1)
+		     AND status NOT IN ('completed', 'failed', 'cancelled', 'archived')`,
+		pq.Array(jobIDs))
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var active []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		active = append(active, id)
+	}
+	return active, rows.Err()
 }
 
 // clearBrokerState invokes broker.ClearAll when the broker is wired and

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/Harvey-AU/hover/internal/auth"
+	"github.com/Harvey-AU/hover/internal/broker"
 	"github.com/Harvey-AU/hover/internal/db"
 	"github.com/Harvey-AU/hover/internal/jobs"
 	"github.com/Harvey-AU/hover/internal/logging"
@@ -213,11 +214,11 @@ type DBClient interface {
 }
 
 // BrokerCleaner is the subset of the broker client the API needs for
-// admin reset endpoints. Defining it here keeps the api package free of
-// a hard import on internal/broker and makes the Handler trivially
-// mockable in tests.
+// admin reset endpoints. The interface keeps the Handler trivially
+// mockable; production wiring uses *broker.Client.
 type BrokerCleaner interface {
 	ClearAll(ctx context.Context) (int, error)
+	ReclaimTerminalJobKeys(ctx context.Context, filter broker.TerminalFilter) (broker.ReclaimReport, error)
 }
 
 // Handler holds dependencies for API handlers
@@ -374,6 +375,7 @@ func (h *Handler) SetupRoutes(mux *http.ServeMux) {
 	// Admin endpoints (require authentication and admin role)
 	mux.Handle("/v1/admin/reset-db", auth.AuthMiddleware(http.HandlerFunc(h.AdminResetDatabase)))
 	mux.Handle("/v1/admin/reset-data", auth.AuthMiddleware(http.HandlerFunc(h.AdminResetData)))
+	mux.Handle("/v1/admin/reclaim-redis", auth.AuthMiddleware(http.HandlerFunc(h.AdminReclaimRedis)))
 
 	// Protected pprof endpoints (system admin + auth required)
 	pprofProtected := func(handler http.Handler) http.Handler {

--- a/internal/broker/pacer_lua.go
+++ b/internal/broker/pacer_lua.go
@@ -22,16 +22,25 @@ local threshold = tonumber(ARGV[1])
 local step = tonumber(ARGV[2])
 
 redis.call('HINCRBY', key, 'success_streak', 1)
-redis.call('HSET', key, 'error_streak', '0')
 
-local streak = tonumber(redis.call('HGET', key, 'success_streak') or '0')
-local delay = tonumber(redis.call('HGET', key, 'adaptive_delay_ms') or '0')
-local floor = tonumber(redis.call('HGET', key, 'floor_ms') or '0')
+-- One HMGET replaces three HGETs against the same hash; the post-
+-- HINCRBY read is intentional so the streak value reflects this call.
+local fields = redis.call('HMGET', key, 'success_streak', 'adaptive_delay_ms', 'floor_ms')
+local streak = tonumber(fields[1] or '0') or 0
+local delay = tonumber(fields[2] or '0') or 0
+local floor = tonumber(fields[3] or '0') or 0
 
 if streak >= threshold and delay > floor then
     delay = math.max(floor, delay - step)
-    redis.call('HSET', key, 'adaptive_delay_ms', tostring(delay))
-    redis.call('HSET', key, 'success_streak', '0')
+    -- Single HMSET batches the three writes (error_streak reset, new
+    -- adaptive delay, success_streak reset) that previously ran as
+    -- separate HSETs.
+    redis.call('HMSET', key,
+        'error_streak', '0',
+        'adaptive_delay_ms', tostring(delay),
+        'success_streak', '0')
+else
+    redis.call('HSET', key, 'error_streak', '0')
 end
 
 redis.call('EXPIRE', key, 86400)
@@ -55,8 +64,12 @@ var tryAcquireScript = redis.NewScript(`
 local cfgKey = KEYS[1]
 local gateKey = KEYS[2]
 
-local base = tonumber(redis.call('HGET', cfgKey, 'base_delay_ms') or '0') or 0
-local adaptive = tonumber(redis.call('HGET', cfgKey, 'adaptive_delay_ms') or '0') or 0
+-- One HMGET replaces two HGETs against cfgKey. tryAcquire is on the
+-- dispatch hot path; halving the per-call command count meaningfully
+-- shrinks the Upstash command bill.
+local cfg = redis.call('HMGET', cfgKey, 'base_delay_ms', 'adaptive_delay_ms')
+local base = tonumber(cfg[1] or '0') or 0
+local adaptive = tonumber(cfg[2] or '0') or 0
 local delay = base
 if adaptive > delay then
     delay = adaptive
@@ -94,11 +107,14 @@ local step = tonumber(ARGV[1])
 local maxDelay = tonumber(ARGV[2])
 
 redis.call('HINCRBY', key, 'error_streak', 1)
-redis.call('HSET', key, 'success_streak', '0')
 
 local delay = tonumber(redis.call('HGET', key, 'adaptive_delay_ms') or '0')
 delay = math.min(maxDelay, delay + step)
-redis.call('HSET', key, 'adaptive_delay_ms', tostring(delay))
+-- HMSET coalesces the success_streak reset and the new adaptive delay
+-- into a single write; the previous code issued these as two HSETs.
+redis.call('HMSET', key,
+    'success_streak', '0',
+    'adaptive_delay_ms', tostring(delay))
 
 redis.call('EXPIRE', key, 86400)
 return delay

--- a/internal/broker/reclaim.go
+++ b/internal/broker/reclaim.go
@@ -1,0 +1,133 @@
+package broker
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// TerminalFilter receives a batch of jobIDs found in Redis and must
+// return the subset that have reached a terminal state in the
+// authoritative store (Postgres). Implementations can be batched (one
+// IN-clause SELECT) so the broker package stays free of SQL.
+type TerminalFilter func(ctx context.Context, jobIDs []string) ([]string, error)
+
+// ReclaimReport summarises a one-off reclaim sweep.
+type ReclaimReport struct {
+	// CandidatesScanned is the number of unique jobIDs found in any
+	// per-job Redis key (schedule ZSET, streams, running-counter HASH).
+	CandidatesScanned int
+	// TerminalJobs is the number of jobIDs the filter classified as
+	// terminal — i.e. eligible for cleanup.
+	TerminalJobs int
+	// Cleaned is the number of jobs whose RemoveJobKeys call returned
+	// without error.
+	Cleaned int
+	// Failed is the number of jobs whose RemoveJobKeys call returned an
+	// error. The first such error is captured in FirstError so the caller
+	// can surface it without holding a slice of every failure.
+	Failed     int
+	FirstError error
+}
+
+// ReclaimTerminalJobKeys is the one-off backfill sweeper described in
+// the Redis usage optimisation plan, phase 2. It enumerates jobIDs that
+// still own per-job Redis state, asks the supplied filter which of
+// those are terminal in Postgres, and runs RemoveJobKeys for each.
+//
+// Designed to be invoked manually after the completion-tick cleanup in
+// startHealthMonitoring is verified in production. Idempotent; safe to
+// re-run.
+func (c *Client) ReclaimTerminalJobKeys(ctx context.Context, filter TerminalFilter) (ReclaimReport, error) {
+	if filter == nil {
+		return ReclaimReport{}, fmt.Errorf("broker: ReclaimTerminalJobKeys requires a TerminalFilter")
+	}
+
+	candidates, err := c.listJobIDsInRedis(ctx)
+	if err != nil {
+		return ReclaimReport{}, err
+	}
+
+	report := ReclaimReport{CandidatesScanned: len(candidates)}
+	if len(candidates) == 0 {
+		return report, nil
+	}
+
+	terminal, err := filter(ctx, candidates)
+	if err != nil {
+		return report, fmt.Errorf("broker: terminal filter: %w", err)
+	}
+	report.TerminalJobs = len(terminal)
+
+	for _, jobID := range terminal {
+		if err := c.RemoveJobKeys(ctx, jobID); err != nil {
+			report.Failed++
+			if report.FirstError == nil {
+				report.FirstError = err
+			}
+			brokerLog.Warn("reclaim: RemoveJobKeys failed", "error", err, "job_id", jobID)
+			continue
+		}
+		report.Cleaned++
+	}
+	return report, nil
+}
+
+// listJobIDsInRedis returns every jobID that owns at least one per-job
+// key in Redis. Sources scanned: schedule ZSETs, both stream variants,
+// and the running-counter HASH fields. Consumer-group keys live inside
+// streams so deleting the stream removes them implicitly — no separate
+// scan needed.
+func (c *Client) listJobIDsInRedis(ctx context.Context) ([]string, error) {
+	const batch = 500
+	seen := make(map[string]struct{})
+
+	schedPrefix := keyPrefix + "sched:"
+	streamPrefix := keyPrefix + "stream:"
+	lhSuffix := ":lh"
+
+	for _, pattern := range []string{schedPrefix + "*", streamPrefix + "*"} {
+		var cursor uint64
+		for {
+			page, next, err := c.rdb.Scan(ctx, cursor, pattern, batch).Result()
+			if err != nil {
+				return nil, fmt.Errorf("broker: scan %s: %w", pattern, err)
+			}
+			for _, key := range page {
+				var jobID string
+				switch {
+				case strings.HasPrefix(key, schedPrefix):
+					jobID = strings.TrimPrefix(key, schedPrefix)
+				case strings.HasPrefix(key, streamPrefix):
+					jobID = strings.TrimPrefix(key, streamPrefix)
+					jobID = strings.TrimSuffix(jobID, lhSuffix)
+				}
+				if jobID != "" {
+					seen[jobID] = struct{}{}
+				}
+			}
+			if next == 0 {
+				break
+			}
+			cursor = next
+		}
+	}
+
+	fields, err := c.rdb.HKeys(ctx, RunningCountersKey).Result()
+	if err != nil && err != redis.Nil {
+		return nil, fmt.Errorf("broker: hkeys %s: %w", RunningCountersKey, err)
+	}
+	for _, f := range fields {
+		if f != "" {
+			seen[f] = struct{}{}
+		}
+	}
+
+	out := make([]string, 0, len(seen))
+	for id := range seen {
+		out = append(out, id)
+	}
+	return out, nil
+}

--- a/internal/broker/reclaim_test.go
+++ b/internal/broker/reclaim_test.go
@@ -1,0 +1,166 @@
+package broker
+
+import (
+	"context"
+	"errors"
+	"sort"
+	"testing"
+
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestClient_ReclaimTerminalJobKeys_HappyPath seeds three jobs (one
+// terminal, one still running, one with only a lighthouse stream and
+// also terminal) and verifies the sweeper cleans only the terminal ones
+// while leaving the running job intact.
+func TestClient_ReclaimTerminalJobKeys_HappyPath(t *testing.T) {
+	client, _ := newTestClientWithMiniredis(t)
+	ctx := context.Background()
+
+	// Job A: terminal, full key set.
+	require.NoError(t, client.rdb.ZAdd(ctx, ScheduleKey("A"),
+		redis.Z{Score: 1, Member: "task-a"}).Err())
+	require.NoError(t, client.rdb.XGroupCreateMkStream(ctx,
+		StreamKey("A"), ConsumerGroup("A"), "0").Err())
+	require.NoError(t, client.rdb.HSet(ctx, RunningCountersKey, "A", 3).Err())
+
+	// Job B: still running, must survive.
+	require.NoError(t, client.rdb.ZAdd(ctx, ScheduleKey("B"),
+		redis.Z{Score: 2, Member: "task-b"}).Err())
+	require.NoError(t, client.rdb.HSet(ctx, RunningCountersKey, "B", 7).Err())
+
+	// Job C: terminal, lighthouse-only — exercises the :lh suffix path.
+	require.NoError(t, client.rdb.XGroupCreateMkStream(ctx,
+		LighthouseStreamKey("C"), LighthouseConsumerGroup("C"), "0").Err())
+
+	filter := func(ctx context.Context, ids []string) ([]string, error) {
+		var terminal []string
+		for _, id := range ids {
+			if id == "A" || id == "C" {
+				terminal = append(terminal, id)
+			}
+		}
+		return terminal, nil
+	}
+
+	report, err := client.ReclaimTerminalJobKeys(ctx, filter)
+	require.NoError(t, err)
+	// Three unique candidates: A, B, C.
+	assert.Equal(t, 3, report.CandidatesScanned)
+	assert.Equal(t, 2, report.TerminalJobs)
+	assert.Equal(t, 2, report.Cleaned)
+	assert.Equal(t, 0, report.Failed)
+	assert.NoError(t, report.FirstError)
+
+	// A and C gone.
+	for _, key := range []string{
+		ScheduleKey("A"), StreamKey("A"), LighthouseStreamKey("C"),
+	} {
+		exists, err := client.rdb.Exists(ctx, key).Result()
+		require.NoError(t, err)
+		assert.Equal(t, int64(0), exists, "%s must be deleted", key)
+	}
+	exA, err := client.rdb.HExists(ctx, RunningCountersKey, "A").Result()
+	require.NoError(t, err)
+	assert.False(t, exA)
+
+	// B intact.
+	bScore, err := client.rdb.ZScore(ctx, ScheduleKey("B"), "task-b").Result()
+	require.NoError(t, err)
+	assert.Equal(t, float64(2), bScore)
+	bCount, err := client.rdb.HGet(ctx, RunningCountersKey, "B").Int64()
+	require.NoError(t, err)
+	assert.Equal(t, int64(7), bCount)
+}
+
+// TestClient_ReclaimTerminalJobKeys_Empty verifies the sweeper is a
+// no-op when Redis holds no per-job state.
+func TestClient_ReclaimTerminalJobKeys_Empty(t *testing.T) {
+	client, _ := newTestClientWithMiniredis(t)
+	ctx := context.Background()
+
+	called := false
+	filter := func(ctx context.Context, ids []string) ([]string, error) {
+		called = true
+		return nil, nil
+	}
+
+	report, err := client.ReclaimTerminalJobKeys(ctx, filter)
+	require.NoError(t, err)
+	assert.Equal(t, 0, report.CandidatesScanned)
+	assert.False(t, called, "filter must not be invoked when there are no candidates")
+}
+
+// TestClient_ReclaimTerminalJobKeys_FilterError surfaces filter errors
+// without partial cleanup running.
+func TestClient_ReclaimTerminalJobKeys_FilterError(t *testing.T) {
+	client, _ := newTestClientWithMiniredis(t)
+	ctx := context.Background()
+
+	require.NoError(t, client.rdb.ZAdd(ctx, ScheduleKey("X"),
+		redis.Z{Score: 1, Member: "task-x"}).Err())
+
+	wantErr := errors.New("postgres unavailable")
+	filter := func(ctx context.Context, ids []string) ([]string, error) {
+		return nil, wantErr
+	}
+
+	report, err := client.ReclaimTerminalJobKeys(ctx, filter)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, wantErr)
+	assert.Equal(t, 1, report.CandidatesScanned)
+	assert.Equal(t, 0, report.Cleaned)
+
+	// X still present — no partial cleanup before the filter answered.
+	exists, err := client.rdb.Exists(ctx, ScheduleKey("X")).Result()
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), exists)
+}
+
+// TestClient_ReclaimTerminalJobKeys_RejectsNilFilter guards the
+// happy-path call signature.
+func TestClient_ReclaimTerminalJobKeys_RejectsNilFilter(t *testing.T) {
+	client, _ := newTestClientWithMiniredis(t)
+	ctx := context.Background()
+
+	_, err := client.ReclaimTerminalJobKeys(ctx, nil)
+	require.Error(t, err)
+}
+
+// TestClient_listJobIDsInRedis exercises every source the sweeper
+// scans, including the lighthouse stream :lh suffix and the running-
+// counter HASH-only path.
+func TestClient_listJobIDsInRedis(t *testing.T) {
+	client, _ := newTestClientWithMiniredis(t)
+	ctx := context.Background()
+
+	require.NoError(t, client.rdb.ZAdd(ctx, ScheduleKey("sched-only"),
+		redis.Z{Score: 1, Member: "m"}).Err())
+	require.NoError(t, client.rdb.XAdd(ctx, &redis.XAddArgs{
+		Stream: StreamKey("stream-only"),
+		Values: map[string]interface{}{"task_id": "t"},
+	}).Err())
+	require.NoError(t, client.rdb.XAdd(ctx, &redis.XAddArgs{
+		Stream: LighthouseStreamKey("lh-only"),
+		Values: map[string]interface{}{"task_id": "t"},
+	}).Err())
+	require.NoError(t, client.rdb.HSet(ctx,
+		RunningCountersKey, "counter-only", 1).Err())
+	// Job present in both schedule and stream — must dedupe to one.
+	require.NoError(t, client.rdb.ZAdd(ctx, ScheduleKey("dual"),
+		redis.Z{Score: 1, Member: "m"}).Err())
+	require.NoError(t, client.rdb.XAdd(ctx, &redis.XAddArgs{
+		Stream: StreamKey("dual"),
+		Values: map[string]interface{}{"task_id": "t"},
+	}).Err())
+
+	got, err := client.listJobIDsInRedis(ctx)
+	require.NoError(t, err)
+	sort.Strings(got)
+	assert.Equal(t,
+		[]string{"counter-only", "dual", "lh-only", "sched-only", "stream-only"},
+		got,
+	)
+}

--- a/internal/broker/redis.go
+++ b/internal/broker/redis.go
@@ -96,6 +96,56 @@ func (c *Client) Close() error {
 // access (e.g. Lua scripts, pipelines).
 func (c *Client) RDB() *redis.Client { return c.rdb }
 
+// RemoveJobKeys deletes every Redis key owned by the broker for a single
+// terminal (completed/cancelled/failed) job. Called from the completion
+// tick and CancelJob to stop the per-job key set leaking into resident
+// data — without it the schedule ZSET, both streams, both consumer
+// groups, and the running-counter HASH field persist forever once the
+// dispatcher stops scanning the job.
+//
+// The two XGroupDestroy calls are best-effort: NOGROUP/no-such-stream
+// errors are tolerated so a partially-cleaned job (or a job that never
+// produced lighthouse work) doesn't abort the rest of the cleanup.
+func (c *Client) RemoveJobKeys(ctx context.Context, jobID string) error {
+	if jobID == "" {
+		return fmt.Errorf("broker: RemoveJobKeys requires a jobID")
+	}
+
+	streamKey := StreamKey(jobID)
+	lhStreamKey := LighthouseStreamKey(jobID)
+
+	// Destroy consumer groups before deleting the streams. Failures here
+	// are non-fatal — the group may already be gone, or the stream may
+	// never have been created (e.g. a job cancelled before any task ran).
+	if err := c.rdb.XGroupDestroy(ctx, streamKey, ConsumerGroup(jobID)).Err(); err != nil && !isMissingGroup(err) {
+		brokerLog.Warn("XGroupDestroy crawl group failed", "error", err, "job_id", jobID)
+	}
+	if err := c.rdb.XGroupDestroy(ctx, lhStreamKey, LighthouseConsumerGroup(jobID)).Err(); err != nil && !isMissingGroup(err) {
+		brokerLog.Warn("XGroupDestroy lighthouse group failed", "error", err, "job_id", jobID)
+	}
+
+	pipe := c.rdb.Pipeline()
+	pipe.Del(ctx, ScheduleKey(jobID), streamKey, lhStreamKey)
+	pipe.HDel(ctx, RunningCountersKey, jobID)
+	if _, err := pipe.Exec(ctx); err != nil {
+		return fmt.Errorf("broker: remove job keys for %s: %w", jobID, err)
+	}
+	return nil
+}
+
+// isMissingGroup reports whether err is the Redis NOGROUP / no-such-key
+// response from XGroupDestroy on a stream or group that does not exist.
+// Tolerated by RemoveJobKeys so cleanup is idempotent.
+func isMissingGroup(err error) bool {
+	if err == nil || err == redis.Nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "NOGROUP") ||
+		strings.Contains(msg, "no such key") ||
+		strings.Contains(msg, "requires the key to exist")
+}
+
 // ClearAll deletes every Redis key the broker writes to. Used by admin
 // reset endpoints. Does not call FLUSHDB — only touches hover:* prefixes
 // owned by this package, so it stays safe on a shared Redis. Returns the

--- a/internal/broker/redis_test.go
+++ b/internal/broker/redis_test.go
@@ -88,6 +88,92 @@ func TestClient_ClearAll_Empty(t *testing.T) {
 	assert.Equal(t, 0, deleted)
 }
 
+// TestClient_RemoveJobKeys seeds the full per-job key set for one job
+// alongside an unrelated job, then asserts RemoveJobKeys deletes the
+// targeted job's keys without disturbing the other.
+func TestClient_RemoveJobKeys(t *testing.T) {
+	client, _ := newTestClientWithMiniredis(t)
+	ctx := context.Background()
+
+	const target = "job-target"
+	const survivor = "job-survivor"
+
+	// Seed the targeted job: schedule ZSET, both streams (with their
+	// consumer groups), and a running-counter entry.
+	require.NoError(t, client.rdb.ZAdd(ctx, ScheduleKey(target),
+		redis.Z{Score: 1, Member: "task-1"}).Err())
+	require.NoError(t, client.rdb.XGroupCreateMkStream(ctx,
+		StreamKey(target), ConsumerGroup(target), "0").Err())
+	require.NoError(t, client.rdb.XAdd(ctx, &redis.XAddArgs{
+		Stream: StreamKey(target),
+		Values: map[string]interface{}{"task_id": "t1"},
+	}).Err())
+	require.NoError(t, client.rdb.XGroupCreateMkStream(ctx,
+		LighthouseStreamKey(target), LighthouseConsumerGroup(target), "0").Err())
+	require.NoError(t, client.rdb.XAdd(ctx, &redis.XAddArgs{
+		Stream: LighthouseStreamKey(target),
+		Values: map[string]interface{}{"task_id": "lh1"},
+	}).Err())
+	require.NoError(t, client.rdb.HSet(ctx,
+		RunningCountersKey, target, 5).Err())
+
+	// Seed an unrelated job that must survive the cleanup.
+	require.NoError(t, client.rdb.ZAdd(ctx, ScheduleKey(survivor),
+		redis.Z{Score: 2, Member: "task-2"}).Err())
+	require.NoError(t, client.rdb.HSet(ctx,
+		RunningCountersKey, survivor, 9).Err())
+
+	require.NoError(t, client.RemoveJobKeys(ctx, target))
+
+	// Targeted keys gone.
+	for _, key := range []string{
+		ScheduleKey(target),
+		StreamKey(target),
+		LighthouseStreamKey(target),
+	} {
+		exists, err := client.rdb.Exists(ctx, key).Result()
+		require.NoError(t, err)
+		assert.Equal(t, int64(0), exists, "key %s must be deleted", key)
+	}
+	// Targeted running-counter field gone.
+	exists, err := client.rdb.HExists(ctx, RunningCountersKey, target).Result()
+	require.NoError(t, err)
+	assert.False(t, exists, "running counter for %s must be deleted", target)
+
+	// Survivor untouched.
+	survScore, err := client.rdb.ZScore(ctx, ScheduleKey(survivor), "task-2").Result()
+	require.NoError(t, err)
+	assert.Equal(t, float64(2), survScore)
+	survCount, err := client.rdb.HGet(ctx, RunningCountersKey, survivor).Int64()
+	require.NoError(t, err)
+	assert.Equal(t, int64(9), survCount)
+}
+
+// TestClient_RemoveJobKeys_Idempotent verifies RemoveJobKeys tolerates
+// missing streams / consumer groups, so a partially-cleaned or
+// never-started job can be re-cleaned without error.
+func TestClient_RemoveJobKeys_Idempotent(t *testing.T) {
+	client, _ := newTestClientWithMiniredis(t)
+	ctx := context.Background()
+
+	// Nothing seeded — cleanup must succeed silently.
+	require.NoError(t, client.RemoveJobKeys(ctx, "ghost"))
+
+	// Run again to confirm a second call is also harmless.
+	require.NoError(t, client.RemoveJobKeys(ctx, "ghost"))
+}
+
+// TestClient_RemoveJobKeys_RejectsEmpty guards against a caller passing
+// "" by mistake — that would HDEL nothing but DEL-against-prefix would
+// match everything if the key helpers ever changed shape.
+func TestClient_RemoveJobKeys_RejectsEmpty(t *testing.T) {
+	client, _ := newTestClientWithMiniredis(t)
+	ctx := context.Background()
+
+	err := client.RemoveJobKeys(ctx, "")
+	require.Error(t, err)
+}
+
 // TestClient_ClearAll_ManyKeys exercises the SCAN+DEL batch path by
 // seeding well over the 500-batch threshold.
 func TestClient_ClearAll_ManyKeys(t *testing.T) {

--- a/internal/jobs/manager.go
+++ b/internal/jobs/manager.go
@@ -99,6 +99,14 @@ type JobManager struct {
 	// without the analysis app, tests).
 	OnProgressMilestone ProgressMilestoneCallback
 
+	// OnJobTerminated is called after a job's Postgres status has been
+	// flipped to a terminal state (cancelled, completed, failed). Set by
+	// the API server to drop the per-job Redis keys (schedule ZSET,
+	// streams, consumer groups, running-counter HASH field). Fire-and-
+	// forget: errors are logged inside the callback. Nil is allowed for
+	// tests and for deploys without REDIS_URL.
+	OnJobTerminated JobTerminatedCallback
+
 	// lastMilestoneFired is the in-process record of the last 10%
 	// boundary that has been signalled per job, gating MaybeFireMilestones
 	// against duplicate fires within this replica. Multiple replicas may
@@ -122,6 +130,12 @@ type JobManager struct {
 // implementations must return promptly — long-running work belongs in a
 // goroutine inside the callback.
 type ProgressMilestoneCallback func(ctx context.Context, jobID string, oldPct, newPct int)
+
+// JobTerminatedCallback is invoked after a job has been moved to a
+// terminal state (cancelled, completed, failed). Implementations are
+// expected to release per-job Redis state. The callback is fire-and-
+// forget; errors must be handled inside the callback.
+type JobTerminatedCallback func(ctx context.Context, jobID string)
 
 // NewJobManager creates a new job manager
 func NewJobManager(db *sql.DB, dbQueue DbQueueProvider, crawler CrawlerInterface) *JobManager {
@@ -852,6 +866,13 @@ func (jm *JobManager) CancelJob(ctx context.Context, jobID string) error {
 	// Clear processed pages for this job
 	jm.clearProcessedPages(job.ID)
 	jm.clearMilestoneState(job.ID)
+
+	// Drop per-job Redis keys. Without this the schedule ZSET, both
+	// streams + their consumer groups, and the running-counter HASH
+	// field linger forever — the dispatcher only scans active jobs.
+	if jm.OnJobTerminated != nil {
+		jm.OnJobTerminated(ctx, job.ID)
+	}
 
 	jobsLog.Debug("Cancelled job", "job_id", job.ID, "domain", job.Domain)
 

--- a/internal/mocks/db.go
+++ b/internal/mocks/db.go
@@ -713,9 +713,13 @@ func (m *MockBrokerCleaner) ClearAll(ctx context.Context) (int, error) {
 
 // ReclaimTerminalJobKeys mocks the broker reclaim sweeper. Returns the
 // configured (report, error) pair so admin handler tests can assert on
-// the surfaced counts.
+// the surfaced counts. A nil first arg yields a zero-value report;
+// passing any other type panics so misconfigured mocks fail loudly
+// rather than silently returning empty counts.
 func (m *MockBrokerCleaner) ReclaimTerminalJobKeys(ctx context.Context, filter broker.TerminalFilter) (broker.ReclaimReport, error) {
 	args := m.Called(ctx, filter)
-	report, _ := args.Get(0).(broker.ReclaimReport)
-	return report, args.Error(1)
+	if args.Get(0) == nil {
+		return broker.ReclaimReport{}, args.Error(1)
+	}
+	return args.Get(0).(broker.ReclaimReport), args.Error(1)
 }

--- a/internal/mocks/db.go
+++ b/internal/mocks/db.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"time"
 
+	"github.com/Harvey-AU/hover/internal/broker"
 	"github.com/Harvey-AU/hover/internal/db"
 	"github.com/stretchr/testify/mock"
 )
@@ -708,4 +709,13 @@ type MockBrokerCleaner struct {
 func (m *MockBrokerCleaner) ClearAll(ctx context.Context) (int, error) {
 	args := m.Called(ctx)
 	return args.Int(0), args.Error(1)
+}
+
+// ReclaimTerminalJobKeys mocks the broker reclaim sweeper. Returns the
+// configured (report, error) pair so admin handler tests can assert on
+// the surfaced counts.
+func (m *MockBrokerCleaner) ReclaimTerminalJobKeys(ctx context.Context, filter broker.TerminalFilter) (broker.ReclaimReport, error) {
+	args := m.Called(ctx, filter)
+	report, _ := args.Get(0).(broker.ReclaimReport)
+	return report, args.Error(1)
 }


### PR DESCRIPTION
## Summary

Cuts Upstash command volume and resident-data growth so prod can run safely on a Fixed 1 GB tier and review apps stop burning PAYG charges.

- **Phase 1** — `RemoveJobKeys` drops the per-job schedule ZSET, both streams, both consumer groups, and the running-counter HASH field. Wired into the 30 s completion tick (`startHealthMonitoring`) and `JobManager.CancelJob` via a new `OnJobTerminated` callback. Closes the leak that produced ~3 GB resident growth over four test days — `RemoveJobSchedule` and `RemoveJob` were defined but never called.
- **Phase 2** — `POST /v1/admin/reclaim-redis` runs a one-off backfill sweeper that scans `hover:sched:*`, `hover:stream:*`, and the running-counter HASH, asks Postgres which jobIDs are terminal (or missing), and `RemoveJobKeys`-es each. Gated on `ALLOW_DB_RESET=true` + system-admin role.
- **Phase 3** — Review-app Redis provisioning now reads `vars.REVIEW_REDIS_PLAN` so a Fixed-tier slug can be turned on once verified locally; empty keeps the historical PAYG behaviour. The hourly orphan-cleanup workflow now also enumerates and destroys orphaned `hover-redis-pr-*` instances — the recurring vector that PR-330 hit ($150 of accrued charges).
- **Phase 4** — Pacer Lua: `tryAcquire` collapses 2 HGETs into 1 HMGET; the success script collapses 3 HGETs into 1 HMGET and 3 conditional HSETs into 1 HMSET; the error script collapses 2 HSETs into 1 HMSET. Returns are unchanged so `pacer.go` is untouched.

Phase 5 (defensive TTL on `hover:running`) was deliberately skipped — Phase 1 already wires `RemoveJob` into both terminal paths.

## Test plan

- [x] `go test ./...` (full sweep)
- [x] `go vet ./...`
- [x] `gofmt -l` on touched dirs (clean)
- [x] `prettier --check` on workflow files
- [x] New unit tests: `TestClient_RemoveJobKeys{,_Idempotent,_RejectsEmpty}`, `TestClient_ReclaimTerminalJobKeys_*`, `TestClient_listJobIDsInRedis`
- [x] All 8 existing pacer tests still pass after Lua consolidation
- [ ] Runtime: trigger a small crawl, observe `redis-cli KEYS 'hover:sched:*'` and `KEYS 'hover:stream:*'` clear within one completion tick after the job finishes
- [ ] Runtime: hit `POST /v1/admin/reclaim-redis` once after deploy and confirm Upstash Data Size drops toward the in-flight working set
- [ ] Runtime: open a throwaway PR with `vars.REVIEW_REDIS_PLAN` set and confirm flyctl provisions on the Fixed tier
- [ ] Runtime: trigger `cleanup-orphaned-apps.yml` manually and confirm orphaned `hover-redis-pr-*` instances are destroyed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin endpoint to reclaim and clean up orphaned Redis resources for terminal or orphaned jobs (returns reclaim metrics)
  * Automatic removal of per-job Redis state when jobs complete or are terminated
* **Chores**
  * Enhanced preview-app cleanup to also sweep and destroy matching Redis instances
  * Review app Redis provisioning can accept a configurable fixed plan; defaults preserved
  * Reduced Redis round-trips via batched reads/writes
* **Tests**
  * Added coverage verifying Redis reclamation and targeted key removals
<!-- end of auto-generated comment: release notes by coderabbit.ai -->