### PR TITLE
Fix cancel-job deadlock and click UX

### DIFF
--- a/internal/jobs/cancel_job_test.go
+++ b/internal/jobs/cancel_job_test.go
@@ -1,0 +1,155 @@
+package jobs
+
+import (
+	"context"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// jobRow returns a sqlmock row matching the column list selected by
+// JobManager.GetJob. Helper keeps the test ordering aligned with the
+// production query — if GetJob's SELECT changes, this is the single
+// place to update.
+func jobRow(jobID string, status JobStatus) *sqlmock.Rows {
+	return sqlmock.NewRows([]string{
+		"id", "name", "status", "progress",
+		"total_tasks", "completed_tasks", "failed_tasks", "skipped_tasks",
+		"created_at", "started_at", "completed_at", "concurrency", "find_links",
+		"include_paths", "exclude_paths", "error_message", "required_workers",
+		"found_tasks", "sitemap_tasks", "duration_seconds", "avg_time_per_task_seconds",
+		"user_id", "organisation_id",
+	}).AddRow(
+		jobID, "example.com", string(status), 0.0,
+		1, 0, 0, 0,
+		time.Now(), nil, nil, 1, false,
+		[]byte("[]"), []byte("[]"), nil, 1,
+		0, 0, 0, 0,
+		nil, nil,
+	)
+}
+
+// TestCancelJob_LockOrder asserts the cancel transaction UPDATEs tasks
+// before jobs (tasks-first ordering matches the worker batch path and
+// the AFTER STATEMENT counter trigger, breaking the 40P01 deadlock cycle
+// that surfaced on 30k+ page jobs). sqlmock fails the test if calls
+// arrive out of declared order.
+func TestCancelJob_LockOrder(t *testing.T) {
+	mockDB, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherRegexp))
+	require.NoError(t, err)
+	defer mockDB.Close()
+
+	jm := &JobManager{
+		db:             mockDB,
+		dbQueue:        &mockDbQueueWrapper{mockDB: mockDB},
+		processedPages: make(map[string]struct{}),
+	}
+
+	const jobID = "job-cancel-1"
+
+	// GetJob (read-only, runs in its own dbQueue.Execute)
+	mock.ExpectBegin()
+	mock.ExpectQuery(`SELECT[\s\S]+FROM jobs j[\s\S]+JOIN domains d`).
+		WithArgs(jobID).
+		WillReturnRows(jobRow(jobID, JobStatusRunning))
+	mock.ExpectCommit()
+
+	// CancelJob transaction — order matters.
+	mock.ExpectBegin()
+
+	// 1. Tasks first, with deterministic ORDER BY id.
+	mock.ExpectExec(`(?s)WITH picked AS \(\s*SELECT id FROM tasks\s+WHERE job_id = \$1\s+AND status IN \(\$3, \$4\)\s+ORDER BY id\s+FOR UPDATE\s*\)\s*UPDATE tasks t\s+SET status = \$2`).
+		WithArgs(jobID, string(TaskStatusSkipped), string(TaskStatusPending), string(TaskStatusWaiting)).
+		WillReturnResult(sqlmock.NewResult(0, 5))
+
+	// 2. Jobs second.
+	mock.ExpectExec(`UPDATE jobs\s+SET status = \$1, completed_at = \$2\s+WHERE id = \$3`).
+		WithArgs(string(JobStatusCancelled), sqlmock.AnyArg(), jobID).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	// 3. Outbox cleanup last (no row lock contention with workers).
+	mock.ExpectExec(`DELETE FROM task_outbox WHERE job_id = \$1`).
+		WithArgs(jobID).
+		WillReturnResult(sqlmock.NewResult(0, 5))
+
+	mock.ExpectCommit()
+
+	err = jm.CancelJob(context.Background(), jobID)
+	require.NoError(t, err)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+// TestCancelJob_AlreadyCancelledIsNoOp asserts a duplicate cancel against
+// an already-cancelled job returns nil without running the cancel
+// transaction. Stops red toasts on impatient multi-clicks where the
+// first request has already won.
+func TestCancelJob_AlreadyCancelledIsNoOp(t *testing.T) {
+	mockDB, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherRegexp))
+	require.NoError(t, err)
+	defer mockDB.Close()
+
+	jm := &JobManager{
+		db:             mockDB,
+		dbQueue:        &mockDbQueueWrapper{mockDB: mockDB},
+		processedPages: make(map[string]struct{}),
+	}
+
+	const jobID = "job-already-cancelled"
+
+	mock.ExpectBegin()
+	mock.ExpectQuery(`SELECT[\s\S]+FROM jobs j[\s\S]+JOIN domains d`).
+		WithArgs(jobID).
+		WillReturnRows(jobRow(jobID, JobStatusCancelled))
+	mock.ExpectCommit()
+
+	// No further ExpectBegin / ExpectExec — the cancel transaction must
+	// not run for an already-cancelled job.
+
+	err = jm.CancelJob(context.Background(), jobID)
+	require.NoError(t, err)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+// TestCancelJob_TerminalStatusErrors asserts a cancel against a terminal
+// job (completed/failed) still surfaces an error — only the cancelled
+// status is treated as idempotent success.
+func TestCancelJob_TerminalStatusErrors(t *testing.T) {
+	for _, status := range []JobStatus{JobStatusCompleted, JobStatusFailed} {
+		t.Run(string(status), func(t *testing.T) {
+			mockDB, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherRegexp))
+			require.NoError(t, err)
+			defer mockDB.Close()
+
+			jm := &JobManager{
+				db:             mockDB,
+				dbQueue:        &mockDbQueueWrapper{mockDB: mockDB},
+				processedPages: make(map[string]struct{}),
+			}
+
+			const jobID = "job-terminal"
+
+			mock.ExpectBegin()
+			mock.ExpectQuery(`SELECT[\s\S]+FROM jobs j[\s\S]+JOIN domains d`).
+				WithArgs(jobID).
+				WillReturnRows(jobRow(jobID, status))
+			mock.ExpectCommit()
+
+			err = jm.CancelJob(context.Background(), jobID)
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), "cannot be canceled")
+			assert.NoError(t, mock.ExpectationsWereMet())
+		})
+	}
+}
+
+// Sanity check that the regex literal in GetJob's expected query above
+// has not become brittle if someone reflows the SQL. Failing here points
+// the developer at the test, not the production query.
+func TestCancelJob_GetJobQueryRegexCompiles(t *testing.T) {
+	_, err := regexp.Compile(`SELECT[\s\S]+FROM jobs j[\s\S]+JOIN domains d`)
+	require.NoError(t, err)
+}

