### PR TITLE
Parallelise Fly deploy pipeline

### DIFF
--- a/.fly/review_apps.analysis.toml
+++ b/.fly/review_apps.analysis.toml
@@ -14,7 +14,9 @@ primary_region = "syd"
   # Match production fly.analysis.toml — without this, flyctl deploy
   # --build-only falls back to the default Dockerfile (which builds the
   # API and worker binaries) and the analysis app boots the wrong binary.
-  dockerfile = "Dockerfile.analysis"
+  # Path is relative to this toml file's directory, so we need ../ to
+  # reach the repo root where Dockerfile.analysis lives.
+  dockerfile = "../Dockerfile.analysis"
 
 # Override the Dockerfile CMD to run start-analysis.sh, which boots the
 # Alloy metrics sidecar alongside the analysis binary so review apps emit

--- a/.fly/review_apps.analysis.toml
+++ b/.fly/review_apps.analysis.toml
@@ -11,6 +11,10 @@
 primary_region = "syd"
 
 [build]
+  # Match production fly.analysis.toml — without this, flyctl deploy
+  # --build-only falls back to the default Dockerfile (which builds the
+  # API and worker binaries) and the analysis app boots the wrong binary.
+  dockerfile = "Dockerfile.analysis"
 
 # Override the Dockerfile CMD to run start-analysis.sh, which boots the
 # Alloy metrics sidecar alongside the analysis binary so review apps emit

--- a/.github/actions/fly-setup/action.yml
+++ b/.github/actions/fly-setup/action.yml
@@ -1,0 +1,78 @@
+# Shared setup for Fly deploy jobs.
+#
+# Each parallel job in fly-deploy.yml re-runs this composite to obtain
+# the Go toolchain, flyctl, and the runtime/Fly secrets from 1Password.
+# GitHub Actions does not let us share env-loaded secrets across jobs
+# safely, so each job pays the small cost of running this block once.
+#
+# Callers must run actions/checkout before invoking this action — local
+# composite actions resolve from the workflow workspace, so the repo
+# must be on disk first.
+#
+# REDIS_URL is shared by the API (scheduler enqueue path) and the worker
+# (consumer); validate it up front so an empty value fails fast in every
+# job rather than producing a half-deployed surface.
+
+name: Fly setup
+description: >-
+  Install Go + flyctl, load runtime/Fly secrets from 1Password, and validate
+  REDIS_URL. Used by every job in the Fly deploy workflow.
+
+inputs:
+  op-service-account-token:
+    description: 1Password service-account token used to load secrets.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Go
+      uses: actions/setup-go@v6
+      with:
+        go-version: "1.26.2"
+
+    - name: Load secrets from 1Password
+      uses: 1password/load-secrets-action@v2
+      with:
+        export-env: true
+      env:
+        OP_SERVICE_ACCOUNT_TOKEN: ${{ inputs.op-service-account-token }}
+        # CI-only
+        FLY_API_TOKEN: op://Good Native/hover-fly/FLY_API_TOKEN
+        # Runtime secrets — hover-supabase
+        DATABASE_URL: op://Good Native/hover-supabase/DATABASE_URL
+        DATABASE_DIRECT_URL: op://Good Native/hover-supabase/DATABASE_DIRECT_URL
+        SUPABASE_JWT_SECRET: op://Good Native/hover-supabase/SUPABASE_JWT_SECRET
+        SUPABASE_SERVICE_ROLE_KEY:
+          op://Good Native/hover-supabase/SUPABASE_SERVICE_ROLE_KEY
+        # Runtime secrets — hover-runtime
+        SENTRY_DSN: op://Good Native/hover-runtime/SENTRY_DSN
+        LOOPS_API_KEY: op://Good Native/hover-runtime/LOOPS_API_KEY
+        SLACK_CLIENT_SECRET: op://Good Native/hover-runtime/SLACK_CLIENT_SECRET
+        WEBFLOW_CLIENT_SECRET:
+          op://Good Native/hover-runtime/WEBFLOW_CLIENT_SECRET
+        GOOGLE_CLIENT_SECRET:
+          op://Good Native/hover-runtime/GOOGLE_CLIENT_SECRET
+        OTEL_EXPORTER_OTLP_HEADERS:
+          op://Good Native/hover-runtime/OTEL_EXPORTER_OTLP_HEADERS
+        GRAFANA_CLOUD_USER: op://Good Native/hover-runtime/GRAFANA_CLOUD_USER
+        GRAFANA_CLOUD_API_KEY:
+          op://Good Native/hover-runtime/GRAFANA_CLOUD_API_KEY
+        # Redis broker (shared by hover + hover-worker)
+        REDIS_URL: op://Good Native/hover-runtime/REDIS_URL
+        # Archive (R2 cold storage)
+        ARCHIVE_ACCESS_KEY_ID:
+          op://Good Native/hover-archive/ARCHIVE_ACCESS_KEY_ID
+        ARCHIVE_SECRET_ACCESS_KEY:
+          op://Good Native/hover-archive/ARCHIVE_SECRET_ACCESS_KEY
+        ARCHIVE_ENDPOINT: op://Good Native/hover-archive/ARCHIVE_ENDPOINT
+
+    - uses: superfly/flyctl-actions/setup-flyctl@63da3ecc5e2793b98a3f2519b3d75d4f4c11cec2 # pinned
+
+    - name: Validate runtime secrets
+      shell: bash
+      run: |
+        if [ -z "$REDIS_URL" ]; then
+          echo "❌ REDIS_URL is required. Check 1Password: op://Good Native/hover-runtime/REDIS_URL" >&2
+          exit 1
+        fi

--- a/.github/actions/fly-setup/action.yml
+++ b/.github/actions/fly-setup/action.yml
@@ -22,6 +22,14 @@ inputs:
   op-service-account-token:
     description: 1Password service-account token used to load secrets.
     required: true
+  validate-redis-url:
+    description: >-
+      When 'true' (default), fail the job if REDIS_URL is empty after the
+      1Password load. Production deploys depend on REDIS_URL coming from
+      1Password; review apps provision their own per-PR Redis later in the
+      workflow and pass 'false' to skip the check.
+    required: false
+    default: "true"
 
 runs:
   using: composite
@@ -39,6 +47,9 @@ runs:
         OP_SERVICE_ACCOUNT_TOKEN: ${{ inputs.op-service-account-token }}
         # CI-only
         FLY_API_TOKEN: op://Good Native/hover-fly/FLY_API_TOKEN
+        # Supabase API (review apps look up preview-branch URLs)
+        SUPABASE_ACCESS_TOKEN:
+          op://Good Native/hover-supabase/SUPABASE_ACCESS_TOKEN
         # Runtime secrets — hover-supabase
         DATABASE_URL: op://Good Native/hover-supabase/DATABASE_URL
         DATABASE_DIRECT_URL: op://Good Native/hover-supabase/DATABASE_DIRECT_URL
@@ -70,6 +81,7 @@ runs:
     - uses: superfly/flyctl-actions/setup-flyctl@63da3ecc5e2793b98a3f2519b3d75d4f4c11cec2 # pinned
 
     - name: Validate runtime secrets
+      if: inputs.validate-redis-url == 'true'
       shell: bash
       run: |
         if [ -z "$REDIS_URL" ]; then

--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -16,7 +16,6 @@ on:
       - ".prettierrc"
       - ".prettierignore"
       - ".golangci.yml"
-      - ".github/**"
 
 jobs:
   check-changelog:
@@ -54,15 +53,44 @@ jobs:
             exit 1
           fi
 
+          # PR-level enforcement: every PR must add new content under
+          # [Unreleased]. We compare the unreleased section between
+          # origin/main and HEAD; if they're identical, the PR didn't
+          # add anything and is rejected. This catches the failure mode
+          # where [Unreleased] is non-empty (because previous PRs
+          # accumulated entries) but the current PR forgot to add one.
+          extract_unreleased() {
+            awk '
+              /^## \[Unreleased/ {f=1; next}
+              /^## Full changelog history$/ {f=0}
+              /^## \[[0-9]/ {f=0}
+              f
+            ' "$1" | sed '/^_Add unreleased changes here\._$/d' | sed '/^[[:space:]]*$/d'
+          }
+
+          MAIN_UNRELEASED=$(git show "$COMPARE_REF":CHANGELOG.md 2>/dev/null | extract_unreleased /dev/stdin || true)
+          HEAD_UNRELEASED=$(extract_unreleased CHANGELOG.md)
+
+          if [ "$MAIN_UNRELEASED" = "$HEAD_UNRELEASED" ]; then
+            echo "❌ ERROR: This PR did not add any new entry under ## [Unreleased]."
+            echo ""
+            echo "Every PR to main must add at least one line under ## [Unreleased]"
+            echo "in CHANGELOG.md describing the change. For example:"
+            echo ""
+            echo "  ## [Unreleased]"
+            echo ""
+            echo "  ### Changed"
+            echo "  - Brief description of the change."
+            echo ""
+            echo "If your change really does not warrant a changelog entry, justify"
+            echo "it explicitly in the PR description and request the gate be waived."
+            exit 1
+          fi
+
           # Use shared script for changelog parsing and version calculation
           bash scripts/changelog-version.sh
 
-          # Report status
-          if grep -q 'should_release=true' "$GITHUB_OUTPUT"; then
-            echo "✅ Changelog has been updated with changes"
-          else
-            echo "⚠️  [Unreleased] section is empty — release will have blank changelog"
-          fi
+          echo "✅ Changelog has new content under [Unreleased]"
 
       - name: Comment on PR with version info
         uses: actions/github-script@v8

--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -1,5 +1,16 @@
 # See https://fly.io/docs/app-guides/continuous-deployment-with-github-actions/
