### PR TITLE
Enforce per-job lighthouse global cap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,61 @@ On merge, CI will:
 
 ## [Unreleased]
 
-_Add unreleased changes here._
+### Added
+
+- Lighthouse Performance reports — Phase 1 foundations (PR #353). New
+  `lighthouse_runs` table storing headline metrics plus an R2 report key (no
+  JSONB blob); `task_type` column added to `tasks` and `task_outbox` so the
+  dispatcher can route Lighthouse work onto `stream:{jobID}:lh`. DB helpers for
+  insert / mark-running / complete / fail / skip-quota are gated on
+  `status='running'` so a duplicate-delivered worker can't clobber a row that
+  already reached a terminal state. A stub Runner behind a `Runner` interface
+  lets the rest of the pipeline be exercised before Chromium lands. Sampler is a
+  pure function with deterministic tie-break by PageID; its initial shape was
+  2.5%-per-band / floor 1 / cap 50.
+- Lighthouse Phase 2 producer + analysis app (PR #356). New `hover-analysis` Fly
+  service (`cmd/analysis/main.go`, `Dockerfile.analysis`, `fly.analysis.toml`)
+  consuming a dedicated `stream:{jobID}:lh` Redis stream. JobManager now fires
+  `OnProgressMilestone` at every 10% boundary;
+  `lighthouse.Scheduler.OnMilestone` loads completed tasks, runs the sampler,
+  inserts `pending` `lighthouse_runs` rows, and bulk-enqueues `task_outbox`
+  entries in a single transaction. Review-app and CI deploy workflows extended
+  to build and deploy the analysis service alongside web + worker.
+- Lighthouse Phase 3 real audits (PR #357).
+  `internal/lighthouse/runner_local.go` runs Chromium plus the `lighthouse` npm
+  CLI in-process; the JSON report is gzipped and uploaded to R2 under
+  `jobs/{job_id}/tasks/{task_id}/lighthouse-mobile.json.gz`.
+  `internal/lighthouse/report.go` extracts headline metrics (performance score,
+  LCP, CLS, INP, TBT, FCP, Speed Index, TTFB, total byte weight) onto the
+  `lighthouse_runs` row. Includes a memory-shed pre-check that defers an audit
+  when the host is under pressure and a one-shot retry on transient Chromium
+  failures. Production analysis app flipped from StubRunner to the local runner;
+  `ARCHIVE_PROVIDER` / `ARCHIVE_BUCKET` set on the analysis service so reports
+  land in R2 alongside crawl HTML.
+
+### Changed
+
+- Lighthouse sampler retuned from 2.5%-per-band / floor 1 / cap 50 to
+  `floor(sqrt(completed) × 0.15)` per band, floored at 1, capped at 15. A
+  10,000-page crawl now tops out at 30 audits/job (15 fastest + 15 slowest)
+  instead of the previous 1,000-cap arithmetic. Added shed and retry metrics
+  around the local runner so an operator can correlate skips with host memory
+  pressure.
+- `lighthouse 12` ships the mobile profile by default, so the explicit
+  `--preset=mobile` flag was dropped from the local runner invocation.
+
+### Fixed
+
+- Lighthouse sampler now enforces the per-band cap **globally per job** instead
+  of re-spending the quota at every 10% milestone. The Phase 1 sampler deduped
+  by `page_id` only, so each milestone happily picked another `perBand` fastest
+  - slowest from the not-yet-sampled pool — production observed 4 jobs producing
+    110 `lighthouse_runs` rows when the cap should have held them to ~14.
+    `SelectSamples` now takes `map[int]SelectionBand`, counts existing fastest /
+    slowest rows, and only requests `max(0, target − existing)` per band per
+    call. The 100% reconcile pass shares the same global budget rather than
+    spending a separate one. New `db.GetLighthouseRunPageBands` replaces the
+    page-id-only `GetLighthouseRunPageIDs`.
 
 ## Full changelog history
 

--- a/docs/plans/lighthouse-performance-reports.md
+++ b/docs/plans/lighthouse-performance-reports.md
@@ -99,6 +99,15 @@ Lighthouse runs for both bands.
 | 10,000  | 15 (cap)  | 30           | 0.3%      |
 | 20,000+ | 15 (cap)  | 30           | ≤0.15%    |
 
+The cap is **global per-job, not per-milestone.** At each 10% boundary the
+sampler tops up only the band slots that haven't been filled yet — once the
+quota is met it returns no further picks for the rest of the job. PR #357
+shipped a sampler that deduped by `page_id` only and re-spent the per-band quota
+at every milestone, accumulating ≈30 rows on a 337-page job (4 such jobs
+produced 110 audits in production when the cap should have held them to ~14).
+Fixed in the follow-up PR by counting existing band rows and only requesting
+`max(0, target - existing)` per band per call.
+
 Properties: floor of 1 per band means even a 5-page site gets 1 fastest + 1
 slowest. The square-root curve gives small/medium sites generous coverage while
 keeping the audit fleet sub-linear. Cap of 15 binds at exactly 10,000 pages,

--- a/internal/db/lighthouse.go
+++ b/internal/db/lighthouse.go
@@ -303,31 +303,38 @@ func (db *DB) ListLighthouseRunsByJob(ctx context.Context, jobID string) ([]Ligh
 	return runs, nil
 }
 
-// GetLighthouseRunPageIDs returns the set of page IDs already queued
-// for a job. Used by the sampler to dedupe across milestones.
-func (db *DB) GetLighthouseRunPageIDs(ctx context.Context, jobID string) (map[int]struct{}, error) {
+// GetLighthouseRunPageBands returns the page IDs already queued for a
+// job, mapped to the band they were scheduled under. Used by the
+// sampler to enforce the per-band global cap (count existing
+// fastest/slowest rows when deciding how much to top up at each
+// milestone) and to dedupe page IDs across milestones regardless of
+// band.
+func (db *DB) GetLighthouseRunPageBands(ctx context.Context, jobID string) (map[int]LighthouseSelectionBand, error) {
 	const q = `
-		SELECT page_id
+		SELECT page_id, selection_band
 		  FROM lighthouse_runs
 		 WHERE job_id = $1
 	`
 
 	rows, err := db.client.QueryContext(ctx, q, jobID)
 	if err != nil {
-		return nil, fmt.Errorf("list lighthouse run page ids: %w", err)
+		return nil, fmt.Errorf("list lighthouse run page bands: %w", err)
 	}
 	defer rows.Close()
 
-	seen := make(map[int]struct{})
+	seen := make(map[int]LighthouseSelectionBand)
 	for rows.Next() {
-		var pageID int
-		if err := rows.Scan(&pageID); err != nil {
-			return nil, fmt.Errorf("scan page id: %w", err)
+		var (
+			pageID int
+			band   string
+		)
+		if err := rows.Scan(&pageID, &band); err != nil {
+			return nil, fmt.Errorf("scan page band: %w", err)
 		}
-		seen[pageID] = struct{}{}
+		seen[pageID] = LighthouseSelectionBand(band)
 	}
 	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("iterate page ids: %w", err)
+		return nil, fmt.Errorf("iterate page bands: %w", err)
 	}
 	return seen, nil
 }

--- a/internal/lighthouse/sampler.go
+++ b/internal/lighthouse/sampler.go
@@ -84,10 +84,24 @@ func PerBand(completedPages int) int {
 	return n
 }
 
-// SelectSamples picks up to PerBand(len(tasks)) fastest and slowest
-// tasks from completed, after excluding any whose PageID appears in
-// alreadySampled. The fastest and slowest sets are guaranteed
-// disjoint: when fewer than 2*perBand candidates remain, fastest
+// SelectSamples picks fastest and slowest tasks from completed,
+// enforcing a global per-band cap of PerBand(len(completed)) across
+// the lifetime of a job. alreadySampled maps every page_id already
+// queued for the job (any band) to the band it was scheduled under;
+// the function uses it both to dedupe (a page never appears twice)
+// and to count existing fastest/slowest rows so each milestone only
+// tops up the band quotas — it never re-spends them.
+//
+// BandReconcile rows in alreadySampled count toward dedupe but not
+// toward fastest/slowest quotas: at milestone 100 the scheduler
+// retags whatever the sampler picks as reconcile, so by construction
+// reconcile rows shouldn't exist before this call. If they do (e.g.
+// a duplicate milestone-100 fire) the dedupe still keeps page IDs
+// disjoint while the quota math correctly treats the existing rows
+// as already-spent budget.
+//
+// The fastest and slowest output sets are guaranteed disjoint: when
+// fewer than fastestNeeded+slowestNeeded candidates remain, fastest
 // takes priority and slowest fills from what's left.
 //
 // Order in the returned slice is fastest band first (ascending
@@ -96,13 +110,41 @@ func PerBand(completedPages int) int {
 //
 // The function is pure — it does not touch the database or the
 // network — so it is straightforward to unit test.
-func SelectSamples(completed []CompletedTask, milestone int, alreadySampled map[int]struct{}) []Sample {
+func SelectSamples(completed []CompletedTask, milestone int, alreadySampled map[int]SelectionBand) []Sample {
 	if len(completed) == 0 {
 		return nil
 	}
 
-	// Filter out previously-sampled pages. Defensive copy so the
-	// caller's slice ordering is preserved.
+	target := PerBand(len(completed))
+	if target == 0 {
+		return nil
+	}
+
+	var fastestExisting, slowestExisting int
+	for _, b := range alreadySampled {
+		switch b {
+		case BandFastest:
+			fastestExisting++
+		case BandSlowest:
+			slowestExisting++
+		}
+	}
+
+	fastestNeeded := target - fastestExisting
+	if fastestNeeded < 0 {
+		fastestNeeded = 0
+	}
+	slowestNeeded := target - slowestExisting
+	if slowestNeeded < 0 {
+		slowestNeeded = 0
+	}
+	if fastestNeeded == 0 && slowestNeeded == 0 {
+		return nil
+	}
+
+	// Filter out previously-sampled pages (any band) so the same page
+	// can never be queued twice. Defensive copy preserves the caller's
+	// slice ordering.
 	candidates := make([]CompletedTask, 0, len(completed))
 	for _, t := range completed {
 		if _, seen := alreadySampled[t.PageID]; seen {
@@ -111,11 +153,6 @@ func SelectSamples(completed []CompletedTask, milestone int, alreadySampled map[
 		candidates = append(candidates, t)
 	}
 	if len(candidates) == 0 {
-		return nil
-	}
-
-	perBand := PerBand(len(completed))
-	if perBand == 0 {
 		return nil
 	}
 
@@ -128,14 +165,14 @@ func SelectSamples(completed []CompletedTask, milestone int, alreadySampled map[
 		return candidates[i].PageID < candidates[j].PageID
 	})
 
-	fastestN := perBand
+	fastestN := fastestNeeded
 	if fastestN > len(candidates) {
 		fastestN = len(candidates)
 	}
 
 	// Slowest pulls from the tail, but never overlaps with fastest.
 	remaining := len(candidates) - fastestN
-	slowestN := perBand
+	slowestN := slowestNeeded
 	if slowestN > remaining {
 		slowestN = remaining
 	}

--- a/internal/lighthouse/sampler_test.go
+++ b/internal/lighthouse/sampler_test.go
@@ -206,32 +206,30 @@ func TestSampleAtCap(t *testing.T) {
 }
 
 func TestSampleDedupeAcrossMilestones(t *testing.T) {
-	// First milestone over 200 tasks samples 2 fastest + 2 slowest.
-	// Second milestone over the same 200 tasks should skip the
-	// pre-sampled IDs and select different ones from the remaining.
+	// Once the per-band quota for a 200-page job (perBand = 2) is
+	// satisfied, subsequent milestone calls must not top up further —
+	// the cap is global per-job, not per-call. PR #357 violated this:
+	// each milestone happily picked another perBand fastest + slowest
+	// from the not-yet-sampled pool, so a 200-page crawl could
+	// accumulate ≈30 rows across 10 milestones instead of 4.
 	tasks := makeTasks(200)
 	first := SelectSamples(tasks, 10, nil)
 	if len(first) != 4 {
 		t.Fatalf("first pass expected 4 samples, got %d", len(first))
 	}
 
-	already := make(map[int]struct{})
+	already := make(map[int]SelectionBand)
 	for _, s := range first {
-		already[s.Task.PageID] = struct{}{}
+		already[s.Task.PageID] = s.Band
 	}
 
 	second := SelectSamples(tasks, 20, already)
-	if len(second) != 4 {
-		t.Fatalf("second pass expected 4 samples, got %d", len(second))
+	if len(second) != 0 {
+		t.Fatalf("second pass expected 0 samples (quota already met), got %d (%+v)",
+			len(second), second)
 	}
 
-	for _, s := range second {
-		if _, dup := already[s.Task.PageID]; dup {
-			t.Errorf("second pass returned already-sampled page %d", s.Task.PageID)
-		}
-	}
-
-	// Combined coverage: first 4 + next 4 = 8 distinct pages.
+	// Combined coverage: still 4 distinct pages, not 8.
 	all := make(map[int]struct{})
 	for _, s := range first {
 		all[s.Task.PageID] = struct{}{}
@@ -239,20 +237,121 @@ func TestSampleDedupeAcrossMilestones(t *testing.T) {
 	for _, s := range second {
 		all[s.Task.PageID] = struct{}{}
 	}
-	if len(all) != 8 {
-		t.Errorf("expected 8 distinct pages across two milestones, got %d", len(all))
+	if len(all) != 4 {
+		t.Errorf("expected 4 distinct pages across two milestones, got %d", len(all))
 	}
 }
 
 func TestSampleAllAlreadyConsumed(t *testing.T) {
 	// All candidates already sampled — nothing left to schedule.
 	tasks := makeTasks(20)
-	already := make(map[int]struct{})
+	already := make(map[int]SelectionBand)
 	for _, t := range tasks {
-		already[t.PageID] = struct{}{}
+		// Half tagged fastest, half tagged slowest; doesn't matter for
+		// this test — quota and dedupe both filter the pool to empty.
+		if t.PageID%2 == 0 {
+			already[t.PageID] = BandFastest
+		} else {
+			already[t.PageID] = BandSlowest
+		}
 	}
 	if got := SelectSamples(tasks, 50, already); got != nil {
 		t.Errorf("expected nil when nothing left, got %+v", got)
+	}
+}
+
+// simulateMilestoneRun walks a job through the 10%, 20%, …, 100%
+// milestones the JobManager fires, threading the prior calls' picks
+// (with their bands) back in as alreadySampled each iteration. It
+// returns the merged result so tests can assert the global cap.
+func simulateMilestoneRun(t *testing.T, totalPages int) []Sample {
+	t.Helper()
+
+	tasks := makeTasks(totalPages)
+	already := make(map[int]SelectionBand)
+	var combined []Sample
+
+	for milestone := 10; milestone <= 100; milestone += 10 {
+		completedSoFar := totalPages * milestone / 100
+		if completedSoFar > totalPages {
+			completedSoFar = totalPages
+		}
+		picks := SelectSamples(tasks[:completedSoFar], milestone, already)
+		for _, s := range picks {
+			if _, dup := already[s.Task.PageID]; dup {
+				t.Errorf("milestone %d returned already-sampled page %d",
+					milestone, s.Task.PageID)
+			}
+			already[s.Task.PageID] = s.Band
+			combined = append(combined, s)
+		}
+	}
+	return combined
+}
+
+func TestSampleGlobalCap_337Pages(t *testing.T) {
+	// 337 pages → perBand = 2 → global cap = 4 audits total.
+	// Pre-fix (PR #357) this scenario produced ≈30 rows because each
+	// milestone re-spent the per-band quota. With the global cap the
+	// total is exactly 4 (2 fastest + 2 slowest).
+	picks := simulateMilestoneRun(t, 337)
+	if len(picks) != 4 {
+		t.Fatalf("expected exactly 4 samples for 337-page job, got %d", len(picks))
+	}
+
+	var fastest, slowest int
+	seen := make(map[int]bool)
+	for _, s := range picks {
+		if seen[s.Task.PageID] {
+			t.Errorf("page %d picked twice across milestones", s.Task.PageID)
+		}
+		seen[s.Task.PageID] = true
+		switch s.Band {
+		case BandFastest:
+			fastest++
+		case BandSlowest:
+			slowest++
+		}
+	}
+	if fastest != 2 || slowest != 2 {
+		t.Errorf("expected 2 fastest + 2 slowest, got %d + %d", fastest, slowest)
+	}
+}
+
+func TestSampleGlobalCap_200Pages(t *testing.T) {
+	// 200 pages → perBand = 2 → cap = 4 audits total.
+	picks := simulateMilestoneRun(t, 200)
+	if len(picks) != 4 {
+		t.Fatalf("expected exactly 4 samples for 200-page job, got %d", len(picks))
+	}
+}
+
+func TestSampleGlobalCap_1000Pages(t *testing.T) {
+	// 1,000 pages → perBand = 4 → cap = 8 audits total.
+	picks := simulateMilestoneRun(t, 1000)
+	if len(picks) != 8 {
+		t.Fatalf("expected exactly 8 samples for 1,000-page job, got %d", len(picks))
+	}
+}
+
+func TestSampleGlobalCap_10000Pages(t *testing.T) {
+	// 10,000 pages → perBand = 15 (cap) → cap = 30 audits total.
+	picks := simulateMilestoneRun(t, 10000)
+	if len(picks) != 30 {
+		t.Fatalf("expected exactly 30 samples for 10,000-page job, got %d", len(picks))
+	}
+
+	var fastest, slowest int
+	for _, s := range picks {
+		switch s.Band {
+		case BandFastest:
+			fastest++
+		case BandSlowest:
+			slowest++
+		}
+	}
+	if fastest != 15 || slowest != 15 {
+		t.Errorf("expected 15 fastest + 15 slowest at cap, got %d + %d", fastest, slowest)
 	}
 }
 

--- a/internal/lighthouse/scheduler.go
+++ b/internal/lighthouse/scheduler.go
@@ -17,7 +17,7 @@ import (
 // full Postgres pool.
 type SchedulerDB interface {
 	GetCompletedTasksForLighthouseSampling(ctx context.Context, jobID string) ([]db.CompletedTaskForSampling, error)
-	GetLighthouseRunPageIDs(ctx context.Context, jobID string) (map[int]struct{}, error)
+	GetLighthouseRunPageBands(ctx context.Context, jobID string) (map[int]db.LighthouseSelectionBand, error)
 }
 
 // TxRunner runs the supplied function inside a Postgres transaction.
@@ -75,9 +75,13 @@ func (s *Scheduler) OnMilestone(ctx context.Context, jobID string, milestone int
 		return nil
 	}
 
-	alreadySampled, err := s.db.GetLighthouseRunPageIDs(ctx, jobID)
+	existingBands, err := s.db.GetLighthouseRunPageBands(ctx, jobID)
 	if err != nil {
-		return fmt.Errorf("lighthouse: load already-sampled page IDs: %w", err)
+		return fmt.Errorf("lighthouse: load already-sampled page bands: %w", err)
+	}
+	alreadySampled := make(map[int]SelectionBand, len(existingBands))
+	for pageID, b := range existingBands {
+		alreadySampled[pageID] = SelectionBand(b)
 	}
 
 	// Map page_id -> meta so the band selection (which only carries

--- a/internal/lighthouse/scheduler_test.go
+++ b/internal/lighthouse/scheduler_test.go
@@ -18,7 +18,7 @@ import (
 type fakeSchedulerDB struct {
 	completed    []db.CompletedTaskForSampling
 	completedErr error
-	sampled      map[int]struct{}
+	sampled      map[int]db.LighthouseSelectionBand
 	sampledErr   error
 }
 
@@ -29,12 +29,12 @@ func (f *fakeSchedulerDB) GetCompletedTasksForLighthouseSampling(_ context.Conte
 	return f.completed, nil
 }
 
-func (f *fakeSchedulerDB) GetLighthouseRunPageIDs(_ context.Context, _ string) (map[int]struct{}, error) {
+func (f *fakeSchedulerDB) GetLighthouseRunPageBands(_ context.Context, _ string) (map[int]db.LighthouseSelectionBand, error) {
 	if f.sampledErr != nil {
 		return nil, f.sampledErr
 	}
 	if f.sampled == nil {
-		return map[int]struct{}{}, nil
+		return map[int]db.LighthouseSelectionBand{}, nil
 	}
 	return f.sampled, nil
 }
@@ -164,7 +164,10 @@ func TestScheduler_OnMilestone_AllAlreadySampled(t *testing.T) {
 			{TaskID: "t1", PageID: 1, Host: "example.com", Path: "/", ResponseTime: 200},
 			{TaskID: "t2", PageID: 2, Host: "example.com", Path: "/about", ResponseTime: 1500},
 		},
-		sampled: map[int]struct{}{1: {}, 2: {}},
+		sampled: map[int]db.LighthouseSelectionBand{
+			1: db.LighthouseBandFastest,
+			2: db.LighthouseBandSlowest,
+		},
 	}
 	s := NewScheduler(fake, &txRunnerFromMock{db: mockDB})
 


### PR DESCRIPTION
## Summary

- Lighthouse sampler now enforces the per-band cap globally across a job instead of re-spending the quota at every 10% milestone.
- Each milestone tops up only `max(0, PerBand(completed) - existing)` per band; once the quota is satisfied subsequent milestones return zero picks.
- A 200-page job stays at 4 audits, a 1,000-page job at 8, a 10,000-page job at the 30 ceiling.

## Why

PR #357 shipped a sampler that deduped by `page_id` only. The scheduler fires `OnMilestone` at every 10% boundary and the sampler happily picked another `perBand` fastest + `perBand` slowest from the not-yet-sampled pool each time. Production observed 4 jobs producing **110** `lighthouse_runs` rows when the documented cap held them to ~14. The plan-doc table at `docs/plans/lighthouse-performance-reports.md` was correct; the implementation wasn't.

## What changed

- **internal/db/lighthouse.go** — replaced `GetLighthouseRunPageIDs` (returned a set of page IDs) with `GetLighthouseRunPageBands` (returns `map[int]LighthouseSelectionBand`) so callers can count existing fastest/slowest rows.
- **internal/lighthouse/sampler.go** — `SelectSamples` signature changed to `map[int]SelectionBand`. The function now computes `target := PerBand(len(completed))`, counts existing band usage from the map, and only picks `max(0, target - existing)` per band. BandReconcile rows count toward dedupe but not toward fastest/slowest quotas.
- **internal/lighthouse/scheduler.go** — swapped the interface method, threaded the new map through. The milestone-100 retag-to-reconcile block is unchanged. Under the new cap, by milestone 100 the per-band quotas are normally full so reconcile contributes 0 picks — same global budget rather than a separate one.
- **internal/lighthouse/sampler_test.go** — rewrote `TestSampleDedupeAcrossMilestones` to assert that a second milestone returns 0 picks once the quota is met. Added `TestSampleGlobalCap_{200,337,1000,10000}Pages` driven by a `simulateMilestoneRun` helper that walks the actual 10–100% progression, asserts the global cap, and verifies the band split.
- **internal/lighthouse/scheduler_test.go** — fake DB updated to the new map shape.
- **docs/plans/lighthouse-performance-reports.md** — added a clarifying paragraph under the cap table noting the cap is global per job, not per milestone, and calling out the PR #357 regression with this fix.

`PerBand()` itself, the 10% milestone trigger in `JobManager.MaybeFireMilestones`, and the consumer-side cancel/redeliver semantics are unchanged.

## Test plan

- [x] `gofmt`/`goimports`/Prettier clean on touched files (pre-commit hook ran)
- [x] `go test ./internal/lighthouse/... ./internal/db/...` passes including the new global-cap tests (200 → 4, 337 → 4, 1,000 → 8, 10,000 → 30)
- [x] `go build ./...` clean — no stale `GetLighthouseRunPageIDs` callers
- [x] `bash scripts/security-check.sh` reports 0 issues
- [ ] Synthetic 200-page crawl in dev: assert `SELECT count(*) FROM lighthouse_runs WHERE job_id = $1` returns 4 (manual sanity check before merge)
- [ ] Confirm the 80 buggy `lighthouse_runs` rows marked `error_message='cancelled — pre-global-cap test data, see follow-up PR'` are untouched (audit trail)

## Reviewer notes

- The previous behaviour where reconcile could "catch up" late-arriving extremes inside the same 30-audit budget is preserved: reconcile picks whatever quota slack remains at milestone 100. If a smaller dedicated reconcile budget is wanted later, that's a separate change.
- 80 lighthouse_runs rows from earlier test runs are intentionally left in place tagged with `error_message='cancelled — pre-global-cap test data, see follow-up PR'` as the audit trail for the bug.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced global per-band caps so sampler stops requesting further audits once a band’s job-wide quota is met, preventing repeated sampling across milestones and reducing excessive audit counts.

* **Documentation**
  * Added docs describing the corrected per-band cap enforcement, the previously observed sampler behavior, and the remediation approach.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->