--- a/internal/jobs/manager.go
+++ b/internal/jobs/manager.go
@@ -798,6 +798,13 @@ func (jm *JobManager) CancelJob(ctx context.Context, jobID string) error {
 		return fmt.Errorf("failed to get job: %w", err)
 	}
 
+	// Already-cancelled is a no-op success so duplicate clicks from a flaky
+	// network or an impatient user do not surface as red toasts.
+	if job.Status == JobStatusCancelled {
+		jobsLog.Debug("Cancel requested on already-cancelled job", "job_id", job.ID)
+		return nil
+	}
+
 	// Check if job can be canceled
 	if job.Status != JobStatusRunning && job.Status != JobStatusPending && job.Status != JobStatusPaused && job.Status != JobStatusInitialising {
 		return fmt.Errorf("job cannot be canceled: %s", job.Status)
@@ -807,34 +814,53 @@ func (jm *JobManager) CancelJob(ctx context.Context, jobID string) error {
 	job.Status = JobStatusCancelled
 	job.CompletedAt = time.Now().UTC()
 
-	// Use dbQueue for transaction safety
+	// Use dbQueue for transaction safety. Lock order matters here: workers
+	// update task rows first and the AFTER STATEMENT counter trigger then
+	// acquires jobs row locks in id order (see migrations 20260425000001
+	// and 20260426013451). The cancel transaction must follow the same
+	// tasks-before-jobs order or it deadlocks against any in-flight worker
+	// batch on the same job (HOVER: 40P01 on 30k-page cancels).
 	err = jm.dbQueue.Execute(ctx, func(tx *sql.Tx) error {
-		// Update job status
+		// 1. Skip pending/waiting tasks first. ORDER BY id keeps the
+		//    row-lock graph acyclic across concurrent transactions, mirroring
+		//    promote_waiting_with_outbox (20260425000001).
 		_, err := tx.ExecContext(ctx, `
+			WITH picked AS (
+				SELECT id FROM tasks
+				 WHERE job_id = $1
+				   AND status IN ($3, $4)
+				 ORDER BY id
+				 FOR UPDATE
+			)
+			UPDATE tasks t
+			   SET status = $2
+			  FROM picked
+			 WHERE t.id = picked.id
+		`, job.ID, TaskStatusSkipped, TaskStatusPending, TaskStatusWaiting)
+		if err != nil {
+			return err
+		}
+
+		// 2. Flip the job status. The AFTER STATEMENT trigger on the
+		//    previous UPDATE has already taken the jobs row lock for us in
+		//    id order; this just writes the cancelled status under that
+		//    same lock. The trigger preserves jobs.status when it is
+		//    already 'cancelled' or 'failed', so no race with a late
+		//    completion fire.
+		_, err = tx.ExecContext(ctx, `
 			UPDATE jobs
 			SET status = $1, completed_at = $2
 			WHERE id = $3
 		`, job.Status, job.CompletedAt, job.ID)
-
 		if err != nil {
 			return err
 		}
 
-		// Cancel pending and waiting tasks
-		_, err = tx.ExecContext(ctx, `
-			UPDATE tasks
-			SET status = $1
-			WHERE job_id = $2 AND status IN ($3, $4)
-		`, TaskStatusSkipped, job.ID, TaskStatusPending, TaskStatusWaiting)
-		if err != nil {
-			return err
-		}
-
-		// Drop any task_outbox rows for this job so the sweeper does
-		// not waste work ZADDing tasks whose status has just flipped
-		// to skipped. Without this, outbox rows for cancelled jobs
-		// linger until their next sweep and inflate the outbox backlog
-		// and oldest-age gauges.
+		// 3. Drop any task_outbox rows for this job so the sweeper does
+		//    not waste work ZADDing tasks whose status has just flipped
+		//    to skipped. Without this, outbox rows for cancelled jobs
+		//    linger until their next sweep and inflate the outbox backlog
+		//    and oldest-age gauges.
 		_, err = tx.ExecContext(ctx, `
 			DELETE FROM task_outbox WHERE job_id = $1
 		`, job.ID)

--- a/web/static/js/gnh-dashboard-actions.js
+++ b/web/static/js/gnh-dashboard-actions.js
@@ -76,7 +76,7 @@ function handleDashboardAction(action, element) {
         element.getAttribute("gnh-id") ||
         element.getAttribute("gnh-data-job-id");
       if (jobId) {
-        cancelJob(jobId);
+        cancelJob(jobId, element);
       }
       break;
     }
@@ -120,7 +120,19 @@ async function restartJob(jobId) {
   }
 }
 
-async function cancelJob(jobId) {
+const cancelJobInflight = new Set();
+
+async function cancelJob(jobId, triggerElement) {
+  if (cancelJobInflight.has(jobId)) {
+    return;
+  }
+  cancelJobInflight.add(jobId);
+  let originalLabel = null;
+  if (triggerElement) {
+    originalLabel = triggerElement.textContent;
+    triggerElement.disabled = true;
+    triggerElement.textContent = "Cancelling…";
+  }
   try {
     await window.dataBinder.fetchData(`/v1/jobs/${jobId}/cancel`, {
       method: "POST",
@@ -132,6 +144,14 @@ async function cancelJob(jobId) {
   } catch (error) {
     console.error("Failed to cancel job:", error);
     showDashboardError("Failed to cancel job");
+    if (triggerElement) {
+      triggerElement.disabled = false;
+      if (originalLabel !== null) {
+        triggerElement.textContent = originalLabel;
+      }
+    }
+  } finally {
+    cancelJobInflight.delete(jobId);
   }
 }
 

--- a/web/static/js/job-page.js
+++ b/web/static/js/job-page.js
@@ -1037,11 +1037,21 @@ function setupInteractions(state) {
       cancelBtn.style.display = "none";
     } else {
       cancelBtn.addEventListener("click", async () => {
+        if (cancelBtn.disabled) {
+          return;
+        }
+        const originalLabel = cancelBtn.textContent;
+        cancelBtn.disabled = true;
+        cancelBtn.textContent = "Cancelling…";
         try {
           await cancelJobFromPage(state);
+          // Leave the button disabled on success — the next refresh hides
+          // it because can_cancel flips to false.
         } catch (error) {
           console.error("Failed to cancel job:", error);
           showToast("Failed to cancel job.", true);
+          cancelBtn.disabled = false;
+          cancelBtn.textContent = originalLabel;
         }
       });
     }


### PR DESCRIPTION
## Summary

- **Backend (root cause):** `JobManager.CancelJob` runs `UPDATE jobs … → UPDATE tasks …` inside one transaction, which is the opposite lock order to worker batch updates (which lock `tasks` first and acquire the `jobs` row lock via the AFTER STATEMENT counter trigger from migrations [20260425000001](supabase/migrations/20260425000001_promote_waiting_deterministic_lock_order.sql) / [20260426013451](supabase/migrations/20260426013451_statement_level_job_counter_triggers.sql)). On a 30k+ page job the lock-order cycle deadlocks (`SQLSTATE 40P01`) faster than `dbQueue.Execute` can retry.
- **Frontend (symptom):** the Cancel buttons in [web/static/js/job-page.js](web/static/js/job-page.js) and [web/static/js/gnh-dashboard-actions.js](web/static/js/gnh-dashboard-actions.js) have no disabled state, so impatient clicks fire multiple POSTs that each fight for the same locks and surface multiple red toasts.

## Plan

1. Reverse the SQL order inside `CancelJob` — `UPDATE tasks` first (with `ORDER BY id` for deterministic locking, mirroring `promote_waiting_with_outbox`), then `UPDATE jobs`, then `DELETE FROM task_outbox`. Lock graph stays acyclic against worker batches.
2. Make `CancelJob` idempotent for already-cancelled jobs so duplicate clicks return 200 instead of an error.
3. Disable the Cancel button + show a `Cancelling…` label while the request is in flight (job page and dashboard).

A draft of the implementation is preserved on `main` as `stash@{0}` (\"WIP: cancel deadlock fix …\") and will be pushed as a follow-up commit on this branch.

## Test plan

- [ ] `go test ./internal/jobs/...`
- [ ] Run `air`, `/dev/auto-login`, kick off a multi-thousand-page job, click Cancel once → button shows `Cancelling…`, toast shows `Cancel requested. Refreshing…`, no `40P01` in logs.
- [ ] Spam Cancel ~10× in 200ms → exactly one POST in `preview_network`, one toast.
- [ ] Click Cancel on an already-cancelled job → 200, no error toast.
- [ ] (Optional) Reproduce against a 30k-page staging job and confirm Cancel returns under ~2s.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Job cancellation now handles already-cancelled jobs gracefully without errors, eliminating error notifications for duplicate cancel attempts.

* **Improvements**
  * Enhanced user feedback during job cancellation with button state changes displaying "Cancelling..." progress indicator.
  * Added safeguards to prevent duplicate concurrent cancellation requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->