-# CI trigger after repository rename (no functional change)
+#
+# Pipeline shape: the deploy is split into a build phase that pushes
+# images to registry.fly.io in parallel, and a release phase that points
+# each Fly app at the pre-built image. The build phase is the slow part
+# (~3 min on Fly's remote builder); decoupling it from release lets us
+# build the shared hover/hover-worker image once instead of twice, and
+# build the analysis image concurrently rather than after.
+#
+# Ordering invariant (preserved from the original workflow): hover-analysis
+# (lighthouse consumer) must be live before hover-worker (lighthouse
+# producer) starts XADDing onto the per-job lighthouse stream. The
+# release-worker job declares needs: [release-analysis] to enforce this.
 
 name: Fly Deploy
 on:
@@ -17,69 +28,77 @@ on:
       - "SECURITY.md"
       - "Roadmap.md"
       - "QandA.md"
+
+# Workflow-level lock: only one full deploy run for this group is in
+# flight at a time. cancel-in-progress: false so a second push to main
+# queues behind the first rather than aborting it mid-release.
+concurrency:
+  group: deploy-group
+  cancel-in-progress: false
+
 jobs:
-  deploy:
-    name: Deploy app
+  # ───────── Build phase ───────────────────────────────────────────────
+  # Two image builds run in parallel. The shared image carries both the
+  # API binary (cmd/app) and the worker binary (cmd/worker) — see
+  # Dockerfile lines 19–20 — so it is reused by both release-api and
+  # release-worker. The analysis image has its own runtime (Debian +
+  # Chromium) and is built independently.
+  build-shared:
+    name: Build hover image (API + worker)
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    concurrency: deploy-group # optional: ensure only one action runs at a time
+    outputs:
+      image: ${{ steps.build.outputs.image }}
     steps:
       - uses: actions/checkout@v6
-
-      - name: Set up Go
-        uses: actions/setup-go@v6
+      - uses: ./.github/actions/fly-setup
         with:
-          go-version: "1.26.2"
+          op-service-account-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
 
-      - name: Load secrets from 1Password
-        uses: 1password/load-secrets-action@v2
-        with:
-          export-env: true
+      - name: Build and push hover image
+        id: build
         env:
-          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-          # CI-only
-          FLY_API_TOKEN: op://Good Native/hover-fly/FLY_API_TOKEN
-          # Runtime secrets — hover-supabase
-          DATABASE_URL: op://Good Native/hover-supabase/DATABASE_URL
-          DATABASE_DIRECT_URL:
-            op://Good Native/hover-supabase/DATABASE_DIRECT_URL
-          SUPABASE_JWT_SECRET:
-            op://Good Native/hover-supabase/SUPABASE_JWT_SECRET
-          SUPABASE_SERVICE_ROLE_KEY:
-            op://Good Native/hover-supabase/SUPABASE_SERVICE_ROLE_KEY
-          # Runtime secrets — hover-runtime
-          SENTRY_DSN: op://Good Native/hover-runtime/SENTRY_DSN
-          LOOPS_API_KEY: op://Good Native/hover-runtime/LOOPS_API_KEY
-          SLACK_CLIENT_SECRET:
-            op://Good Native/hover-runtime/SLACK_CLIENT_SECRET
-          WEBFLOW_CLIENT_SECRET:
-            op://Good Native/hover-runtime/WEBFLOW_CLIENT_SECRET
-          GOOGLE_CLIENT_SECRET:
-            op://Good Native/hover-runtime/GOOGLE_CLIENT_SECRET
-          OTEL_EXPORTER_OTLP_HEADERS:
-            op://Good Native/hover-runtime/OTEL_EXPORTER_OTLP_HEADERS
-          GRAFANA_CLOUD_USER: op://Good Native/hover-runtime/GRAFANA_CLOUD_USER
-          GRAFANA_CLOUD_API_KEY:
-            op://Good Native/hover-runtime/GRAFANA_CLOUD_API_KEY
-          # Redis broker (shared by hover + hover-worker)
-          REDIS_URL: op://Good Native/hover-runtime/REDIS_URL
-          # Archive (R2 cold storage)
-          ARCHIVE_ACCESS_KEY_ID:
-            op://Good Native/hover-archive/ARCHIVE_ACCESS_KEY_ID
-          ARCHIVE_SECRET_ACCESS_KEY:
-            op://Good Native/hover-archive/ARCHIVE_SECRET_ACCESS_KEY
-          ARCHIVE_ENDPOINT: op://Good Native/hover-archive/ARCHIVE_ENDPOINT
-
-      - uses: superfly/flyctl-actions/setup-flyctl@63da3ecc5e2793b98a3f2519b3d75d4f4c11cec2 # pinned
-
-      - name: Validate runtime secrets
+          IMAGE_LABEL: deployment-${{ github.run_id }}-${{ github.run_attempt }}
         run: |
