### PR TITLE
Fix per-job broker state leak on cancel/restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,31 @@ On merge, CI will:
 
 ## [Unreleased]
 
-_Add unreleased changes here._
+### Fixed
+
+- Job throughput could collapse to ~0.3 tasks/s after a same-domain
+  cancel-and-restart, while concurrent jobs on other domains kept running at 5–8
+  tasks/s. Root cause was stale per-job broker state from the previous run
+  leaking into the new dispatcher loop.
+  - `RemoveJobKeys` now also clears the cancelled job's field from every
+    per-host `hover:dom:flight:*` HASH. Without this every cancel left a
+    leftover counter that drifted unbounded across restarts.
+  - On worker boot, scan `hover:dom:flight:*` and drop fields whose job is not
+    in the active Postgres set. Hard SIGKILL bypasses the graceful-shutdown
+    drain, so the dispatcher's increment runs but the worker's `pacer.Release`
+    decrement never does — `dom:flight` has no dedicated reconciler, so drift
+    used to accumulate forever.
+  - `RunningCounters.Reconcile` is now atomic: a single Lua EVAL replaces the
+    previous `DEL + HSET` pipeline. Concurrent `Increment` / `Decrement` could
+    land between the two commands and have its update silently lost when the
+    rewrite landed, freezing dispatch for any job whose counter floated up to
+    its concurrency cap until the next 120s reconcile.
+
+- Job status pill stayed on "Starting up" forever because `UpdateJobStatus` had
+  no callers in the production graph. The dispatcher now flips
+  `pending → running` on the first successful publish for a job via a new
+  `JobManager.MarkJobRunning` (guarded UPDATE, idempotent across worker
+  restarts).
 
 ## Full changelog history
 

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -315,11 +315,10 @@ func main() {
 	// 'pending' forever (UpdateJobStatus has no other callers in the
 	// production graph) and the dashboard "Starting up" pill never
 	// goes away. MarkJobRunning is a guarded UPDATE so it is idempotent
-	// across worker restarts.
-	dispatcher.SetOnFirstDispatch(func(ctx context.Context, jobID string) {
-		if err := jobManager.MarkJobRunning(ctx, jobID); err != nil {
-			workerLog.Warn("MarkJobRunning failed", "error", err, "job_id", jobID)
-		}
+	// across worker restarts. Returning the error lets the dispatcher
+	// retry on the next tick if the DB call fails transiently.
+	dispatcher.SetOnFirstDispatch(func(ctx context.Context, jobID string) error {
+		return jobManager.MarkJobRunning(ctx, jobID)
 	})
 
 	// --- running counter DB sync ---

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -630,10 +630,15 @@ func sweepOrphanInflightOnBoot(redisClient *broker.Client, sqlDB *sql.DB) {
 	defer cancel()
 
 	var activeJobIDs []string
+	// 'initializing' is a live pre-running state (sitemap fetch + parse)
+	// that the rest of the lifecycle treats as active — including
+	// MarkJobRunning, which flips initializing → running on the
+	// dispatcher's first publish. Excluding it here would let the sweep
+	// wipe dom:flight entries for jobs that are about to dispatch.
 	err := sqlDB.QueryRowContext(ctx, `
 		SELECT COALESCE(array_agg(id::text), ARRAY[]::text[])
 		  FROM jobs
-		 WHERE status IN ('running', 'pending')
+		 WHERE status IN ('running', 'pending', 'initializing')
 	`).Scan(pq.Array(&activeJobIDs))
 	if err != nil {
 		workerLog.Warn("dom:flight orphan sweep skipped — active job query failed",

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -28,6 +29,7 @@ import (
 	"github.com/Harvey-AU/hover/internal/observability"
 	"github.com/Harvey-AU/hover/internal/watchdog"
 	"github.com/getsentry/sentry-go"
+	"github.com/lib/pq"
 )
 
 var workerLog = logging.Component("worker")
@@ -204,6 +206,10 @@ func main() {
 		}
 	}
 
+	// Sweep stale per-job entries from every dom:flight HASH. See
+	// sweepOrphanInflightOnBoot for the full rationale.
+	sweepOrphanInflightOnBoot(redisClient, pgDB.GetDB())
+
 	machineName := os.Getenv("FLY_MACHINE_ID")
 	if machineName == "" {
 		machineName, _ = os.Hostname()
@@ -303,6 +309,18 @@ func main() {
 		swp, // implements broker.ConcurrencyChecker
 		dispatcherOpts,
 	)
+
+	// Flip pending → running on the first successful publish for each
+	// job. Without this hook, jobs created via CreateJob stay at
+	// 'pending' forever (UpdateJobStatus has no other callers in the
+	// production graph) and the dashboard "Starting up" pill never
+	// goes away. MarkJobRunning is a guarded UPDATE so it is idempotent
+	// across worker restarts.
+	dispatcher.SetOnFirstDispatch(func(ctx context.Context, jobID string) {
+		if err := jobManager.MarkJobRunning(ctx, jobID); err != nil {
+			workerLog.Warn("MarkJobRunning failed", "error", err, "job_id", jobID)
+		}
+	})
 
 	// --- running counter DB sync ---
 	counterSyncSec := envInt("REDIS_COUNTER_SYNC_INTERVAL_S", 5)
@@ -590,6 +608,49 @@ func buildHTMLPersister(log *logging.Logger, dbQueue *db.DbQueue) *jobs.HTMLPers
 		"batch_size", cfg.BatchSize,
 	)
 	return persister
+}
+
+// sweepOrphanInflightOnBoot scans hover:dom:flight:* and removes
+// per-job fields whose jobID is no longer in the active Postgres set.
+//
+// dom:flight is incremented by the dispatcher on publish and
+// decremented by the worker on pacer.Release; a hard SIGKILL (Fly OOM,
+// panic, force-redeploy) bypasses the graceful shutdown that drains
+// in-flight tasks, so the increment runs but the decrement never does.
+// Unlike the running-counter HASH there is no dedicated reconciler for
+// dom:flight, so drift accumulates across every restart on every
+// domain that had work in flight at SIGTERM. Run once on boot, before
+// the dispatcher starts, so new dispatches in this run write into a
+// clean slate. Active set comes from Postgres to avoid wiping fields
+// for jobs the dispatcher will resume.
+//
+// All failures are logged and tolerated: the sweep is a best-effort
+// hygiene pass, not load-bearing for correctness.
+func sweepOrphanInflightOnBoot(redisClient *broker.Client, sqlDB *sql.DB) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	var activeJobIDs []string
+	err := sqlDB.QueryRowContext(ctx, `
+		SELECT COALESCE(array_agg(id::text), ARRAY[]::text[])
+		  FROM jobs
+		 WHERE status IN ('running', 'pending')
+	`).Scan(pq.Array(&activeJobIDs))
+	if err != nil {
+		workerLog.Warn("dom:flight orphan sweep skipped — active job query failed",
+			"error", err)
+		return
+	}
+
+	removed, err := redisClient.SweepOrphanInflight(ctx, activeJobIDs)
+	if err != nil {
+		workerLog.Warn("dom:flight orphan sweep failed", "error", err)
+		return
+	}
+	if removed > 0 {
+		workerLog.Info("dom:flight orphan sweep complete",
+			"fields_removed", removed, "active_jobs", len(activeJobIDs))
+	}
 }
 
 // Compile-time interface checks.

--- a/internal/broker/counters.go
+++ b/internal/broker/counters.go
@@ -76,30 +76,50 @@ func (rc *RunningCounters) GetAll(ctx context.Context) (map[string]int64, error)
 	return counts, nil
 }
 
+// reconcileScript atomically clears RunningCountersKey and rewrites
+// it with the field/value pairs in ARGV. ARGV is laid out as
+// jobID, count, jobID, count, ...
+//
+// Replaces a non-atomic Del+HSet pipeline. Under that earlier shape a
+// concurrent Increment or Decrement could land between the Del and the
+// HSet and have its update silently lost when the rewrite landed —
+// drift then persisted until the next reconcile (every 120s) and any
+// job whose counter floated up to its concurrency cap could freeze
+// dispatch in the meantime. The Lua wrapper closes that race because
+// EVAL runs as one server-side step, blocking the HIncrBy call until
+// the rewrite is complete.
+var reconcileScript = redis.NewScript(`
+redis.call('DEL', KEYS[1])
+if #ARGV >= 2 then
+    redis.call('HSET', KEYS[1], unpack(ARGV))
+end
+return 1
+`)
+
 // Reconcile sets the running counters from an authoritative source
-// (typically a Postgres query on startup). This overwrites any
-// stale state in Redis.
+// (typically PEL counts on the periodic tick or a Postgres query on
+// startup). Atomic: a single server-side EVAL replaces the previous
+// Del+HSet pipeline so concurrent Increment/Decrement cannot lose
+// updates in the gap between the clear and the rewrite.
 func (rc *RunningCounters) Reconcile(ctx context.Context, counts map[string]int64) error {
 	if len(counts) == 0 {
-		// No running tasks — clear the hash.
+		// No running tasks — clear the hash. Single-command op already
+		// atomic; no need to invoke the script for the empty case.
 		return rc.client.rdb.Del(ctx, RunningCountersKey).Err()
 	}
 
-	pipe := rc.client.rdb.Pipeline()
-	// Delete existing hash and rebuild.
-	pipe.Del(ctx, RunningCountersKey)
-	fields := make([]interface{}, 0, len(counts)*2)
+	args := make([]interface{}, 0, len(counts)*2)
 	for jobID, count := range counts {
 		if count > 0 {
-			fields = append(fields, jobID, strconv.FormatInt(count, 10))
+			args = append(args, jobID, strconv.FormatInt(count, 10))
 		}
 	}
-	if len(fields) > 0 {
-		pipe.HSet(ctx, RunningCountersKey, fields...)
+	if len(args) == 0 {
+		// All counts non-positive — equivalent to the empty case above.
+		return rc.client.rdb.Del(ctx, RunningCountersKey).Err()
 	}
 
-	_, err := pipe.Exec(ctx)
-	return err
+	return reconcileScript.Run(ctx, rc.client.rdb, []string{RunningCountersKey}, args...).Err()
 }
 
 // RemoveJob clears the running counter for a specific job

--- a/internal/broker/counters_test.go
+++ b/internal/broker/counters_test.go
@@ -2,6 +2,7 @@ package broker
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -79,4 +80,63 @@ func TestRunningCounters_Reconcile(t *testing.T) {
 	val, err = rc.Get(ctx, "j1")
 	require.NoError(t, err)
 	assert.Equal(t, int64(5), val)
+}
+
+// TestRunningCounters_Reconcile_Empty covers the no-running-tasks
+// branch: Reconcile must clear the hash without invoking the script.
+func TestRunningCounters_Reconcile_Empty(t *testing.T) {
+	client := newTestClient(t)
+	rc := NewRunningCounters(client)
+	ctx := context.Background()
+
+	_, err := rc.Increment(ctx, "ghost")
+	require.NoError(t, err)
+
+	require.NoError(t, rc.Reconcile(ctx, nil))
+
+	all, err := rc.GetAll(ctx)
+	require.NoError(t, err)
+	assert.Empty(t, all)
+}
+
+// TestRunningCounters_Reconcile_AllNonPositive verifies the path where
+// every supplied count is <=0: the hash is cleared, no fields written.
+func TestRunningCounters_Reconcile_AllNonPositive(t *testing.T) {
+	client := newTestClient(t)
+	rc := NewRunningCounters(client)
+	ctx := context.Background()
+
+	_, err := rc.Increment(ctx, "old")
+	require.NoError(t, err)
+
+	require.NoError(t, rc.Reconcile(ctx, map[string]int64{
+		"a": 0,
+		"b": -3,
+	}))
+
+	all, err := rc.GetAll(ctx)
+	require.NoError(t, err)
+	assert.Empty(t, all)
+}
+
+// TestRunningCounters_Reconcile_Atomic exercises the Lua script via a
+// large fan-in: many fields land in one EVAL. Catches regressions
+// where the script mishandles long ARGV or unpack widths.
+func TestRunningCounters_Reconcile_Atomic(t *testing.T) {
+	client := newTestClient(t)
+	rc := NewRunningCounters(client)
+	ctx := context.Background()
+
+	counts := make(map[string]int64, 200)
+	for i := 0; i < 200; i++ {
+		counts[fmt.Sprintf("job-%03d", i)] = int64(i + 1)
+	}
+	require.NoError(t, rc.Reconcile(ctx, counts))
+
+	got, err := rc.GetAll(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, len(counts), len(got))
+	for k, v := range counts {
+		assert.Equal(t, v, got[k], "field %s", k)
+	}
 }

--- a/internal/broker/dispatcher.go
+++ b/internal/broker/dispatcher.go
@@ -76,6 +76,20 @@ type Dispatcher struct {
 	// worker has ever dispatched for, which is small in practice and
 	// released when the worker process exits.
 	groupEnsured sync.Map
+
+	// firstDispatched remembers jobs we have already fired the
+	// onFirstDispatch hook for in this dispatcher's lifetime. Resets on
+	// process restart, but the hook implementation must be idempotent
+	// (typical: a guarded UPDATE that no-ops once status moves past
+	// pending) so re-firing on restart costs at most one cheap UPDATE.
+	firstDispatched sync.Map
+
+	// onFirstDispatch is invoked the first time dispatchJob successfully
+	// publishes a task for a given jobID. Optional: nil disables the
+	// hook. Used by the worker to flip status pending → running so the
+	// status pill reflects reality without requiring every potential
+	// entry point to coordinate the transition.
+	onFirstDispatch func(ctx context.Context, jobID string)
 }
 
 // NewDispatcher creates a Dispatcher.
@@ -97,6 +111,14 @@ func NewDispatcher(
 		concCheck: concCheck,
 		opts:      opts,
 	}
+}
+
+// SetOnFirstDispatch installs a callback fired the first time
+// dispatchJob successfully publishes a task for a given jobID in this
+// dispatcher's lifetime. The hook must be idempotent — see
+// firstDispatched on Dispatcher.
+func (d *Dispatcher) SetOnFirstDispatch(fn func(ctx context.Context, jobID string)) {
+	d.onFirstDispatch = fn
 }
 
 // Run is the dispatcher's main loop. It blocks until ctx is
@@ -247,6 +269,17 @@ func (d *Dispatcher) dispatchJob(ctx context.Context, jobID string, now time.Tim
 		// Increment domain inflight counter.
 		if err := d.pacer.IncrementInflight(ctx, domain, jobID); err != nil {
 			brokerLog.Warn("inflight increment failed", "error", err, "domain", domain)
+		}
+
+		// First successful publish for this job in this dispatcher's
+		// lifetime → flip status pending → running. LoadOrStore returns
+		// loaded=false only the first time, so the hook fires exactly
+		// once per jobID per process. Cheap atomic on the hot path
+		// (sync.Map for an O(active-jobs) keyspace).
+		if d.onFirstDispatch != nil {
+			if _, loaded := d.firstDispatched.LoadOrStore(jobID, struct{}{}); !loaded {
+				d.onFirstDispatch(ctx, jobID)
+			}
 		}
 
 		observability.RecordBrokerDispatch(ctx, jobID, "ok")

--- a/internal/broker/dispatcher.go
+++ b/internal/broker/dispatcher.go
@@ -82,6 +82,11 @@ type Dispatcher struct {
 	// process restart, but the hook implementation must be idempotent
 	// (typical: a guarded UPDATE that no-ops once status moves past
 	// pending) so re-firing on restart costs at most one cheap UPDATE.
+	//
+	// Only populated on hook success — a transient hook failure leaves
+	// the entry absent so the next dispatch tick retries. Without that,
+	// one bad UPDATE could leave a job stranded in pending for the
+	// dispatcher's lifetime.
 	firstDispatched sync.Map
 
 	// onFirstDispatch is invoked the first time dispatchJob successfully
@@ -89,7 +94,13 @@ type Dispatcher struct {
 	// hook. Used by the worker to flip status pending → running so the
 	// status pill reflects reality without requiring every potential
 	// entry point to coordinate the transition.
-	onFirstDispatch func(ctx context.Context, jobID string)
+	//
+	// Returning a non-nil error signals a transient failure: the
+	// dispatcher does NOT mark the job as "first-dispatched", so the
+	// next dispatch tick will retry. Implementations should make this
+	// idempotent — the hook may fire repeatedly for the same job until
+	// it succeeds.
+	onFirstDispatch func(ctx context.Context, jobID string) error
 }
 
 // NewDispatcher creates a Dispatcher.
@@ -116,8 +127,9 @@ func NewDispatcher(
 // SetOnFirstDispatch installs a callback fired the first time
 // dispatchJob successfully publishes a task for a given jobID in this
 // dispatcher's lifetime. The hook must be idempotent — see
-// firstDispatched on Dispatcher.
-func (d *Dispatcher) SetOnFirstDispatch(fn func(ctx context.Context, jobID string)) {
+// firstDispatched on Dispatcher. Returning a non-nil error from the
+// hook causes the dispatcher to retry on the next dispatch.
+func (d *Dispatcher) SetOnFirstDispatch(fn func(ctx context.Context, jobID string) error) {
 	d.onFirstDispatch = fn
 }
 
@@ -272,13 +284,21 @@ func (d *Dispatcher) dispatchJob(ctx context.Context, jobID string, now time.Tim
 		}
 
 		// First successful publish for this job in this dispatcher's
-		// lifetime → flip status pending → running. LoadOrStore returns
-		// loaded=false only the first time, so the hook fires exactly
-		// once per jobID per process. Cheap atomic on the hot path
-		// (sync.Map for an O(active-jobs) keyspace).
+		// lifetime → flip status pending → running. We Load before
+		// calling the hook and Store only after success: a transient
+		// failure must not be memoised, otherwise one bad UPDATE could
+		// leave a job stranded in pending for the dispatcher's whole
+		// lifetime. Worst case under load is a few duplicate UPDATEs
+		// while the database recovers; the hook is guarded so the
+		// extra UPDATEs are no-ops once a peer wins the race.
 		if d.onFirstDispatch != nil {
-			if _, loaded := d.firstDispatched.LoadOrStore(jobID, struct{}{}); !loaded {
-				d.onFirstDispatch(ctx, jobID)
+			if _, seen := d.firstDispatched.Load(jobID); !seen {
+				if err := d.onFirstDispatch(ctx, jobID); err != nil {
+					brokerLog.Warn("onFirstDispatch failed",
+						"error", err, "job_id", jobID)
+				} else {
+					d.firstDispatched.Store(jobID, struct{}{})
+				}
 			}
 		}
 

--- a/internal/broker/dispatcher_test.go
+++ b/internal/broker/dispatcher_test.go
@@ -365,3 +365,55 @@ func TestConsumer_ReclaimStaleMessage(t *testing.T) {
 	require.Len(t, reclaimed, 1, "stale message should be reclaimed")
 	assert.Equal(t, msgs[0].TaskID, reclaimed[0].TaskID)
 }
+
+// --- OnFirstDispatch hook -----------------------------------------------
+
+// TestDispatcher_OnFirstDispatch_FiresExactlyOncePerJob verifies the
+// hook fires the first time a task lands in the stream for a given
+// jobID and never again in the same dispatcher's lifetime, even after
+// many dispatches across multiple ticks.
+func TestDispatcher_OnFirstDispatch_FiresExactlyOncePerJob(t *testing.T) {
+	lister := &staticJobLister{ids: []string{"job-A", "job-B"}}
+	conc := &staticConcurrency{can: true}
+	d, s, _, _, _, _ := newDispatcherRig(t, lister, conc)
+	ctx := context.Background()
+
+	calls := make(map[string]int)
+	d.SetOnFirstDispatch(func(_ context.Context, jobID string) {
+		calls[jobID]++
+	})
+
+	// Seed several tasks for two different jobs.
+	now := time.Now()
+	seedEntry(t, s, "job-A", "a1", "a.com", now)
+	seedEntry(t, s, "job-A", "a2", "a.com", now)
+	seedEntry(t, s, "job-A", "a3", "a.com", now)
+	seedEntry(t, s, "job-B", "b1", "b.com", now)
+	seedEntry(t, s, "job-B", "b2", "b.com", now)
+
+	for _, id := range []string{"job-A", "job-B"} {
+		_, err := d.dispatchJob(ctx, id, now)
+		require.NoError(t, err)
+		// Run a second tick to confirm the hook does not fire again.
+		_, err = d.dispatchJob(ctx, id, now)
+		require.NoError(t, err)
+	}
+
+	assert.Equal(t, 1, calls["job-A"], "job-A hook must fire exactly once")
+	assert.Equal(t, 1, calls["job-B"], "job-B hook must fire exactly once")
+}
+
+// TestDispatcher_OnFirstDispatch_NotInvokedWhenUnset confirms the
+// dispatcher tolerates a nil hook (default state) without panicking.
+func TestDispatcher_OnFirstDispatch_NotInvokedWhenUnset(t *testing.T) {
+	lister := &staticJobLister{ids: []string{"job-N"}}
+	conc := &staticConcurrency{can: true}
+	d, s, _, _, _, _ := newDispatcherRig(t, lister, conc)
+	ctx := context.Background()
+
+	seedEntry(t, s, "job-N", "n1", "n.com", time.Now())
+
+	n, err := d.dispatchJob(ctx, "job-N", time.Now())
+	require.NoError(t, err)
+	assert.Equal(t, 1, n)
+}

--- a/internal/broker/dispatcher_test.go
+++ b/internal/broker/dispatcher_test.go
@@ -379,8 +379,9 @@ func TestDispatcher_OnFirstDispatch_FiresExactlyOncePerJob(t *testing.T) {
 	ctx := context.Background()
 
 	calls := make(map[string]int)
-	d.SetOnFirstDispatch(func(_ context.Context, jobID string) {
+	d.SetOnFirstDispatch(func(_ context.Context, jobID string) error {
 		calls[jobID]++
+		return nil
 	})
 
 	// Seed several tasks for two different jobs.
@@ -403,6 +404,38 @@ func TestDispatcher_OnFirstDispatch_FiresExactlyOncePerJob(t *testing.T) {
 	assert.Equal(t, 1, calls["job-B"], "job-B hook must fire exactly once")
 }
 
+// TestDispatcher_OnFirstDispatch_RetriesOnFailure verifies the hook is
+// re-invoked on subsequent dispatches if the previous call returned
+// an error — closes a class of bugs where a transient DB failure on
+// the very first dispatch would leave the job stranded in 'pending'
+// for the dispatcher's whole lifetime.
+func TestDispatcher_OnFirstDispatch_RetriesOnFailure(t *testing.T) {
+	lister := &staticJobLister{ids: []string{"job-R"}}
+	conc := &staticConcurrency{can: true}
+	d, s, _, _, _, _ := newDispatcherRig(t, lister, conc)
+	ctx := context.Background()
+
+	var calls int
+	d.SetOnFirstDispatch(func(_ context.Context, _ string) error {
+		calls++
+		if calls < 3 {
+			return errors.New("transient")
+		}
+		return nil
+	})
+
+	now := time.Now()
+	for i := 0; i < 4; i++ {
+		seedEntry(t, s, "job-R",
+			"r-"+string(rune('a'+i)), "r.com", now)
+		_, err := d.dispatchJob(ctx, "job-R", now)
+		require.NoError(t, err)
+	}
+
+	assert.Equal(t, 3, calls,
+		"hook must retry until success, then stop firing")
+}
+
 // TestDispatcher_OnFirstDispatch_NotInvokedWhenUnset confirms the
 // dispatcher tolerates a nil hook (default state) without panicking.
 func TestDispatcher_OnFirstDispatch_NotInvokedWhenUnset(t *testing.T) {
@@ -416,4 +449,34 @@ func TestDispatcher_OnFirstDispatch_NotInvokedWhenUnset(t *testing.T) {
 	n, err := d.dispatchJob(ctx, "job-N", time.Now())
 	require.NoError(t, err)
 	assert.Equal(t, 1, n)
+}
+
+// TestDispatcher_OnFirstDispatch_NoMemoiseOnError exposes the regression
+// the LoadOrStore variant introduced: marking the job as "first
+// dispatched" before the hook runs means a transient error never
+// retries. With Load+Store-on-success that bug is closed — exercised
+// here with a stub that fails forever, asserting the hook is called
+// on every dispatch (one call per attempt) until it succeeds.
+func TestDispatcher_OnFirstDispatch_NoMemoiseOnError(t *testing.T) {
+	lister := &staticJobLister{ids: []string{"job-E"}}
+	conc := &staticConcurrency{can: true}
+	d, s, _, _, _, _ := newDispatcherRig(t, lister, conc)
+	ctx := context.Background()
+
+	var calls int
+	d.SetOnFirstDispatch(func(_ context.Context, _ string) error {
+		calls++
+		return errors.New("always fail")
+	})
+
+	now := time.Now()
+	for i := 0; i < 5; i++ {
+		seedEntry(t, s, "job-E",
+			"e-"+string(rune('a'+i)), "e.com", now)
+		_, err := d.dispatchJob(ctx, "job-E", now)
+		require.NoError(t, err)
+	}
+
+	assert.Equal(t, 5, calls,
+		"failing hook must fire on every dispatch, never memoised")
 }

--- a/internal/broker/redis.go
+++ b/internal/broker/redis.go
@@ -130,7 +130,108 @@ func (c *Client) RemoveJobKeys(ctx context.Context, jobID string) error {
 	if _, err := pipe.Exec(ctx); err != nil {
 		return fmt.Errorf("broker: remove job keys for %s: %w", jobID, err)
 	}
+
+	// Drop the job's field from every per-host dom:flight HASH. Without
+	// this sweep, every cancel/restart on the same domain leaves a stale
+	// per-job entry that grows unbounded. Today GetInflight has no
+	// production callers gating dispatch, so the leak is observability
+	// noise only — but anything that starts reading the counter as a cap
+	// would deadlock on the drift, and the job we hit (HOVER stuck job
+	// 91026da8) carried a 12h-old c7d00550 entry that confirmed cleanup
+	// has never happened on this path. SCAN-based because RemoveJobKeys
+	// receives only a jobID; the dom:flight key set is bounded by domain
+	// count (O(thousands)), trivially smaller than ZSET/stream volumes,
+	// so the scan is cheap on the cleanup path. Errors are non-fatal:
+	// leaked fields are the existing behaviour, so failure here cannot
+	// regress correctness.
+	if err := c.cleanupInflightForJob(ctx, jobID); err != nil {
+		brokerLog.Warn("dom:flight cleanup failed", "error", err, "job_id", jobID)
+	}
+
 	return nil
+}
+
+// cleanupInflightForJob scans every hover:dom:flight:* HASH and HDels
+// the given jobID field from each. Idempotent: HDel on a missing field
+// is a no-op. Used by RemoveJobKeys.
+func (c *Client) cleanupInflightForJob(ctx context.Context, jobID string) error {
+	pattern := keyPrefix + "dom:flight:*"
+	cursor := uint64(0)
+	for {
+		page, next, err := c.rdb.Scan(ctx, cursor, pattern, 500).Result()
+		if err != nil {
+			return fmt.Errorf("broker: scan %s: %w", pattern, err)
+		}
+		if len(page) > 0 {
+			pipe := c.rdb.Pipeline()
+			for _, key := range page {
+				pipe.HDel(ctx, key, jobID)
+			}
+			if _, err := pipe.Exec(ctx); err != nil {
+				return fmt.Errorf("broker: HDel inflight pipeline: %w", err)
+			}
+		}
+		cursor = next
+		if cursor == 0 {
+			break
+		}
+	}
+	return nil
+}
+
+// SweepOrphanInflight scans every hover:dom:flight:* HASH and removes
+// jobID fields that are not present in activeJobIDs. Returns the number
+// of fields removed.
+//
+// Intended for worker startup: dom:flight is incremented by the
+// dispatcher on publish and decremented by the worker on pacer.Release.
+// A hard SIGKILL (Fly OOM, panic, force-redeploy) bypasses the graceful
+// shutdown that drains in-flight tasks, so the increment runs but the
+// matching decrement never does. Unlike the running-counter HASH there
+// is no dedicated reconciler for dom:flight, so drift accumulates
+// across every restart on every domain that had work in flight at the
+// SIGTERM moment.
+func (c *Client) SweepOrphanInflight(ctx context.Context, activeJobIDs []string) (int, error) {
+	active := make(map[string]struct{}, len(activeJobIDs))
+	for _, id := range activeJobIDs {
+		active[id] = struct{}{}
+	}
+
+	pattern := keyPrefix + "dom:flight:*"
+	cursor := uint64(0)
+	removed := 0
+	for {
+		page, next, err := c.rdb.Scan(ctx, cursor, pattern, 500).Result()
+		if err != nil {
+			return removed, fmt.Errorf("broker: scan %s: %w", pattern, err)
+		}
+		for _, key := range page {
+			fields, err := c.rdb.HKeys(ctx, key).Result()
+			if err != nil {
+				brokerLog.Warn("HKeys failed during orphan sweep", "error", err, "key", key)
+				continue
+			}
+			var orphans []string
+			for _, jobID := range fields {
+				if _, ok := active[jobID]; !ok {
+					orphans = append(orphans, jobID)
+				}
+			}
+			if len(orphans) == 0 {
+				continue
+			}
+			if err := c.rdb.HDel(ctx, key, orphans...).Err(); err != nil {
+				brokerLog.Warn("HDel orphans failed", "error", err, "key", key, "orphans", len(orphans))
+				continue
+			}
+			removed += len(orphans)
+		}
+		cursor = next
+		if cursor == 0 {
+			break
+		}
+	}
+	return removed, nil
 }
 
 // isMissingGroup reports whether err is the Redis NOGROUP / no-such-key

--- a/internal/broker/redis.go
+++ b/internal/broker/redis.go
@@ -154,29 +154,50 @@ func (c *Client) RemoveJobKeys(ctx context.Context, jobID string) error {
 // cleanupInflightForJob scans every hover:dom:flight:* HASH and HDels
 // the given jobID field from each. Idempotent: HDel on a missing field
 // is a no-op. Used by RemoveJobKeys.
+//
+// Two-phase to keep SCAN safe: the SCAN cursor's iteration guarantees
+// degrade once the keyspace mutates mid-scan (HDel that empties a HASH
+// causes Redis to drop the key, and SCAN may then skip later keys).
+// Collect every matching key first, complete the iteration, then issue
+// the deletes in a separate pipeline.
 func (c *Client) cleanupInflightForJob(ctx context.Context, jobID string) error {
 	pattern := keyPrefix + "dom:flight:*"
+	keys, err := c.scanAll(ctx, pattern)
+	if err != nil {
+		return err
+	}
+	if len(keys) == 0 {
+		return nil
+	}
+	pipe := c.rdb.Pipeline()
+	for _, key := range keys {
+		pipe.HDel(ctx, key, jobID)
+	}
+	if _, err := pipe.Exec(ctx); err != nil {
+		return fmt.Errorf("broker: HDel inflight pipeline: %w", err)
+	}
+	return nil
+}
+
+// scanAll walks every key matching pattern with SCAN and returns the
+// full key set. Used by cleanup helpers that need to mutate matching
+// keys, where issuing the mutation inline with SCAN risks skipping
+// later keys when an HDel empties (and Redis drops) a HASH.
+func (c *Client) scanAll(ctx context.Context, pattern string) ([]string, error) {
+	var keys []string
 	cursor := uint64(0)
 	for {
 		page, next, err := c.rdb.Scan(ctx, cursor, pattern, 500).Result()
 		if err != nil {
-			return fmt.Errorf("broker: scan %s: %w", pattern, err)
+			return nil, fmt.Errorf("broker: scan %s: %w", pattern, err)
 		}
-		if len(page) > 0 {
-			pipe := c.rdb.Pipeline()
-			for _, key := range page {
-				pipe.HDel(ctx, key, jobID)
-			}
-			if _, err := pipe.Exec(ctx); err != nil {
-				return fmt.Errorf("broker: HDel inflight pipeline: %w", err)
-			}
-		}
+		keys = append(keys, page...)
 		cursor = next
 		if cursor == 0 {
 			break
 		}
 	}
-	return nil
+	return keys, nil
 }
 
 // SweepOrphanInflight scans every hover:dom:flight:* HASH and removes
@@ -197,39 +218,37 @@ func (c *Client) SweepOrphanInflight(ctx context.Context, activeJobIDs []string)
 		active[id] = struct{}{}
 	}
 
-	pattern := keyPrefix + "dom:flight:*"
-	cursor := uint64(0)
+	// Two-phase: complete the SCAN before issuing any HDel. Deleting
+	// the last field in a HASH causes Redis to drop the key, and SCAN
+	// makes no completeness guarantee against a mutating keyspace —
+	// later matches can be silently skipped, leaving orphan counters
+	// behind exactly when this sweep is most needed.
+	keys, err := c.scanAll(ctx, keyPrefix+"dom:flight:*")
+	if err != nil {
+		return 0, err
+	}
+
 	removed := 0
-	for {
-		page, next, err := c.rdb.Scan(ctx, cursor, pattern, 500).Result()
+	for _, key := range keys {
+		fields, err := c.rdb.HKeys(ctx, key).Result()
 		if err != nil {
-			return removed, fmt.Errorf("broker: scan %s: %w", pattern, err)
+			brokerLog.Warn("HKeys failed during orphan sweep", "error", err, "key", key)
+			continue
 		}
-		for _, key := range page {
-			fields, err := c.rdb.HKeys(ctx, key).Result()
-			if err != nil {
-				brokerLog.Warn("HKeys failed during orphan sweep", "error", err, "key", key)
-				continue
+		var orphans []string
+		for _, jobID := range fields {
+			if _, ok := active[jobID]; !ok {
+				orphans = append(orphans, jobID)
 			}
-			var orphans []string
-			for _, jobID := range fields {
-				if _, ok := active[jobID]; !ok {
-					orphans = append(orphans, jobID)
-				}
-			}
-			if len(orphans) == 0 {
-				continue
-			}
-			if err := c.rdb.HDel(ctx, key, orphans...).Err(); err != nil {
-				brokerLog.Warn("HDel orphans failed", "error", err, "key", key, "orphans", len(orphans))
-				continue
-			}
-			removed += len(orphans)
 		}
-		cursor = next
-		if cursor == 0 {
-			break
+		if len(orphans) == 0 {
+			continue
 		}
+		if err := c.rdb.HDel(ctx, key, orphans...).Err(); err != nil {
+			brokerLog.Warn("HDel orphans failed", "error", err, "key", key, "orphans", len(orphans))
+			continue
+		}
+		removed += len(orphans)
 	}
 	return removed, nil
 }

--- a/internal/broker/redis_test.go
+++ b/internal/broker/redis_test.go
@@ -174,6 +174,104 @@ func TestClient_RemoveJobKeys_RejectsEmpty(t *testing.T) {
 	require.Error(t, err)
 }
 
+// TestClient_RemoveJobKeys_ClearsDomFlight verifies that RemoveJobKeys
+// drops the cancelled job's field from every per-host dom:flight HASH.
+// Without this the per-job field accumulates forever — see redis.go:99
+// for the production rationale and the cursor.com stuck-job postmortem
+// (HOVER 91026da8) that traced back to a 12h-old leftover field.
+func TestClient_RemoveJobKeys_ClearsDomFlight(t *testing.T) {
+	client, _ := newTestClientWithMiniredis(t)
+	ctx := context.Background()
+
+	const target = "job-target"
+	const survivor = "job-survivor"
+
+	// Two hosts, both with both jobs in flight.
+	require.NoError(t, client.rdb.HSet(ctx,
+		DomainInflightKey("a.example.com"), target, 4).Err())
+	require.NoError(t, client.rdb.HSet(ctx,
+		DomainInflightKey("a.example.com"), survivor, 2).Err())
+	require.NoError(t, client.rdb.HSet(ctx,
+		DomainInflightKey("b.example.com"), target, 1).Err())
+	require.NoError(t, client.rdb.HSet(ctx,
+		DomainInflightKey("b.example.com"), survivor, 7).Err())
+
+	require.NoError(t, client.RemoveJobKeys(ctx, target))
+
+	for _, host := range []string{"a.example.com", "b.example.com"} {
+		exists, err := client.rdb.HExists(ctx,
+			DomainInflightKey(host), target).Result()
+		require.NoError(t, err)
+		assert.False(t, exists,
+			"target field for host %s must be deleted", host)
+
+		survVal, err := client.rdb.HGet(ctx,
+			DomainInflightKey(host), survivor).Int64()
+		require.NoError(t, err)
+		assert.Greater(t, survVal, int64(0),
+			"survivor field for host %s must remain", host)
+	}
+}
+
+// TestClient_SweepOrphanInflight verifies the startup sweep removes
+// fields whose jobID is not in the active set, leaves active fields
+// alone, and tolerates HASH keys that have no orphans.
+func TestClient_SweepOrphanInflight(t *testing.T) {
+	client, _ := newTestClientWithMiniredis(t)
+	ctx := context.Background()
+
+	require.NoError(t, client.rdb.HSet(ctx,
+		DomainInflightKey("host1"), "active-1", 3).Err())
+	require.NoError(t, client.rdb.HSet(ctx,
+		DomainInflightKey("host1"), "orphan-A", 9).Err())
+	require.NoError(t, client.rdb.HSet(ctx,
+		DomainInflightKey("host2"), "orphan-B", 5).Err())
+	require.NoError(t, client.rdb.HSet(ctx,
+		DomainInflightKey("host3"), "active-2", 1).Err())
+
+	removed, err := client.SweepOrphanInflight(ctx,
+		[]string{"active-1", "active-2"})
+	require.NoError(t, err)
+	assert.Equal(t, 2, removed)
+
+	orphanA, err := client.rdb.HExists(ctx,
+		DomainInflightKey("host1"), "orphan-A").Result()
+	require.NoError(t, err)
+	assert.False(t, orphanA)
+
+	orphanB, err := client.rdb.HExists(ctx,
+		DomainInflightKey("host2"), "orphan-B").Result()
+	require.NoError(t, err)
+	assert.False(t, orphanB)
+
+	active1, err := client.rdb.HGet(ctx,
+		DomainInflightKey("host1"), "active-1").Int64()
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), active1)
+
+	active2, err := client.rdb.HGet(ctx,
+		DomainInflightKey("host3"), "active-2").Int64()
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), active2)
+}
+
+// TestClient_SweepOrphanInflight_NoActiveJobs covers the all-orphan
+// case: every field in every dom:flight HASH belongs to a job that
+// is no longer active, so the sweep wipes them all.
+func TestClient_SweepOrphanInflight_NoActiveJobs(t *testing.T) {
+	client, _ := newTestClientWithMiniredis(t)
+	ctx := context.Background()
+
+	require.NoError(t, client.rdb.HSet(ctx,
+		DomainInflightKey("host1"), "ghost-1", 4).Err())
+	require.NoError(t, client.rdb.HSet(ctx,
+		DomainInflightKey("host2"), "ghost-2", 6).Err())
+
+	removed, err := client.SweepOrphanInflight(ctx, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 2, removed)
+}
+
 // TestClient_ClearAll_ManyKeys exercises the SCAN+DEL batch path by
 // seeding well over the 500-batch threshold.
 func TestClient_ClearAll_ManyKeys(t *testing.T) {

--- a/internal/jobs/job_lifecycle_test.go
+++ b/internal/jobs/job_lifecycle_test.go
@@ -410,10 +410,12 @@ func TestJobManagerUpdateJobStatus(t *testing.T) {
 }
 
 // TestJobManager_MarkJobRunning verifies the guarded transition flips
-// pending → running and stamps started_at when not already set. The
-// WHERE status='pending' guard makes the call a no-op for jobs that
-// have already moved past pending, so dispatcher restarts that re-fire
-// OnFirstDispatch do not stomp on existing state.
+// the pre-running statuses → running and stamps started_at when not
+// already set. The WHERE clause matches both 'pending' and
+// 'initializing' so sitemap jobs that spend a real window in the
+// initialising state still flip on first dispatch — without that the
+// first-dispatch hook would silently miss them and the "Starting up"
+// pill would never go away.
 func TestJobManager_MarkJobRunning(t *testing.T) {
 	mockDB, mock, err := sqlmock.New()
 	require.NoError(t, err)
@@ -425,7 +427,7 @@ func TestJobManager_MarkJobRunning(t *testing.T) {
 	jm := &JobManager{db: mockDB, dbQueue: mockDbQueue}
 
 	mock.ExpectBegin()
-	mock.ExpectExec(`UPDATE jobs\s+SET status = 'running',\s+started_at = COALESCE\(started_at, NOW\(\)\)\s+WHERE id = \$1\s+AND status = 'pending'`).
+	mock.ExpectExec(`UPDATE jobs\s+SET status = 'running',\s+started_at = COALESCE\(started_at, NOW\(\)\)\s+WHERE id = \$1\s+AND status IN \('pending', 'initializing'\)`).
 		WithArgs("job-mark").
 		WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectCommit()

--- a/internal/jobs/job_lifecycle_test.go
+++ b/internal/jobs/job_lifecycle_test.go
@@ -408,3 +408,28 @@ func TestJobManagerUpdateJobStatus(t *testing.T) {
 		})
 	}
 }
+
+// TestJobManager_MarkJobRunning verifies the guarded transition flips
+// pending → running and stamps started_at when not already set. The
+// WHERE status='pending' guard makes the call a no-op for jobs that
+// have already moved past pending, so dispatcher restarts that re-fire
+// OnFirstDispatch do not stomp on existing state.
+func TestJobManager_MarkJobRunning(t *testing.T) {
+	mockDB, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer mockDB.Close()
+
+	ctx := context.Background()
+
+	mockDbQueue := &mockDbQueueWrapper{mockDB: mockDB}
+	jm := &JobManager{db: mockDB, dbQueue: mockDbQueue}
+
+	mock.ExpectBegin()
+	mock.ExpectExec(`UPDATE jobs\s+SET status = 'running',\s+started_at = COALESCE\(started_at, NOW\(\)\)\s+WHERE id = \$1\s+AND status = 'pending'`).
+		WithArgs("job-mark").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
+
+	require.NoError(t, jm.MarkJobRunning(ctx, "job-mark"))
+	require.NoError(t, mock.ExpectationsWereMet())
+}

--- a/internal/jobs/manager.go
+++ b/internal/jobs/manager.go
@@ -47,6 +47,7 @@ type JobManagerInterface interface {
 	CalculateJobProgress(job *Job) float64
 	ValidateStatusTransition(from, to JobStatus) error
 	UpdateJobStatus(ctx context.Context, jobID string, status JobStatus) error
+	MarkJobRunning(ctx context.Context, jobID string) error
 
 	// GetRobotsRules fetches parsed robots.txt rules for a domain.
 	// Used by worker-side link-discovery filtering. Returns nil (not an
@@ -1217,6 +1218,30 @@ func (jm *JobManager) ValidateStatusTransition(from, to JobStatus) error {
 	}
 
 	return fmt.Errorf("invalid status transition from %s to %s", from, to)
+}
+
+// MarkJobRunning transitions a pending job to running and stamps
+// started_at if not already set. Guarded UPDATE so it is a no-op once
+// the job has already moved past 'pending' — safe to call repeatedly,
+// safe to call again after a worker restart.
+//
+// Wired from the dispatcher's first successful publish for a job, so
+// the status pill reflects reality without any other code path needing
+// to know about the transition. Without this, jobs created via
+// CreateJob stay at 'pending' forever (UpdateJobStatus has no other
+// callers in the production graph) and the dashboard's "Starting up"
+// label never goes away.
+func (jm *JobManager) MarkJobRunning(ctx context.Context, jobID string) error {
+	return jm.dbQueue.Execute(ctx, func(tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx, `
+			UPDATE jobs
+			   SET status = 'running',
+			       started_at = COALESCE(started_at, NOW())
+			 WHERE id = $1
+			   AND status = 'pending'
+		`, jobID)
+		return err
+	})
 }
 
 // UpdateJobStatus updates the status of a job with appropriate timestamps

--- a/internal/jobs/manager.go
+++ b/internal/jobs/manager.go
@@ -1220,17 +1220,22 @@ func (jm *JobManager) ValidateStatusTransition(from, to JobStatus) error {
 	return fmt.Errorf("invalid status transition from %s to %s", from, to)
 }
 
-// MarkJobRunning transitions a pending job to running and stamps
+// MarkJobRunning transitions a pre-running job to running and stamps
 // started_at if not already set. Guarded UPDATE so it is a no-op once
-// the job has already moved past 'pending' — safe to call repeatedly,
-// safe to call again after a worker restart.
+// the job has already moved past the pre-running statuses — safe to
+// call repeatedly, safe to call again after a worker restart.
+//
+// The guard accepts both 'pending' and 'initializing' because sitemap
+// jobs spend a real window in 'initializing' (sitemap fetch + parse)
+// before the dispatcher publishes their first task. Without that wider
+// match the first-dispatch hook would silently miss those jobs and
+// leave them stuck on the "Starting up" pill.
 //
 // Wired from the dispatcher's first successful publish for a job, so
-// the status pill reflects reality without any other code path needing
-// to know about the transition. Without this, jobs created via
-// CreateJob stay at 'pending' forever (UpdateJobStatus has no other
-// callers in the production graph) and the dashboard's "Starting up"
-// label never goes away.
+// the status reflects reality without any other code path needing to
+// know about the transition. Without this, jobs created via CreateJob
+// stay at their pre-running status forever (UpdateJobStatus has no
+// other callers in the production graph).
 func (jm *JobManager) MarkJobRunning(ctx context.Context, jobID string) error {
 	return jm.dbQueue.Execute(ctx, func(tx *sql.Tx) error {
 		_, err := tx.ExecContext(ctx, `
@@ -1238,7 +1243,7 @@ func (jm *JobManager) MarkJobRunning(ctx context.Context, jobID string) error {
 			   SET status = 'running',
 			       started_at = COALESCE(started_at, NOW())
 			 WHERE id = $1
-			   AND status = 'pending'
+			   AND status IN ('pending', 'initializing')
 		`, jobID)
 		return err
 	})


### PR DESCRIPTION
## Summary

- Cancelling a job and restarting another job for the same domain could leave the new job throttled to ~0.3 tasks/s while concurrent jobs on other domains ran at 5–8/s. Investigation traced this to stale per-job state in Redis from the previous run leaking into the new dispatcher loop. This PR closes three known leak surfaces and fixes a long-standing cosmetic bug surfaced by the same investigation.

### What changed

- **`RemoveJobKeys` now also clears the cancelled job's field from every per-host `hover:dom:flight:*` HASH.** Previously every cancel left a leftover counter that drifted unbounded across restarts. Today nothing reads `dom:flight` for gating, so the leak is observability noise — but it is a deadlock risk if anything starts using the counter as a cap. ([internal/broker/redis.go](internal/broker/redis.go))
- **`SweepOrphanInflight` runs once on worker boot** and drops `dom:flight` fields whose jobID is not in the active Postgres set. Hard SIGKILL bypasses graceful shutdown, so the dispatcher's increment runs but the worker's `pacer.Release` decrement never does — `dom:flight` has no dedicated reconciler, so drift used to accumulate forever. ([cmd/worker/main.go](cmd/worker/main.go))
- **`RunningCounters.Reconcile` is now atomic via a single Lua EVAL.** The previous `DEL + HSET` pipeline could race with concurrent `Increment` / `Decrement` and silently lose updates, freezing dispatch for any job whose counter floated to its concurrency cap until the next 120s reconcile. ([internal/broker/counters.go](internal/broker/counters.go))
- **Job status pill flips `pending → running` on first dispatch.** `UpdateJobStatus` had zero callers in the production graph, so jobs created via `CreateJob` stayed at `pending` forever. The dispatcher now invokes `JobManager.MarkJobRunning` (guarded UPDATE, idempotent across restarts) on the first successful publish for a job. ([internal/jobs/manager.go](internal/jobs/manager.go), [internal/broker/dispatcher.go](internal/broker/dispatcher.go))

### What's NOT in this PR

- Self-heal in dispatcher when `CanDispatch` is stuck while ZSET has due items. Deferred to a follow-up — wanted to land the Reconcile + cleanup fixes first and tune the heuristic against real data.

## Test plan

- [x] `go test ./...` passes
- [x] `bash scripts/security-check.sh` passes (gosec / govulncheck / Trivy)
- [x] New unit tests:
  - `TestClient_RemoveJobKeys_ClearsDomFlight`
  - `TestClient_SweepOrphanInflight` + `_NoActiveJobs`
  - `TestRunningCounters_Reconcile_Empty` + `_AllNonPositive` + `_Atomic`
  - `TestDispatcher_OnFirstDispatch_FiresExactlyOncePerJob` + `_NotInvokedWhenUnset`
  - `TestJobManager_MarkJobRunning`
- [ ] After merge: confirm next cancel-and-restart on the same domain runs at full throughput
- [ ] After merge: confirm dashboard "Starting up" pill flips to "Running" within seconds
- [ ] After merge: spot-check `HLEN hover:dom:flight:<domain>` for active domains stays bounded by concurrent active jobs (no unbounded drift)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented counter drift and improved throughput by making reconciliation atomic and sweeping stale per-job inflight state at startup.
  * Fixed job lifecycle so jobs reliably move from pending to running on first successful dispatch and no longer persist as "Starting up".
  * Improved cleanup of cancelled-job inflight fields to avoid stale data.

* **Tests**
  * Added coverage for counter reconciliation, first-dispatch behavior, inflight cleanup, and job lifecycle transitions.

* **Documentation**
  * Updated changelog with detailed unreleased fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->