-          # REDIS_URL is shared by the API (scheduler enqueue path) and the
-          # worker (consumer). Validate up front so an empty value doesn't
-          # produce a half-deployed API before the worker step fails.
-          if [ -z "$REDIS_URL" ]; then
-            echo "❌ REDIS_URL is required. Check 1Password: op://Good Native/hover-runtime/REDIS_URL" >&2
-            exit 1
-          fi
+          flyctl deploy --build-only --push \
+            --image-label "$IMAGE_LABEL" \
+            --app hover
+          echo "image=registry.fly.io/hover:${IMAGE_LABEL}" >> "$GITHUB_OUTPUT"
+
+  build-analysis:
+    name: Build hover-analysis image
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    outputs:
+      image: ${{ steps.build.outputs.image }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/fly-setup
+        with:
+          op-service-account-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+
+      - name: Build and push hover-analysis image
+        id: build
+        env:
+          IMAGE_LABEL: deployment-${{ github.run_id }}-${{ github.run_attempt }}
+        run: |
+          flyctl deploy --build-only --push \
+            --image-label "$IMAGE_LABEL" \
+            --config fly.analysis.toml \
+            --app hover-analysis
+          echo "image=registry.fly.io/hover-analysis:${IMAGE_LABEL}" >> "$GITHUB_OUTPUT"
+
+  # ───────── Release phase ─────────────────────────────────────────────
+  # release-api and release-analysis fan out in parallel as soon as their
+  # builds are ready. release-worker waits on release-analysis so the
+  # consumer is healthy before the producer starts publishing.
+  release-api:
+    name: Release hover (API)
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    needs: [build-shared]
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/fly-setup
+        with:
+          op-service-account-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
 
       - name: Sync secrets to Fly (API app)
         run: |
@@ -102,15 +121,28 @@ jobs:
             REDIS_URL="$REDIS_URL" \
             --stage
 
-      - name: Deploy API app
-        run: flyctl deploy --remote-only
+      - name: Release API app
+        env:
+          IMAGE: ${{ needs.build-shared.outputs.image }}
+        run: flyctl deploy --image "$IMAGE" --app hover
+
+  release-analysis:
+    name: Release hover-analysis
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    needs: [build-analysis]
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/fly-setup
+        with:
+          op-service-account-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
 
       - name: Sync secrets to Fly (analysis app)
         run: |
-          # hover-analysis consumes the per-job lighthouse streams written by
-          # the dispatcher and writes audit metrics back to lighthouse_runs.
-          # Only secrets actually referenced by the analysis binary are
-          # synced; user-facing auth secrets are deliberately excluded.
+          # hover-analysis consumes the per-job lighthouse streams written
+          # by the dispatcher and writes audit metrics back to
+          # lighthouse_runs. Only secrets actually referenced by the
+          # analysis binary are synced; user-facing auth secrets are
+          # deliberately excluded.
           flyctl secrets set \
             --app hover-analysis \
             DATABASE_URL="$DATABASE_URL" \
@@ -125,22 +157,33 @@ jobs:
             ARCHIVE_ENDPOINT="$ARCHIVE_ENDPOINT" \
             --stage
 
-      - name: Deploy analysis app
-        # Analysis (lighthouse consumer) deploys BEFORE worker (lighthouse
-        # producer) so the per-job lighthouse stream has a reader before the
-        # worker starts XADDing audit jobs onto it. Mirrors the existing
-        # consumer-before-producer rule from the worker/API split.
-        run:
-          flyctl deploy --config fly.analysis.toml --app hover-analysis
-          --remote-only
+      - name: Release analysis app
+        env:
+          IMAGE: ${{ needs.build-analysis.outputs.image }}
+        run: |
+          flyctl deploy --image "$IMAGE" \
+            --config fly.analysis.toml \
+            --app hover-analysis
+
+  release-worker:
+    name: Release hover-worker
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    # Waits on build-shared for the image, and on release-analysis for
+    # the consumer-before-producer invariant.
+    needs: [build-shared, release-analysis]
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/fly-setup
+        with:
+          op-service-account-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
 
       - name: Sync secrets to Fly (worker app)
         run: |
-          # hover-worker consumes Redis streams, executes crawls, persists to
-          # Postgres + R2. Only secrets actually referenced by the worker
-          # binary are synced here; user-facing auth secrets (Supabase JWT,
-          # Slack/Webflow/Google OAuth client secrets) are deliberately
-          # excluded.
+          # hover-worker consumes Redis streams, executes crawls, persists
+          # to Postgres + R2. Only secrets actually referenced by the
+          # worker binary are synced here; user-facing auth secrets
+          # (Supabase JWT, Slack/Webflow/Google OAuth client secrets) are
+          # deliberately excluded.
           flyctl secrets set \
             --app hover-worker \
             DATABASE_URL="$DATABASE_URL" \
@@ -155,15 +198,27 @@ jobs:
             ARCHIVE_ENDPOINT="$ARCHIVE_ENDPOINT" \
             --stage
 
-      - name: Deploy worker app
-        run:
-          flyctl deploy --config fly.worker.toml --app hover-worker
-          --remote-only
+      - name: Release worker app
+        # Reuses the hover image from build-shared — Dockerfile compiles
+        # both binaries, fly.worker.toml selects the worker entrypoint.
+        env:
+          IMAGE: ${{ needs.build-shared.outputs.image }}
+        run: |
+          flyctl deploy --image "$IMAGE" \
+            --config fly.worker.toml \
+            --app hover-worker
 
+  # ───────── Annotation ────────────────────────────────────────────────
+  # if: always() so a partial deploy still produces an annotation for
+  # observability. Annotation is best-effort — failures here log a
+  # warning but do not fail the workflow.
+  annotate:
+    name: Post deploy annotation to Grafana
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    needs: [release-api, release-analysis, release-worker]
+    if: always()
+    steps:
       - name: Load Grafana annotation secrets
-        # Annotation is observability, not a release gate. If 1Password is
-        # unreachable or the items are missing, log a warning and move on —
-        # the deploy itself has already succeeded by this point.
         continue-on-error: true
         uses: 1password/load-secrets-action@v2
         with:
@@ -174,11 +229,11 @@ jobs:
           GRAFANA_SA_TOKEN: op://Good Native/hover-runtime/GRAFANA_SA_TOKEN
 
       - name: Post deploy annotation to Grafana
-        # Best-effort: a Grafana outage logs a warning but does not fail the
-        # deploy. The annotation is observability, not a release gate.
-        # Commit-message and ref are passed via env vars (not direct
-        # ${{ ... }} interpolation) to avoid shell-injection via crafted
-        # commit messages — see GitHub Actions injection guidance.
+        # Best-effort: a Grafana outage logs a warning but does not fail
+        # the workflow. Commit-message and ref are passed via env vars
+        # (not direct ${{ ... }} interpolation) to avoid shell-injection
+        # via crafted commit messages — see GitHub Actions injection
+        # guidance.
         continue-on-error: true
         env:
           COMMIT_SHA: ${{ github.sha }}
@@ -197,9 +252,10 @@ jobs:
           short_sha="${COMMIT_SHA:0:7}"
           commit_url="https://github.com/${REPO}/commit/${COMMIT_SHA}"
 
-          # PR detection — merge commits from GitHub include "(#NNN)" in the
-          # subject. Look up the PR via gh api so we get the canonical title
-          # rather than whatever shorthand appeared in the commit message.
+          # PR detection — merge commits from GitHub include "(#NNN)" in
+          # the subject. Look up the PR via gh api so we get the canonical
+          # title rather than whatever shorthand appeared in the commit
+          # message.
           pr_number="$(printf '%s' "$COMMIT_MESSAGE" | grep -oE '#[0-9]+' | head -n1 | tr -d '#' || true)"
           pr_section=""
           extra_tags_json='[]'
@@ -213,9 +269,9 @@ jobs:
             fi
           fi
 
-          # Commit range since previous successful deploy — walk workflow runs
-          # for this workflow file on main and pick the most recent success
-          # that isn't the current commit.
+          # Commit range since previous successful deploy — walk workflow
+          # runs for this workflow file on main and pick the most recent
+          # success that isn't the current commit.
           prev_sha="$(gh api "repos/${REPO}/actions/workflows/${WORKFLOW_FILE}/runs?branch=main&status=success&per_page=10" \
             --jq "[.workflow_runs[] | select(.head_sha != \"${COMMIT_SHA}\")][0].head_sha" 2>/dev/null || true)"
 
@@ -237,8 +293,9 @@ jobs:
             commit_tags_json="$(jq -cn --arg t "commit:${short_sha}" '[$t]')"
           fi
 
-          # Derive service tags from the files changed in this deploy range.
-          # Falls back to the single-commit API when no compare range is available.
+          # Derive service tags from the files changed in this deploy
+          # range. Falls back to the single-commit API when no compare
+          # range is available.
           changed_files=""
           if [ -n "$compare_json" ]; then
             changed_files="$(printf '%s' "$compare_json" | jq -r '.files[].filename' 2>/dev/null || true)"
@@ -256,8 +313,8 @@ jobs:
             service_tags_json="$(jq -cn --argjson t "$service_tags_json" '$t + ["service:hover-worker"]')"
           fi
           # hover-analysis surface: the analysis binary itself, its image
-          # config, fly app config, and the lighthouse package modules that
-          # only it consumes (runner). The shared lighthouse pieces
+          # config, fly app config, and the lighthouse package modules
+          # that only it consumes (runner). The shared lighthouse pieces
           # (sampler, scheduler) are picked up by the broader internal/...
           # clause below since the worker imports them too.
           if printf '%s\n' "$changed_files" | grep -qE '^(cmd/analysis/|Dockerfile\.analysis|fly\.analysis\.toml|\.fly/review_apps\.analysis\.toml|internal/lighthouse/runner\.go)'; then

--- a/.github/workflows/review-apps.yml
+++ b/.github/workflows/review-apps.yml
@@ -1,3 +1,15 @@
+# Review-app deploys mirror the production fly-deploy.yml shape: provision
+# once, build the shared hover image and the analysis image in parallel,
+# then release each app from a pre-built image. Worker release waits on
+# analysis release for the same consumer-before-producer invariant the
+# prod workflow enforces.
+#
+# Per-PR isolation: each PR has its own Fly apps (hover-pr-N, hover-worker-pr-N,
+# hover-analysis-pr-N), its own Upstash Redis, and its own Supabase preview
+# branch. The provision job sets all of that up and stages secrets onto the
+# three Fly apps; release jobs only need to call `flyctl deploy --image …`,
+# which applies the staged secrets.
+
 name: Deploy Review App
 
 on:
@@ -17,9 +29,20 @@ on:
       - "Roadmap.md"
       - "QandA.md"
 
+# Workflow-level lock: per-PR group, newer pushes cancel any in-flight
+# build/release for the same PR.
+concurrency:
+  group: preview-${{ github.event.number }}
+  cancel-in-progress: true
+
 jobs:
-  deploy-review:
-    name: Deploy Review App
+  # ───────── Provision ─────────────────────────────────────────────────
+  # Looks up the per-PR Supabase preview branch, provisions Upstash Redis,
+  # creates the three Fly apps if missing, and stages all secrets onto
+  # them. After this job, each Fly app has its secrets staged and just
+  # needs a deploy to apply them.
+  provision:
+    name: Provision review-app dependencies
     runs-on: blacksmith-4vcpu-ubuntu-2404
     if: |
       github.event.pull_request.draft == false &&
@@ -28,63 +51,51 @@ jobs:
       !contains(github.event.pull_request.body || '', '[preview skip]')
     permissions:
       pull-requests: write
-
-    concurrency:
-      group: preview-${{ github.event.number }}
-      cancel-in-progress: true
-
+    outputs:
+      image_label: ${{ steps.tag.outputs.image_label }}
+      api_app: ${{ steps.naming.outputs.api_app }}
+      worker_app: ${{ steps.naming.outputs.worker_app }}
+      analysis_app: ${{ steps.naming.outputs.analysis_app }}
+      api_url: ${{ steps.naming.outputs.api_url }}
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-
-      - name: Set up Go
-        uses: actions/setup-go@v6
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/fly-setup
         with:
-          go-version: "1.26.2"
-
-      - name: Setup Fly.io CLI
-        uses: superfly/flyctl-actions/setup-flyctl@63da3ecc5e2793b98a3f2519b3d75d4f4c11cec2 # pinned
+          op-service-account-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          # Per-PR Redis is provisioned below; the prod REDIS_URL loaded by
+          # the composite is irrelevant here and must not be validated.
+          validate-redis-url: "false"
 
       - name: Setup Supabase CLI
         uses: supabase/setup-cli@v1
         with:
           version: "2.67.1"
 
-      - name: Load secrets from 1Password
-        uses: 1password/load-secrets-action@v2
-        with:
-          export-env: true
+      - name: Compute app names and image label
+        id: naming
         env:
-          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-          FLY_API_TOKEN: op://Good Native/hover-fly/FLY_API_TOKEN
-          SUPABASE_ACCESS_TOKEN:
-            op://Good Native/hover-supabase/SUPABASE_ACCESS_TOKEN
-          SENTRY_DSN: op://Good Native/hover-runtime/SENTRY_DSN
-          LOOPS_API_KEY: op://Good Native/hover-runtime/LOOPS_API_KEY
-          SLACK_CLIENT_SECRET:
-            op://Good Native/hover-runtime/SLACK_CLIENT_SECRET
-          WEBFLOW_CLIENT_SECRET:
-            op://Good Native/hover-runtime/WEBFLOW_CLIENT_SECRET
-          GOOGLE_CLIENT_SECRET:
-            op://Good Native/hover-runtime/GOOGLE_CLIENT_SECRET
-          OTEL_EXPORTER_OTLP_HEADERS:
-            op://Good Native/hover-runtime/OTEL_EXPORTER_OTLP_HEADERS
-          SUPABASE_JWT_SECRET:
-            op://Good Native/hover-supabase/SUPABASE_JWT_SECRET
-          SUPABASE_SERVICE_ROLE_KEY:
-            op://Good Native/hover-supabase/SUPABASE_SERVICE_ROLE_KEY
-          # Archive (R2 cold storage)
-          ARCHIVE_ACCESS_KEY_ID:
-            op://Good Native/hover-archive/ARCHIVE_ACCESS_KEY_ID
-          ARCHIVE_SECRET_ACCESS_KEY:
-            op://Good Native/hover-archive/ARCHIVE_SECRET_ACCESS_KEY
-          ARCHIVE_ENDPOINT: op://Good Native/hover-archive/ARCHIVE_ENDPOINT
-          GRAFANA_CLOUD_USER: op://Good Native/hover-runtime/GRAFANA_CLOUD_USER
-          GRAFANA_CLOUD_API_KEY:
-            op://Good Native/hover-runtime/GRAFANA_CLOUD_API_KEY
+          PR_NUMBER: ${{ github.event.number }}
+        run: |
+          {
+            echo "api_app=hover-pr-${PR_NUMBER}"
+            echo "worker_app=hover-worker-pr-${PR_NUMBER}"
+            echo "analysis_app=hover-analysis-pr-${PR_NUMBER}"
+            echo "api_url=https://hover-pr-${PR_NUMBER}.fly.dev"
+          } >> "$GITHUB_OUTPUT"
 
-      - name: Get Supabase Preview Branch URL
+      - name: Set image label
+        id: tag
+        env:
+          RUN_ID: ${{ github.run_id }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
+        run: |
+          echo "image_label=deployment-${RUN_ID}-${RUN_ATTEMPT}" >> "$GITHUB_OUTPUT"
+
+      - name: Get Supabase preview branch URL
         id: supabase
+        env:
+          SUPABASE_PROJECT_REF: gpzjtbgtdjxnacdfujvx
+          BRANCH_NAME: ${{ github.head_ref }}
         run: |
           echo "🔍 Listing all Supabase branches..."
           supabase branches list --project-ref "$SUPABASE_PROJECT_REF" || echo "Failed to list branches"
@@ -102,13 +113,9 @@ jobs:
           BRANCH_JSON=""
 
           for ATTEMPT in $(seq 1 "$MAX_ATTEMPTS"); do
-            # Get branch details as JSON for robust parsing.
             BRANCH_JSON=$(supabase branches get "$BRANCH_NAME" --project-ref "$SUPABASE_PROJECT_REF" --output json 2>/dev/null) || true
 
-            # Extract pooler URL (for general queries) - try multiple field names.
             PREVIEW_DB_URL=$(echo "$BRANCH_JSON" | jq -r '.POSTGRES_URL // .postgres_url // .db_url // empty' 2>/dev/null)
-
-            # Extract direct URL (for LISTEN/NOTIFY) - Supabase uses POSTGRES_URL_NON_POOLING.
             DIRECT_DB_URL=$(echo "$BRANCH_JSON" | jq -r '.POSTGRES_URL_NON_POOLING // empty' 2>/dev/null)
             BRANCH_SERVICE_ROLE_KEY=$(echo "$BRANCH_JSON" | jq -r '.SUPABASE_SERVICE_ROLE_KEY // empty' 2>/dev/null)
             BRANCH_JWT_SECRET=$(echo "$BRANCH_JSON" | jq -r '.SUPABASE_JWT_SECRET // empty' 2>/dev/null)
@@ -124,58 +131,46 @@ jobs:
             fi
           done
 
-          # Debug: show available fields (keys only, not values)
-          echo "🔑 Available JSON fields:"
-          echo "$BRANCH_JSON" | jq -r 'keys[]' 2>/dev/null || echo "  (none)"
-
-          echo "📊 URLs found:"
-          echo "  Pooler URL present: $([ -n "$PREVIEW_DB_URL" ] && echo 'yes' || echo 'no')"
-          echo "  Direct URL present: $([ -n "$DIRECT_DB_URL" ] && echo 'yes' || echo 'no')"
-          echo "  Branch service role key present: $([ -n "$BRANCH_SERVICE_ROLE_KEY" ] && echo 'yes' || echo 'no')"
-          echo "  Branch JWT secret present: $([ -n "$BRANCH_JWT_SECRET" ] && echo 'yes' || echo 'no')"
-          echo "  Branch Supabase URL present: $([ -n "$BRANCH_SUPABASE_URL" ] && echo 'yes' || echo 'no')"
-
-          if [ -n "$PREVIEW_DB_URL" ]; then
-            echo "✅ Found Supabase preview branch!"
-            echo "preview_db_url=$PREVIEW_DB_URL" >> $GITHUB_OUTPUT
-            echo "direct_db_url=$DIRECT_DB_URL" >> $GITHUB_OUTPUT
-            echo "branch_exists=true" >> $GITHUB_OUTPUT
-            # Mask and export branch-specific secrets
-            if [ -n "$BRANCH_SERVICE_ROLE_KEY" ]; then
-              echo "::add-mask::$BRANCH_SERVICE_ROLE_KEY"
-              echo "branch_service_role_key=$BRANCH_SERVICE_ROLE_KEY" >> $GITHUB_OUTPUT
-            fi
-            if [ -n "$BRANCH_JWT_SECRET" ]; then
-              echo "::add-mask::$BRANCH_JWT_SECRET"
-              echo "branch_jwt_secret=$BRANCH_JWT_SECRET" >> $GITHUB_OUTPUT
-            fi
-            if [ -n "$BRANCH_SUPABASE_URL" ]; then
-              echo "branch_supabase_url=$BRANCH_SUPABASE_URL" >> $GITHUB_OUTPUT
-            fi
-          else
-            echo "⚠️ No Supabase preview branch found"
-            echo "branch_exists=false" >> $GITHUB_OUTPUT
+          if [ -z "$PREVIEW_DB_URL" ]; then
+            echo "❌ No Supabase preview branch found. Every PR should have one." >&2
+            exit 1
           fi
-        env:
-          SUPABASE_PROJECT_REF: gpzjtbgtdjxnacdfujvx
-          BRANCH_NAME: ${{ github.head_ref }}
 
-      - name: Log Supabase Branch Status
-        run: |
-          echo "========================================"
-          echo "SUPABASE PREVIEW BRANCH STATUS"
-          echo "========================================"
-          echo "Branch exists: ${{ steps.supabase.outputs.branch_exists }}"
-          echo "Preview DB available: ${{ steps.supabase.outputs.preview_db_url != '' }}"
-          echo "========================================"
+          # Branch-specific keys override the prod-loaded fallbacks.
+          if [ -z "$BRANCH_SERVICE_ROLE_KEY" ]; then
+            BRANCH_SERVICE_ROLE_KEY="$SUPABASE_SERVICE_ROLE_KEY"
+            echo "🔑 Using main project service_role key (branch key not available)"
+          else
+            echo "🔑 Using preview branch service_role key"
+            echo "::add-mask::$BRANCH_SERVICE_ROLE_KEY"
+          fi
+          if [ -z "$BRANCH_JWT_SECRET" ]; then
+            BRANCH_JWT_SECRET="$SUPABASE_JWT_SECRET"
+            echo "🔑 Using main project JWT secret (branch secret not available)"
+          else
+            echo "🔑 Using preview branch JWT secret"
+            echo "::add-mask::$BRANCH_JWT_SECRET"
+          fi
+
+          {
+            echo "preview_db_url=$PREVIEW_DB_URL"
+            echo "direct_db_url=$DIRECT_DB_URL"
+            echo "service_role_key=$BRANCH_SERVICE_ROLE_KEY"
+            echo "jwt_secret=$BRANCH_JWT_SECRET"
+            echo "supabase_url=$BRANCH_SUPABASE_URL"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Set preview branch pool size
-        if: steps.supabase.outputs.branch_exists == 'true'
+        env:
+          BRANCH_SUPABASE_URL: ${{ steps.supabase.outputs.supabase_url }}
         run: |
-          BRANCH_URL="$BRANCH_SUPABASE_URL"
-          BRANCH_REF=$(echo "$BRANCH_URL" | sed 's|https://||' | cut -d'.' -f1)
+          if [ -z "$BRANCH_SUPABASE_URL" ]; then
+            echo "ℹ️ Branch Supabase URL not available — skipping pool size update"
+            exit 0
+          fi
+          BRANCH_REF=$(echo "$BRANCH_SUPABASE_URL" | sed 's|https://||' | cut -d'.' -f1)
           if [ -z "$BRANCH_REF" ]; then
-            echo "⚠️ Could not extract branch ref from $BRANCH_URL — skipping pool size update"
+            echo "⚠️ Could not extract branch ref from $BRANCH_SUPABASE_URL — skipping pool size update"
             exit 0
           fi
           # 60 conns covers the API review app (DB_MAX_OPEN_CONNS=40) plus
@@ -196,27 +191,24 @@ jobs:
           else
             echo "⚠️ Pool size update returned HTTP $HTTP_STATUS — continuing"
           fi
-        env:
-          SUPABASE_ACCESS_TOKEN: ${{ env.SUPABASE_ACCESS_TOKEN }}
-          BRANCH_SUPABASE_URL: ${{ steps.supabase.outputs.branch_supabase_url }}
 
       - name: Provision Upstash Redis
         id: redis
+        env:
+          PR_NUMBER: ${{ github.event.number }}
         run: |
           REDIS_NAME="hover-redis-pr-${PR_NUMBER}"
 
-          # Check if Redis instance already exists (exact word match on name column).
           if flyctl redis list | grep -wq "$REDIS_NAME"; then
             echo "Upstash Redis already exists: $REDIS_NAME"
           else
             echo "Creating Upstash Redis: $REDIS_NAME"
             # Explicitly set --enable-prodpack=false so flyctl does not
             # attempt an interactive prompt (which errors in CI with
-            # "Error: prompt: non interactive"). Piping stdin is not enough;
-            # recent flyctl versions abort rather than read from stdin.
-            # Do not pass --plan: flyctl rejects the documented default
-            # value ("pay-as-you-go") with "plan not found", and the default
-            # is applied automatically when the flag is omitted.
+            # "Error: prompt: non interactive"). Do not pass --plan: flyctl
+            # rejects the documented default value with "plan not found",
+            # and the default is applied automatically when the flag is
+            # omitted.
             if ! flyctl redis create \
               --name "$REDIS_NAME" \
               --region syd \
@@ -229,11 +221,6 @@ jobs:
             fi
           fi
 
-          # Poll for private URL (may take a moment after creation).
-          # flyctl renders the status table with box-drawing characters and
-          # arbitrary whitespace, so extract only the redis://... substring
-          # and strip surrounding whitespace. The earlier sed 's/.*= *//'
-          # approach captured the full line because flyctl uses │, not =.
           REDIS_URL=""
           for i in 1 2 3 4 5 6; do
             REDIS_URL=$(flyctl redis status "$REDIS_NAME" 2>/dev/null \
@@ -255,141 +242,88 @@ jobs:
           echo "::add-mask::$REDIS_URL"
           echo "redis_url=$REDIS_URL" >> "$GITHUB_OUTPUT"
           echo "✅ Redis provisioned: $REDIS_NAME"
+
+      - name: Create Fly apps if missing
         env:
-          FLY_API_TOKEN: ${{ env.FLY_API_TOKEN }}
-          PR_NUMBER: ${{ github.event.number }}
-
-      - name: Build Docker image locally
+          API_APP: ${{ steps.naming.outputs.api_app }}
+          WORKER_APP: ${{ steps.naming.outputs.worker_app }}
+          ANALYSIS_APP: ${{ steps.naming.outputs.analysis_app }}
         run: |
-          # The Dockerfile builds both the API (./main) and the worker
-          # (./worker) binaries into a single image. We tag it twice so the
-          # worker review app can --local-only deploy the same bits without
-          # a second docker build.
-          docker build -t hover-pr-${{ github.event.number }} .
-          docker tag hover-pr-${{ github.event.number }} hover-worker-pr-${{ github.event.number }}
+          # Exact match on app name (column 1). grep -q does substring
+          # matching, so hover-pr-12 would falsely match PR 123.
+          for APP in "$API_APP" "$WORKER_APP" "$ANALYSIS_APP"; do
+            if ! flyctl apps list | awk 'NR>1 {print $1}' | grep -Fxq "$APP"; then
+              echo "Creating: $APP"
+              flyctl apps create "$APP" --org personal
+            else
+              echo "Already exists: $APP"
+            fi
+          done
 
-      - name: Build Analysis image locally
+      - name: Stage secrets on API review app
+        env:
+          API_APP: ${{ steps.naming.outputs.api_app }}
+          API_URL: ${{ steps.naming.outputs.api_url }}
+          DB_URL: ${{ steps.supabase.outputs.preview_db_url }}
+          DIRECT_URL: ${{ steps.supabase.outputs.direct_db_url }}
+          BRANCH_JWT_SECRET: ${{ steps.supabase.outputs.jwt_secret }}
+          BRANCH_SERVICE_ROLE_KEY:
+            ${{ steps.supabase.outputs.service_role_key }}
+          BRANCH_SUPABASE_URL: ${{ steps.supabase.outputs.supabase_url }}
+          REVIEW_REDIS_URL: ${{ steps.redis.outputs.redis_url }}
         run: |
-          # hover-analysis uses a different image (Dockerfile.analysis): the
-          # analysis binary lives in cmd/analysis and Phase 3 will add
-          # Chromium + lighthouse@<pinned> here, so it cannot share the
-          # main image's artefact. Tagged separately and consumed by the
-          # later "Deploy Analysis Review App" step.
-          docker build -f Dockerfile.analysis -t hover-analysis-pr-${{ github.event.number }} .
-
-      # Deploy the analysis review app *before* the worker review app. The
-      # worker is the lighthouse producer (its milestone hook enqueues
-      # outbox rows that the dispatcher routes onto stream:{jobID}:lh); the
-      # analysis app is the consumer of that stream. Bringing the consumer
-      # up first means the first XADD lands in a stream that already has a
-      # reader, mirroring the worker-before-API rule below.
-      - name: Deploy Analysis Review App
-        id: deploy_analysis
-        run: |
-          if [ "${{ steps.supabase.outputs.branch_exists }}" == "true" ]; then
-            DB_URL="${{ steps.supabase.outputs.preview_db_url }}"
-            DIRECT_URL="${{ steps.supabase.outputs.direct_db_url }}"
-          else
-            echo "❌ No Supabase preview branch found; cannot deploy analysis review app." >&2
-            exit 1
-          fi
-
-          ANALYSIS_APP_NAME="hover-analysis-pr-${{ github.event.number }}"
-
-          # Exact match on app name to avoid hover-analysis-pr-1 falsely
-          # matching PR 12. Mirrors the worker review-app guard.
-          if ! flyctl apps list | awk 'NR>1 {print $1}' | grep -Fxq "$ANALYSIS_APP_NAME"; then
-            echo "Creating new analysis review app: $ANALYSIS_APP_NAME"
-            flyctl apps create "$ANALYSIS_APP_NAME" --org personal
-          else
-            echo "Analysis review app already exists: $ANALYSIS_APP_NAME"
-          fi
-
-          if [ -z "$REVIEW_REDIS_URL" ]; then
-            echo "❌ REDIS_URL is required for analysis; provisioning earlier must have failed." >&2
-            exit 1
-          fi
-
+          # Optional flags only included when their source values are set.
           DIRECT_URL_FLAGS=()
           if [ -n "$DIRECT_URL" ]; then
             DIRECT_URL_FLAGS+=(DATABASE_DIRECT_URL="$DIRECT_URL")
           fi
+          SUPABASE_URL_FLAGS=()
+          if [ -n "$BRANCH_SUPABASE_URL" ]; then
+            SUPABASE_URL_FLAGS+=(SUPABASE_URL="$BRANCH_SUPABASE_URL")
+          fi
 
+          flyctl secrets set \
+            --app "$API_APP" \
+            DATABASE_URL="$DB_URL" \
+            "${DIRECT_URL_FLAGS[@]}" \
+            "${SUPABASE_URL_FLAGS[@]}" \
+            REDIS_URL="$REVIEW_REDIS_URL" \
+            SUPABASE_JWT_SECRET="$BRANCH_JWT_SECRET" \
+            SUPABASE_SERVICE_ROLE_KEY="$BRANCH_SERVICE_ROLE_KEY" \
+            SENTRY_DSN="$SENTRY_DSN" \
+            LOOPS_API_KEY="$LOOPS_API_KEY" \
+            SLACK_CLIENT_SECRET="$SLACK_CLIENT_SECRET" \
+            WEBFLOW_CLIENT_SECRET="$WEBFLOW_CLIENT_SECRET" \
+            GOOGLE_CLIENT_SECRET="$GOOGLE_CLIENT_SECRET" \
+            OTEL_EXPORTER_OTLP_HEADERS="$OTEL_EXPORTER_OTLP_HEADERS" \
+            ARCHIVE_ACCESS_KEY_ID="$ARCHIVE_ACCESS_KEY_ID" \
+            ARCHIVE_SECRET_ACCESS_KEY="$ARCHIVE_SECRET_ACCESS_KEY" \
+            ARCHIVE_ENDPOINT="$ARCHIVE_ENDPOINT" \
+            GRAFANA_CLOUD_USER="$GRAFANA_CLOUD_USER" \
+            GRAFANA_CLOUD_API_KEY="$GRAFANA_CLOUD_API_KEY" \
+            WEBFLOW_REDIRECT_URI="${API_URL}/v1/integrations/webflow/callback" \
+            APP_URL="$API_URL" \
+            SETTINGS_URL="${API_URL}/settings" \
+            --stage
+
+      - name: Stage secrets on analysis review app
+        env:
+          ANALYSIS_APP: ${{ steps.naming.outputs.analysis_app }}
+          DB_URL: ${{ steps.supabase.outputs.preview_db_url }}
+          DIRECT_URL: ${{ steps.supabase.outputs.direct_db_url }}
+          REVIEW_REDIS_URL: ${{ steps.redis.outputs.redis_url }}
+          PR_NUMBER: ${{ github.event.number }}
+        run: |
           # Analysis-specific secret set. No OAuth client secrets, no
           # Loops, no auth — analysis only talks to Postgres + Redis + R2 +
           # observability backends.
-          echo "Setting secrets for analysis review app..."
-          flyctl secrets set \
-            DATABASE_URL="$DB_URL" \
-            "${DIRECT_URL_FLAGS[@]}" \
-            REDIS_URL="$REVIEW_REDIS_URL" \
-            SENTRY_DSN="$SENTRY_DSN" \
-            OTEL_EXPORTER_OTLP_HEADERS="$OTEL_EXPORTER_OTLP_HEADERS" \
-            ARCHIVE_ACCESS_KEY_ID="$ARCHIVE_ACCESS_KEY_ID" \
-            ARCHIVE_SECRET_ACCESS_KEY="$ARCHIVE_SECRET_ACCESS_KEY" \
-            ARCHIVE_ENDPOINT="$ARCHIVE_ENDPOINT" \
-            ARCHIVE_PATH_PREFIX="$PR_NUMBER" \
-            GRAFANA_CLOUD_USER="$GRAFANA_CLOUD_USER" \
-            GRAFANA_CLOUD_API_KEY="$GRAFANA_CLOUD_API_KEY" \
-            --app $ANALYSIS_APP_NAME --stage
-
-          flyctl deploy \
-            --app $ANALYSIS_APP_NAME \
-            --config .fly/review_apps.analysis.toml \
-            --local-only \
-            --image "hover-analysis-pr-$PR_NUMBER"
-        env:
-          FLY_API_TOKEN: ${{ env.FLY_API_TOKEN }}
-          REVIEW_REDIS_URL: ${{ steps.redis.outputs.redis_url }}
-          PR_NUMBER: ${{ github.event.number }}
-
-      # Deploy the worker review app *before* the API review app. The API
-      # enables Redis dispatch as soon as REDIS_URL is set on it, so we need
-      # a running consumer on the other end before we flip that switch.
-      # Without this ordering, a failure in the worker step would leave the
-      # API review app live, enqueueing tasks into Redis that no worker
-      # consumes.
-      - name: Deploy Worker Review App
-        id: deploy_worker
-        run: |
-          # Mirrors the API deploy step but uses fly.worker.toml-equivalent
-          # config. The same image is used (Dockerfile builds both binaries);
-          # review_apps.worker.toml overrides CMD to run ./worker directly.
-          if [ "${{ steps.supabase.outputs.branch_exists }}" == "true" ]; then
-            DB_URL="${{ steps.supabase.outputs.preview_db_url }}"
-            DIRECT_URL="${{ steps.supabase.outputs.direct_db_url }}"
-          else
-            echo "❌ No Supabase preview branch found; cannot deploy worker review app." >&2
-            exit 1
-          fi
-
-          WORKER_APP_NAME="hover-worker-pr-${{ github.event.number }}"
-
-          # Exact match on app name (column 1). grep -q does substring
-          # matching, so hover-worker-pr-12 would falsely match PR 123 and
-          # cause secrets to be set on the wrong app.
-          if ! flyctl apps list | awk 'NR>1 {print $1}' | grep -Fxq "$WORKER_APP_NAME"; then
-            echo "Creating new worker review app: $WORKER_APP_NAME"
-            flyctl apps create "$WORKER_APP_NAME" --org personal
-          else
-            echo "Worker review app already exists: $WORKER_APP_NAME"
-          fi
-
-          if [ -z "$REVIEW_REDIS_URL" ]; then
-            echo "❌ REDIS_URL is required for the worker; provisioning earlier must have failed." >&2
-            exit 1
-          fi
-
-          # Worker-specific secret set. Worker does not serve HTTP so OAuth
-          # client secrets (Slack/Webflow/Google), Loops API key, and the
-          # WEBFLOW_REDIRECT_URI/APP_URL/SETTINGS_URL triplet are omitted.
           DIRECT_URL_FLAGS=()
           if [ -n "$DIRECT_URL" ]; then
             DIRECT_URL_FLAGS+=(DATABASE_DIRECT_URL="$DIRECT_URL")
           fi
 
-          echo "Setting secrets for worker review app..."
           flyctl secrets set \
+            --app "$ANALYSIS_APP" \
             DATABASE_URL="$DB_URL" \
             "${DIRECT_URL_FLAGS[@]}" \
             REDIS_URL="$REVIEW_REDIS_URL" \
@@ -401,175 +335,207 @@ jobs:
             ARCHIVE_PATH_PREFIX="$PR_NUMBER" \
             GRAFANA_CLOUD_USER="$GRAFANA_CLOUD_USER" \
             GRAFANA_CLOUD_API_KEY="$GRAFANA_CLOUD_API_KEY" \
-            --app $WORKER_APP_NAME --stage
+            --stage
 
-          flyctl deploy \
-            --app $WORKER_APP_NAME \
-            --config .fly/review_apps.worker.toml \
-            --local-only \
-            --image "hover-worker-pr-$PR_NUMBER"
+      - name: Stage secrets on worker review app
         env:
-          FLY_API_TOKEN: ${{ env.FLY_API_TOKEN }}
+          WORKER_APP: ${{ steps.naming.outputs.worker_app }}
+          DB_URL: ${{ steps.supabase.outputs.preview_db_url }}
+          DIRECT_URL: ${{ steps.supabase.outputs.direct_db_url }}
           REVIEW_REDIS_URL: ${{ steps.redis.outputs.redis_url }}
           PR_NUMBER: ${{ github.event.number }}
-
-      - name: Deploy Review App
-        id: deploy
         run: |
-          # Use Supabase preview branch if available
-          if [ "${{ steps.supabase.outputs.branch_exists }}" == "true" ]; then
-            DB_URL="${{ steps.supabase.outputs.preview_db_url }}"
-            DIRECT_URL="${{ steps.supabase.outputs.direct_db_url }}"
-            # Use the branch's own keys if available, fall back to main project
-            BRANCH_SRK="${{ steps.supabase.outputs.branch_service_role_key }}"
-            BRANCH_JWT="${{ steps.supabase.outputs.branch_jwt_secret }}"
-            if [ -n "$BRANCH_SRK" ]; then
-              SERVICE_ROLE_KEY="$BRANCH_SRK"
-              echo "🔑 Using preview branch service_role key"
-            else
-              SERVICE_ROLE_KEY="$SUPABASE_SERVICE_ROLE_KEY"
-              echo "🔑 Using main project service_role key (branch key not available)"
-            fi
-            if [ -n "$BRANCH_JWT" ]; then
-              JWT_SECRET="$BRANCH_JWT"
-              echo "🔑 Using preview branch JWT secret"
-            else
-              JWT_SECRET="$SUPABASE_JWT_SECRET"
-              echo "🔑 Using main project JWT secret (branch secret not available)"
-            fi
-            BRANCH_URL="${{ steps.supabase.outputs.branch_supabase_url }}"
-            if [ -n "$BRANCH_URL" ]; then
-              SUPABASE_URL="$BRANCH_URL"
-              echo "🔑 Using preview branch Supabase URL"
-            else
-              SUPABASE_URL=""
-              echo "🔑 Using default Supabase URL from review_apps.toml"
-            fi
-            echo "🔀 Using Supabase PREVIEW database"
-            echo "db_type=preview" >> $GITHUB_OUTPUT
-          else
-            echo "❌ No Supabase preview branch found. Every PR should have one." >&2
-            exit 1
-          fi
-
-          # Create review app name
-          # Auth URLs (SUPABASE_FALLBACK_AUTH_URL, SUPABASE_LEGACY_AUTH_URL) are
-          # now in review_apps.toml [env] — no need to set as secrets.
-          APP_NAME="hover-pr-${{ github.event.number }}"
-
-          # Check if app exists, create if not.
-          # Exact match on app name (column 1). grep -q does substring
-          # matching, so hover-pr-12 would falsely match PR 123 and cause
-          # secrets to be set on the wrong app.
-          if ! flyctl apps list | awk 'NR>1 {print $1}' | grep -Fxq "$APP_NAME"; then
-            echo "Creating new review app: $APP_NAME"
-            flyctl apps create "$APP_NAME" --org personal
-          else
-            echo "Review app already exists: $APP_NAME"
-          fi
-
-          # Override SUPABASE_URL if branch provides one
-          SUPABASE_URL_FLAGS=()
-          if [ -n "$SUPABASE_URL" ]; then
-            SUPABASE_URL_FLAGS+=(SUPABASE_URL="$SUPABASE_URL")
-          fi
-
-          # Set secrets for Review App WITHOUT triggering deployment
-          echo "Setting test database connection and auth secrets for review app..."
-          # Non-secret config (OAuth client IDs, auth URLs) is in review_apps.toml [env].
-          # Only set actual secrets and per-PR dynamic values here.
-          # Build optional Redis secret flag
-          REDIS_FLAGS=()
-          if [ -n "$REVIEW_REDIS_URL" ]; then
-            REDIS_FLAGS+=(REDIS_URL="$REVIEW_REDIS_URL")
-            echo "🔴 Setting REDIS_URL for review app worker"
-          fi
-
+          # Worker does not serve HTTP, so OAuth client secrets, Loops, and
+          # the WEBFLOW_REDIRECT_URI/APP_URL/SETTINGS_URL triplet are
+          # omitted.
+          DIRECT_URL_FLAGS=()
           if [ -n "$DIRECT_URL" ]; then
-            echo "📡 Setting DATABASE_DIRECT_URL for real-time notifications"
-            flyctl secrets set \
-              DATABASE_URL="$DB_URL" \
-              DATABASE_DIRECT_URL="$DIRECT_URL" \
-              "${SUPABASE_URL_FLAGS[@]}" \
-              "${REDIS_FLAGS[@]}" \
-              SUPABASE_JWT_SECRET="$JWT_SECRET" \
-              SUPABASE_SERVICE_ROLE_KEY="$SERVICE_ROLE_KEY" \
-              SENTRY_DSN="$SENTRY_DSN" \
-              LOOPS_API_KEY="$LOOPS_API_KEY" \
-              SLACK_CLIENT_SECRET="$SLACK_CLIENT_SECRET" \
-              WEBFLOW_CLIENT_SECRET="$WEBFLOW_CLIENT_SECRET" \
-              GOOGLE_CLIENT_SECRET="$GOOGLE_CLIENT_SECRET" \
-              OTEL_EXPORTER_OTLP_HEADERS="$OTEL_EXPORTER_OTLP_HEADERS" \
-              ARCHIVE_ACCESS_KEY_ID="$ARCHIVE_ACCESS_KEY_ID" \
-              ARCHIVE_SECRET_ACCESS_KEY="$ARCHIVE_SECRET_ACCESS_KEY" \
-              ARCHIVE_ENDPOINT="$ARCHIVE_ENDPOINT" \
-              GRAFANA_CLOUD_USER="$GRAFANA_CLOUD_USER" \
-              GRAFANA_CLOUD_API_KEY="$GRAFANA_CLOUD_API_KEY" \
-              WEBFLOW_REDIRECT_URI="https://$APP_NAME.fly.dev/v1/integrations/webflow/callback" \
-              APP_URL="https://$APP_NAME.fly.dev" \
-              SETTINGS_URL="https://$APP_NAME.fly.dev/settings" \
-              --app $APP_NAME --stage
-          else
-            flyctl secrets set \
-              DATABASE_URL="$DB_URL" \
-              "${SUPABASE_URL_FLAGS[@]}" \
-              "${REDIS_FLAGS[@]}" \
-              SUPABASE_JWT_SECRET="$JWT_SECRET" \
-              SUPABASE_SERVICE_ROLE_KEY="$SERVICE_ROLE_KEY" \
-              SENTRY_DSN="$SENTRY_DSN" \
-              LOOPS_API_KEY="$LOOPS_API_KEY" \
-              SLACK_CLIENT_SECRET="$SLACK_CLIENT_SECRET" \
-              WEBFLOW_CLIENT_SECRET="$WEBFLOW_CLIENT_SECRET" \
-              GOOGLE_CLIENT_SECRET="$GOOGLE_CLIENT_SECRET" \
-              OTEL_EXPORTER_OTLP_HEADERS="$OTEL_EXPORTER_OTLP_HEADERS" \
-              ARCHIVE_ACCESS_KEY_ID="$ARCHIVE_ACCESS_KEY_ID" \
-              ARCHIVE_SECRET_ACCESS_KEY="$ARCHIVE_SECRET_ACCESS_KEY" \
-              ARCHIVE_ENDPOINT="$ARCHIVE_ENDPOINT" \
-              GRAFANA_CLOUD_USER="$GRAFANA_CLOUD_USER" \
-              GRAFANA_CLOUD_API_KEY="$GRAFANA_CLOUD_API_KEY" \
-              WEBFLOW_REDIRECT_URI="https://$APP_NAME.fly.dev/v1/integrations/webflow/callback" \
-              APP_URL="https://$APP_NAME.fly.dev" \
-              SETTINGS_URL="https://$APP_NAME.fly.dev/settings" \
-              --app $APP_NAME --stage
+            DIRECT_URL_FLAGS+=(DATABASE_DIRECT_URL="$DIRECT_URL")
           fi
 
-          # Deploy to review app with local image (this will apply staged secrets)
-          # Region is set via primary_region in .fly/review_apps.toml (syd)
-          flyctl deploy \
-            --app $APP_NAME \
-            --config .fly/review_apps.toml \
-            --local-only \
-            --image hover-pr-${{ github.event.number }}
-        env:
-          FLY_API_TOKEN: ${{ env.FLY_API_TOKEN }}
-          REVIEW_REDIS_URL: ${{ steps.redis.outputs.redis_url }}
+          flyctl secrets set \
+            --app "$WORKER_APP" \
+            DATABASE_URL="$DB_URL" \
+            "${DIRECT_URL_FLAGS[@]}" \
+            REDIS_URL="$REVIEW_REDIS_URL" \
+            SENTRY_DSN="$SENTRY_DSN" \
+            OTEL_EXPORTER_OTLP_HEADERS="$OTEL_EXPORTER_OTLP_HEADERS" \
+            ARCHIVE_ACCESS_KEY_ID="$ARCHIVE_ACCESS_KEY_ID" \
+            ARCHIVE_SECRET_ACCESS_KEY="$ARCHIVE_SECRET_ACCESS_KEY" \
+            ARCHIVE_ENDPOINT="$ARCHIVE_ENDPOINT" \
+            ARCHIVE_PATH_PREFIX="$PR_NUMBER" \
+            GRAFANA_CLOUD_USER="$GRAFANA_CLOUD_USER" \
+            GRAFANA_CLOUD_API_KEY="$GRAFANA_CLOUD_API_KEY" \
+            --stage
 
+  # ───────── Build phase ───────────────────────────────────────────────
+  # Two image builds run in parallel, mirroring fly-deploy.yml. The shared
+  # image carries both API and worker binaries (Dockerfile lines 19–20),
+  # so it is reused by both release-api and release-worker.
+  build-shared:
+    name: Build shared review image (API + worker)
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    needs: [provision]
+    outputs:
+      image: ${{ steps.build.outputs.image }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/fly-setup
+        with:
+          op-service-account-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          validate-redis-url: "false"
+
+      - name: Build and push shared image
+        id: build
+        env:
+          IMAGE_LABEL: ${{ needs.provision.outputs.image_label }}
+          API_APP: ${{ needs.provision.outputs.api_app }}
+        run: |
+          # --local-only builds on this runner; --push uploads to
+          # registry.fly.io/$API_APP:<tag>. Worker release pulls the same
+          # image cross-app via FLY_API_TOKEN (org-scoped).
+          flyctl deploy --build-only --push --local-only \
+            --image-label "$IMAGE_LABEL" \
+            --config .fly/review_apps.toml \
+            --app "$API_APP"
+          echo "image=registry.fly.io/${API_APP}:${IMAGE_LABEL}" >> "$GITHUB_OUTPUT"
+
+  build-analysis:
+    name: Build analysis review image
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    needs: [provision]
+    outputs:
+      image: ${{ steps.build.outputs.image }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/fly-setup
+        with:
+          op-service-account-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          validate-redis-url: "false"
+
+      - name: Build and push analysis image
+        id: build
+        env:
+          IMAGE_LABEL: ${{ needs.provision.outputs.image_label }}
+          ANALYSIS_APP: ${{ needs.provision.outputs.analysis_app }}
+        run: |
+          flyctl deploy --build-only --push --local-only \
+            --image-label "$IMAGE_LABEL" \
+            --config .fly/review_apps.analysis.toml \
+            --app "$ANALYSIS_APP"
+          echo "image=registry.fly.io/${ANALYSIS_APP}:${IMAGE_LABEL}" >> "$GITHUB_OUTPUT"
+
+  # ───────── Release phase ─────────────────────────────────────────────
+  # release-api and release-analysis fan out as soon as their builds are
+  # ready. release-worker waits on release-analysis so the consumer is
+  # healthy before the producer starts XADDing onto the lighthouse stream.
+  release-api:
+    name: Release API review app
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    needs: [provision, build-shared]
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/fly-setup
+        with:
+          op-service-account-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          validate-redis-url: "false"
+
+      - name: Release API review app
+        env:
+          IMAGE: ${{ needs.build-shared.outputs.image }}
+          API_APP: ${{ needs.provision.outputs.api_app }}
+        run: |
+          flyctl deploy \
+            --image "$IMAGE" \
+            --config .fly/review_apps.toml \
+            --app "$API_APP"
+
+  release-analysis:
+    name: Release analysis review app
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    needs: [provision, build-analysis]
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/fly-setup
+        with:
+          op-service-account-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          validate-redis-url: "false"
+
+      - name: Release analysis review app
+        env:
+          IMAGE: ${{ needs.build-analysis.outputs.image }}
+          ANALYSIS_APP: ${{ needs.provision.outputs.analysis_app }}
+        run: |
+          flyctl deploy \
+            --image "$IMAGE" \
+            --config .fly/review_apps.analysis.toml \
+            --app "$ANALYSIS_APP"
+
+  release-worker:
+    name: Release worker review app
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    # build-shared for the image, release-analysis for the
+    # consumer-before-producer invariant.
+    needs: [provision, build-shared, release-analysis]
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/fly-setup
+        with:
+          op-service-account-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          validate-redis-url: "false"
+
+      - name: Release worker review app
+        # Reuses the shared image from build-shared — Dockerfile compiles
+        # both binaries, review_apps.worker.toml selects the worker
+        # entrypoint.
+        env:
+          IMAGE: ${{ needs.build-shared.outputs.image }}
+          WORKER_APP: ${{ needs.provision.outputs.worker_app }}
+        run: |
+          flyctl deploy \
+            --image "$IMAGE" \
+            --config .fly/review_apps.worker.toml \
+            --app "$WORKER_APP"
+
+  # ───────── Comment on PR ─────────────────────────────────────────────
+  # Single comment with the API URL — posted only after the API release
+  # succeeds (worker/analysis are not user-facing).
+  comment-pr:
+    name: Comment review-app URL on PR
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    needs: [provision, release-api]
+    permissions:
+      pull-requests: write
+    steps:
       - name: Comment PR with app URL
         uses: actions/github-script@v8
+        env:
+          API_URL: ${{ needs.provision.outputs.api_url }}
         with:
           script: |
-            const prNumber = ${{ github.event.number }};
-            const appName = `hover-pr-${prNumber}`;
-            const appUrl = `https://${appName}.fly.dev`;
-
+            const apiUrl = process.env.API_URL;
             github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
               body: `🐝 **Review App Deployed**
 
-              Homepage: <a href="${appUrl}">${appUrl}</a>
-              Dashboard: <a href="${appUrl}/dashboard">${appUrl}/dashboard</a>`
+              Homepage: <a href="${apiUrl}">${apiUrl}</a>
+              Dashboard: <a href="${apiUrl}/dashboard">${apiUrl}/dashboard</a>`
             });
 
+  # ───────── Cleanup ───────────────────────────────────────────────────
+  # Runs only on PR close. Tears down the three Fly apps and the
+  # per-PR Redis instance, in the reverse order of creation
+  # (consumer-before-producer applies to teardown too: stop the worker
+  # first so it doesn't log Redis errors as the broker disappears, and
+  # stop the analysis consumer before the API stops enqueueing).
   cleanup-review:
     name: Cleanup Review App
     runs-on: blacksmith-4vcpu-ubuntu-2404
     if: github.event.action == 'closed'
-
     steps:
-      - name: Setup Fly.io CLI
-        uses: superfly/flyctl-actions/setup-flyctl@63da3ecc5e2793b98a3f2519b3d75d4f4c11cec2 # pinned
+      - uses: superfly/flyctl-actions/setup-flyctl@63da3ecc5e2793b98a3f2519b3d75d4f4c11cec2 # pinned
 
       - name: Load secrets from 1Password
         uses: 1password/load-secrets-action@v2
@@ -580,12 +546,10 @@ jobs:
           FLY_API_TOKEN: op://Good Native/hover-fly/FLY_API_TOKEN
 
       - name: Destroy Analysis Review App
+        env:
+          PR_NUMBER: ${{ github.event.number }}
         run: |
           ANALYSIS_APP_NAME="hover-analysis-pr-${PR_NUMBER}"
-          # Destroy the analysis app first so the lighthouse stream
-          # consumer detaches before the worker stops producing. Mirrors
-          # the consumer-before-producer rule that already applies to the
-          # worker → API ordering below.
           if ! APP_LIST=$(flyctl apps list); then
             echo "❌ flyctl apps list failed — cannot determine cleanup state" >&2
             exit 1
@@ -599,18 +563,12 @@ jobs:
           else
             echo "ℹ️ Analysis review app does not exist, nothing to clean up: $ANALYSIS_APP_NAME"
           fi
-        env:
-          FLY_API_TOKEN: ${{ env.FLY_API_TOKEN }}
-          PR_NUMBER: ${{ github.event.number }}
 
       - name: Destroy Worker Review App
+        env:
+          PR_NUMBER: ${{ github.event.number }}
         run: |
           WORKER_APP_NAME="hover-worker-pr-${PR_NUMBER}"
-          # Destroy the worker first so the consumer detaches before Redis
-          # is torn down; otherwise the worker logs a flurry of Redis
-          # connection errors on its way out.
-          # Capture list output separately so API/auth failures surface
-          # instead of being silently treated as "app does not exist".
           if ! APP_LIST=$(flyctl apps list); then
             echo "❌ flyctl apps list failed — cannot determine cleanup state" >&2
             exit 1
@@ -624,14 +582,12 @@ jobs:
           else
             echo "ℹ️ Worker review app does not exist, nothing to clean up: $WORKER_APP_NAME"
           fi
-        env:
-          FLY_API_TOKEN: ${{ env.FLY_API_TOKEN }}
-          PR_NUMBER: ${{ github.event.number }}
 
       - name: Destroy Upstash Redis
+        env:
+          PR_NUMBER: ${{ github.event.number }}
         run: |
           REDIS_NAME="hover-redis-pr-${PR_NUMBER}"
-          # Distinguish "doesn't exist" (OK) from other failures (surface them).
           if ! REDIS_LIST=$(flyctl redis list); then
             echo "❌ flyctl redis list failed — cannot determine cleanup state" >&2
             exit 1
@@ -645,14 +601,12 @@ jobs:
           else
             echo "ℹ️ Redis instance does not exist, nothing to clean up: $REDIS_NAME"
           fi
-        env:
-          FLY_API_TOKEN: ${{ env.FLY_API_TOKEN }}
-          PR_NUMBER: ${{ github.event.number }}
 
       - name: Destroy Review App
+        env:
+          PR_NUMBER: ${{ github.event.number }}
         run: |
           APP_NAME="hover-pr-${PR_NUMBER}"
-          # Distinguish "doesn't exist" (OK) from other failures (surface them).
           if ! APP_LIST=$(flyctl apps list); then
             echo "❌ flyctl apps list failed — cannot determine cleanup state" >&2
             exit 1
@@ -666,6 +620,3 @@ jobs:
           else
             echo "ℹ️ Review app does not exist, nothing to clean up: $APP_NAME"
           fi
-        env:
-          FLY_API_TOKEN: ${{ env.FLY_API_TOKEN }}
-          PR_NUMBER: ${{ github.event.number }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,32 +28,7 @@ On merge, CI will:
 
 ## [Unreleased]
 
-### Changed
-
-- Parallelised the Fly deploy pipeline. `fly-deploy.yml` now splits image build
-  from app release: the shared `hover` image (API + worker, baked together by
-  `Dockerfile`) is built once instead of twice, and the `hover-analysis` image
-  builds in parallel with it. Releases fan out for API and analysis, with worker
-  release gated on analysis being healthy to preserve the
-  consumer-before-producer invariant on the per-job lighthouse stream. Expected
-  wall-clock: ~9.5 min → ~4.5 min.
-- Mirrored the same build-once + parallel structure in `review-apps.yml`, so PR
-  review apps now exercise the production deploy logic. Provision job sets up
-  the per-PR Fly apps, Upstash Redis, and Supabase preview branch and stages
-  secrets onto the three apps; build/release jobs pin to the staged image via
-  `flyctl deploy --image …`. Shared setup (Go, flyctl, 1Password) lives in a new
-  `.github/actions/fly-setup` composite.
-- Tightened the `Changelog Check` workflow to fail PRs that don't add a new
-  entry under `## [Unreleased]`. Removed the `.github/**` exclusion so workflow
-  changes also require a changelog entry.
-
-### Fixed
-
-- `.fly/review_apps.analysis.toml` now pins
-  `dockerfile = "../Dockerfile.analysis"` under `[build]`, matching
-  `fly.analysis.toml`. Without it, flyctl defaulted to the root `Dockerfile` and
-  would have shipped the wrong binary in `hover-analysis-pr-N`. CodeRabbit
-  caught this on PR #361.
+_Add unreleased changes here._
 
 ## Full changelog history
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,32 @@ On merge, CI will:
 
 ## [Unreleased]
 
-_Add unreleased changes here._
+### Changed
+
+- Parallelised the Fly deploy pipeline. `fly-deploy.yml` now splits image build
+  from app release: the shared `hover` image (API + worker, baked together by
+  `Dockerfile`) is built once instead of twice, and the `hover-analysis` image
+  builds in parallel with it. Releases fan out for API and analysis, with worker
+  release gated on analysis being healthy to preserve the
+  consumer-before-producer invariant on the per-job lighthouse stream. Expected
+  wall-clock: ~9.5 min → ~4.5 min.
+- Mirrored the same build-once + parallel structure in `review-apps.yml`, so PR
+  review apps now exercise the production deploy logic. Provision job sets up
+  the per-PR Fly apps, Upstash Redis, and Supabase preview branch and stages
+  secrets onto the three apps; build/release jobs pin to the staged image via
+  `flyctl deploy --image …`. Shared setup (Go, flyctl, 1Password) lives in a new
+  `.github/actions/fly-setup` composite.
+- Tightened the `Changelog Check` workflow to fail PRs that don't add a new
+  entry under `## [Unreleased]`. Removed the `.github/**` exclusion so workflow
+  changes also require a changelog entry.
+
+### Fixed
+
+- `.fly/review_apps.analysis.toml` now pins
+  `dockerfile = "../Dockerfile.analysis"` under `[build]`, matching
+  `fly.analysis.toml`. Without it, flyctl defaulted to the root `Dockerfile` and
+  would have shipped the wrong binary in `hover-analysis-pr-N`. CodeRabbit
+  caught this on PR #361.
 
 ## Full changelog history
 


### PR DESCRIPTION
## Summary

Restructure `.github/workflows/fly-deploy.yml` to split image **build** from app **release**, so the shared `hover` image (API + worker, baked together by `Dockerfile`) is built once instead of twice and the analysis image builds in parallel with it. Reduces deploy wall-clock from ~9.5 min to ~4–4.5 min.

## Why

Today the workflow runs three `flyctl deploy --remote-only` calls in waterfall. The current `Dockerfile` (lines 19–20) compiles **both** `cmd/app/main.go` and `cmd/worker/main.go` and copies both binaries into the final image — so `hover` and `hover-worker` deploy the **same image**, but the workflow rebuilds it from scratch twice, each time taking ~3 min on Fly's remote builder.

Naive job fan-out alone caps at ~30% saving because of the consumer-before-producer invariant (`hover-analysis` must be live before `hover-worker` starts XADDing onto per-job lighthouse streams). Splitting build from release sidesteps that: the slow phase (build) parallelises freely; the fast phase (release, ~30 s) still respects the ordering via `needs:` without paying a build wait.

## Plan

```
            ┌──────────────────────────┐
            │  build-shared (API+wkr)  │──┐
            ├──────────────────────────┤  │
            │  build-analysis          │──┤
            └──────────────────────────┘  ▼
                                  ┌────────────────────┐
                                  │ release-api        │
                                  │ release-analysis   │ (parallel)
                                  └────────────────────┘
                                          │
                                          ▼
                                  ┌────────────────────┐
                                  │ release-worker     │  needs: release-analysis
                                  └────────────────────┘
                                          │
                                          ▼
                                  ┌────────────────────┐
                                  │ annotate-grafana   │  if: always()
                                  └────────────────────┘
```

- `build-shared` and `build-analysis` run in parallel via `flyctl deploy --build-only --push --image-label deployment-<run_id>-<attempt>`, exporting the image ref as a job output.
- `release-api`, `release-analysis`, `release-worker` consume the pre-built image with `flyctl deploy --image …`. Worker reuses `registry.fly.io/hover:<tag>` from `build-shared`.
- Workflow-level `concurrency: deploy-group` (`cancel-in-progress: false`) replaces the job-level lock so a follow-up push to `main` queues behind the in-flight run rather than racing across jobs.
- Shared setup (checkout, Go, flyctl, 1Password load, REDIS_URL validation) is extracted into a composite action `.github/actions/fly-setup` to avoid five-way drift.

## Expected impact

| Phase                             | Today    | Proposed                |
| --------------------------------- | -------- | ----------------------- |
| Build hover image                 | ~3 min   | parallel                |
| Build worker image (same as hover) | ~3 min   | **eliminated**          |
| Build analysis image              | ~3 min   | parallel                |
| Release × 3                       | (in deploy) | ~30 s + ~30 s + ~30 s |
| **Total**                         | **~9.5 min** | **~4–4.5 min (≈55% faster)** |

## Test plan

- [ ] **Tag plumbing**: confirm `release-worker` picks up the same image tag as `release-api` (`flyctl releases list --app hover-worker` and `--app hover` show identical image refs).
- [ ] **Ordering invariant**: deliberately break `cmd/analysis` build, confirm `release-worker` is blocked and the workflow surfaces the analysis failure.
- [ ] **Wall-clock**: compare baseline run vs new run over 3 deploys; expect ≥50% reduction.
- [ ] **Concurrency lock**: push two commits back-to-back, confirm second run queues behind the first via the workflow-level lock.
- [ ] **Grafana annotation**: confirm one annotation per run with correct `service:` tags, even when one release fails (`if: always()`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Split deploys into parallel build and separate release phases using pre-built images, added serialized concurrency, and enforced consumer-before-producer deploy/teardown ordering for review apps.
  * Review-apps pipeline now provisions per-PR resources (DB/Redis), stages secrets per-app, and posts computed preview URLs.
  * Review analysis build uses an explicit build config to ensure correct image.

* **New Features**
  * Added a reusable CI setup action that loads runtime secrets, installs flyctl, and can optionally validate critical config.
  * Best-effort Grafana deployment annotation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->