### PR TITLE
Add dispatcher self-heal on stuck dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,18 @@ On merge, CI will:
   `JobManager.MarkJobRunning` (guarded UPDATE, idempotent across worker
   restarts).
 
+- Dispatcher now self-heals against unknown future drift classes in the per-job
+  `hover:running` counter. When `CanDispatch` keeps refusing dispatch for a
+  single job for longer than `REDIS_DISPATCH_STUCK_THRESHOLD_S` (default 30s)
+  while the job's schedule ZSET still has due tasks, the dispatcher fires an
+  immediate `RunningCounters.Reconcile` from the authoritative Redis PEL via the
+  worker pool's new `TriggerReconcile` hook. Triggers are rate-limited to one
+  per 2× threshold per job and collapse onto any in-flight reconcile via
+  `TryLock`, so a genuinely-at-capacity job can't drive a reconcile burst. This
+  is a safety net layered on top of the existing 120s `reconcileLoop`, not a
+  replacement — closes the gap PR #362 left for future drift classes we haven't
+  yet identified.
+
 ## Full changelog history
 
 ## [0.33.11] – 2026-04-26

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -321,6 +321,14 @@ func main() {
 		return jobManager.MarkJobRunning(ctx, jobID)
 	})
 
+	// Self-heal lever for the running-counter drift class PR #362
+	// could not fully eliminate. When CanDispatch keeps refusing
+	// dispatch despite due work in the ZSET for longer than
+	// REDIS_DISPATCH_STUCK_THRESHOLD_S, the dispatcher fires a single
+	// reconcile against the authoritative PEL via the worker pool.
+	// Rate-limited internally to one trigger per 2× threshold per job.
+	dispatcher.SetReconciler(swp)
+
 	// --- running counter DB sync ---
 	counterSyncSec := envInt("REDIS_COUNTER_SYNC_INTERVAL_S", 5)
 	if counterSyncSec < 1 {
@@ -661,4 +669,5 @@ func sweepOrphanInflightOnBoot(redisClient *broker.Client, sqlDB *sql.DB) {
 var (
 	_ broker.JobLister          = (*jobs.StreamWorkerPool)(nil)
 	_ broker.ConcurrencyChecker = (*jobs.StreamWorkerPool)(nil)
+	_ broker.Reconciler         = (*jobs.StreamWorkerPool)(nil)
 )

--- a/internal/broker/dispatcher.go
+++ b/internal/broker/dispatcher.go
@@ -29,6 +29,14 @@ type DispatcherOpts struct {
 	// dispatcher into a ~70× backlog. Default 32. Override via
 	// REDIS_DISPATCH_PARALLEL_JOBS.
 	ParallelJobs int
+
+	// StuckThreshold is how long a single job may sit blocked on the
+	// CanDispatch capacity gate (with due work in its ZSET) before the
+	// dispatcher fires a self-heal counter reconcile. Default 30s,
+	// overridable via REDIS_DISPATCH_STUCK_THRESHOLD_S. Self-heal is
+	// rate-limited to one trigger per 2× this value per job so a
+	// genuinely-at-capacity job can't burn Redis with reconciles.
+	StuckThreshold time.Duration
 }
 
 // DefaultDispatcherOpts returns production defaults, optionally
@@ -37,10 +45,12 @@ func DefaultDispatcherOpts() DispatcherOpts {
 	interval := time.Duration(envInt("REDIS_DISPATCH_INTERVAL_MS", 100)) * time.Millisecond
 	batch := int64(envInt("REDIS_DISPATCH_BATCH_SIZE", 50))
 	parallel := envInt("REDIS_DISPATCH_PARALLEL_JOBS", 32)
+	stuck := time.Duration(envInt("REDIS_DISPATCH_STUCK_THRESHOLD_S", 30)) * time.Second
 	return DispatcherOpts{
-		ScanInterval: interval,
-		BatchSize:    batch,
-		ParallelJobs: parallel,
+		ScanInterval:   interval,
+		BatchSize:      batch,
+		ParallelJobs:   parallel,
+		StuckThreshold: stuck,
 	}
 }
 
@@ -55,6 +65,19 @@ type JobLister interface {
 type ConcurrencyChecker interface {
 	// CanDispatch returns true if the job has room for another task.
 	CanDispatch(ctx context.Context, jobID string) (bool, error)
+}
+
+// Reconciler triggers an immediate per-job counter reconciliation
+// from the authoritative Redis PEL. The dispatcher invokes this as a
+// last-resort self-heal when CanDispatch keeps refusing dispatch
+// despite due work sitting in the ZSET — the symptom of a drifted
+// `hover:running` counter pinning a job at its concurrency cap.
+//
+// Implementations must be safe for concurrent invocation and should
+// debounce a flood of triggers down to at most one in-flight
+// reconcile (the StreamWorkerPool implementation uses a TryLock).
+type Reconciler interface {
+	TriggerReconcile(ctx context.Context)
 }
 
 // Dispatcher is a long-running goroutine that moves due items from
@@ -101,6 +124,31 @@ type Dispatcher struct {
 	// idempotent — the hook may fire repeatedly for the same job until
 	// it succeeds.
 	onFirstDispatch func(ctx context.Context, jobID string) error
+
+	// reconciler, when non-nil, is invoked as a self-heal when a job
+	// has been blocked on the capacity gate for longer than
+	// opts.StuckThreshold while its ZSET still has due work. Optional:
+	// nil disables the self-heal path entirely (covers tests and any
+	// embedded scenarios where the worker pool isn't wired in).
+	reconciler Reconciler
+
+	// stuckMu guards stuckSince and lastTrigger. Held only for the few
+	// map-mutating ops in maybeTriggerReconcile and clearStuck — the
+	// reconciler call itself runs outside the lock.
+	stuckMu sync.Mutex
+
+	// stuckSince records, per jobID, the timestamp of the first
+	// dispatcher tick where the capacity gate fired with due work in
+	// the ZSET. Cleared the moment that job dispatches successfully or
+	// runs a tick with no due items, so transient at-capacity bursts
+	// (the normal path for a healthy fast job) never trip the heuristic.
+	stuckSince map[string]time.Time
+
+	// lastTrigger records, per jobID, when we last fired the reconciler
+	// for that job. Persisted across stuck/recover cycles so a job
+	// flapping between stuck and not-stuck can't drive reconcile faster
+	// than the rate-limit window allows.
+	lastTrigger map[string]time.Time
 }
 
 // NewDispatcher creates a Dispatcher.
@@ -131,6 +179,15 @@ func NewDispatcher(
 // hook causes the dispatcher to retry on the next dispatch.
 func (d *Dispatcher) SetOnFirstDispatch(fn func(ctx context.Context, jobID string) error) {
 	d.onFirstDispatch = fn
+}
+
+// SetReconciler installs the self-heal target invoked when a single
+// job sits blocked on the CanDispatch capacity gate for longer than
+// opts.StuckThreshold while its ZSET still has due work. Pass nil to
+// disable the self-heal path; nil is the default and is tolerated
+// throughout the dispatcher hot path.
+func (d *Dispatcher) SetReconciler(r Reconciler) {
+	d.reconciler = r
 }
 
 // Run is the dispatcher's main loop. It blocks until ctx is
@@ -218,6 +275,13 @@ func (d *Dispatcher) dispatchJob(ctx context.Context, jobID string, now time.Tim
 		return 0, err
 	}
 	if len(entries) == 0 {
+		// No due work this tick — whatever stuck state we'd been
+		// tracking is no longer load-bearing. Clearing here matters
+		// when a job's tasks all reschedule into the future: we must
+		// not carry the old stuck-since timestamp into the next time
+		// items come due, otherwise the heuristic would treat the
+		// wall-clock gap as continuous capacity-blocked time.
+		d.clearStuck(jobID)
 		return 0, nil
 	}
 
@@ -233,8 +297,15 @@ func (d *Dispatcher) dispatchJob(ctx context.Context, jobID string, now time.Tim
 			break
 		}
 		if !canDispatch {
-			// Job at capacity — remaining items stay in ZSET.
+			// Job at capacity — remaining items stay in ZSET. We're
+			// inside the entries loop, so we already know there is at
+			// least one due task right now: that's the precondition
+			// for the self-heal heuristic. A genuinely-busy job clears
+			// the stuck-since timestamp on its very next successful
+			// dispatch, so the heuristic only fires when the gate
+			// stays shut for opts.StuckThreshold of wall-clock time.
 			observability.RecordBrokerDispatch(ctx, jobID, "capacity")
+			d.maybeTriggerReconcile(ctx, jobID, now)
 			break
 		}
 
@@ -306,7 +377,86 @@ func (d *Dispatcher) dispatchJob(ctx context.Context, jobID string, now time.Tim
 		dispatched++
 	}
 
+	if dispatched > 0 {
+		// Any forward progress for this job invalidates the stuck
+		// hypothesis. We deliberately do not clear lastTrigger here —
+		// that's the rate-limit memory and must persist across
+		// stuck/recover cycles to stop a flapping job from driving
+		// reconcile faster than the rate-limit window allows.
+		d.clearStuck(jobID)
+	}
+
 	return dispatched, nil
+}
+
+// maybeTriggerReconcile updates the per-job stuck timestamp and, if
+// the job has been stuck for opts.StuckThreshold and we're outside
+// the per-job rate-limit window, invokes the installed Reconciler.
+//
+// This is the dispatcher's only self-heal lever: PR #362 closed the
+// known sources of `hover:running` drift, but the cost of an unknown
+// future drift class is a job that throttles to ~0% throughput while
+// peers run at full speed. Triggering an immediate reconcile from
+// the authoritative PEL re-aligns the counter with reality without
+// waiting up to 120s for the periodic reconcileLoop.
+func (d *Dispatcher) maybeTriggerReconcile(ctx context.Context, jobID string, now time.Time) {
+	if d.reconciler == nil {
+		return
+	}
+
+	threshold := d.opts.StuckThreshold
+	if threshold <= 0 {
+		// Self-heal explicitly disabled by configuration. Don't even
+		// record a stuck timestamp — keeps the maps tidy when the
+		// feature is off.
+		return
+	}
+
+	d.stuckMu.Lock()
+	if d.stuckSince == nil {
+		d.stuckSince = make(map[string]time.Time)
+	}
+	if d.lastTrigger == nil {
+		d.lastTrigger = make(map[string]time.Time)
+	}
+
+	first, ok := d.stuckSince[jobID]
+	if !ok {
+		d.stuckSince[jobID] = now
+		d.stuckMu.Unlock()
+		return
+	}
+	if now.Sub(first) < threshold {
+		d.stuckMu.Unlock()
+		return
+	}
+
+	rateLimit := 2 * threshold
+	if last, seen := d.lastTrigger[jobID]; seen && now.Sub(last) < rateLimit {
+		// Still stuck, but we already nudged the reconciler recently.
+		// Letting the next nudge wait until the rate-limit window
+		// expires keeps the cost predictable for a job that's just
+		// genuinely at its concurrency cap.
+		d.stuckMu.Unlock()
+		return
+	}
+	d.lastTrigger[jobID] = now
+	d.stuckMu.Unlock()
+
+	brokerLog.Warn("dispatcher self-heal: triggering counter reconcile",
+		"job_id", jobID, "stuck_for", now.Sub(first).String())
+	d.reconciler.TriggerReconcile(ctx)
+}
+
+// clearStuck removes the per-job stuck timestamp. lastTrigger is
+// intentionally preserved so the rate limit survives a brief
+// recovery window.
+func (d *Dispatcher) clearStuck(jobID string) {
+	d.stuckMu.Lock()
+	defer d.stuckMu.Unlock()
+	if d.stuckSince != nil {
+		delete(d.stuckSince, jobID)
+	}
 }
 
 // publishAndRemove atomically XADDs the task to the job's stream

--- a/internal/broker/dispatcher.go
+++ b/internal/broker/dispatcher.go
@@ -300,14 +300,23 @@ func (d *Dispatcher) dispatchJob(ctx context.Context, jobID string, now time.Tim
 			// Job at capacity — remaining items stay in ZSET. We're
 			// inside the entries loop, so we already know there is at
 			// least one due task right now: that's the precondition
-			// for the self-heal heuristic. A genuinely-busy job clears
-			// the stuck-since timestamp on its very next successful
-			// dispatch, so the heuristic only fires when the gate
-			// stays shut for opts.StuckThreshold of wall-clock time.
+			// for the self-heal heuristic. The stuck timer is reset
+			// the next time we observe canDispatch=true (below), so
+			// the heuristic only fires when the gate stays shut for
+			// opts.StuckThreshold of wall-clock time.
 			observability.RecordBrokerDispatch(ctx, jobID, "capacity")
 			d.maybeTriggerReconcile(ctx, jobID, now)
 			break
 		}
+
+		// canDispatch=true falsifies the "counter pinned at cap"
+		// hypothesis, so any stuck timer accumulated from a previous
+		// tick is no longer load-bearing. Clear here rather than only
+		// on a successful dispatch: a paced or transient-publish-error
+		// path can land us on canDispatch=true without dispatched++,
+		// and we must not let those iterations carry forward stale
+		// stuck state into a later capacity-blocked window.
+		d.clearStuck(jobID)
 
 		// Check domain pacing.
 		domain := entry.Host
@@ -375,15 +384,6 @@ func (d *Dispatcher) dispatchJob(ctx context.Context, jobID string, now time.Tim
 
 		observability.RecordBrokerDispatch(ctx, jobID, "ok")
 		dispatched++
-	}
-
-	if dispatched > 0 {
-		// Any forward progress for this job invalidates the stuck
-		// hypothesis. We deliberately do not clear lastTrigger here —
-		// that's the rate-limit memory and must persist across
-		// stuck/recover cycles to stop a flapping job from driving
-		// reconcile faster than the rate-limit window allows.
-		d.clearStuck(jobID)
 	}
 
 	return dispatched, nil

--- a/internal/broker/dispatcher_test.go
+++ b/internal/broker/dispatcher_test.go
@@ -3,6 +3,7 @@ package broker
 import (
 	"context"
 	"errors"
+	"sync"
 	"testing"
 	"time"
 
@@ -479,4 +480,205 @@ func TestDispatcher_OnFirstDispatch_NoMemoiseOnError(t *testing.T) {
 
 	assert.Equal(t, 5, calls,
 		"failing hook must fire on every dispatch, never memoised")
+}
+
+// --- Self-heal reconcile trigger ---------------------------------------
+
+// togglableConcurrency is a ConcurrencyChecker whose answer can be
+// flipped between ticks, so a test can hold the gate shut for the
+// stuck-threshold window and then let a successful dispatch through
+// to verify the stuck-state reset.
+type togglableConcurrency struct {
+	mu  sync.Mutex
+	can bool
+}
+
+func (c *togglableConcurrency) CanDispatch(_ context.Context, _ string) (bool, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.can, nil
+}
+
+func (c *togglableConcurrency) set(v bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.can = v
+}
+
+// stubReconciler counts TriggerReconcile invocations so tests can
+// assert exactly when (and how often) the dispatcher fires the
+// self-heal hook.
+type stubReconciler struct {
+	mu    sync.Mutex
+	calls int
+}
+
+func (s *stubReconciler) TriggerReconcile(_ context.Context) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.calls++
+}
+
+func (s *stubReconciler) Calls() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.calls
+}
+
+// TestDispatcher_SelfHeal_FiresAfterThreshold verifies the dispatcher
+// trips the reconcile hook once continuous capacity-blocked time
+// passes opts.StuckThreshold while the ZSET still has due work — the
+// signature of running-counter drift pinning a job at its cap.
+func TestDispatcher_SelfHeal_FiresAfterThreshold(t *testing.T) {
+	lister := &staticJobLister{ids: []string{"job-stuck"}}
+	conc := &togglableConcurrency{can: false}
+	d, s, _, _, _, _ := newDispatcherRig(t, lister, conc)
+	d.opts.StuckThreshold = 100 * time.Millisecond
+	rec := &stubReconciler{}
+	d.SetReconciler(rec)
+
+	ctx := context.Background()
+	t0 := time.Now()
+	seedEntry(t, s, "job-stuck", "t1", "x.com", t0)
+
+	// First tick records stuck-since but does not yet trigger.
+	_, err := d.dispatchJob(ctx, "job-stuck", t0)
+	require.NoError(t, err)
+	assert.Equal(t, 0, rec.Calls(), "must not trigger on first stuck tick")
+
+	// Tick within the threshold window — still no trigger.
+	_, err = d.dispatchJob(ctx, "job-stuck", t0.Add(50*time.Millisecond))
+	require.NoError(t, err)
+	assert.Equal(t, 0, rec.Calls(), "must not trigger before threshold elapses")
+
+	// Tick past the threshold — trigger fires exactly once.
+	_, err = d.dispatchJob(ctx, "job-stuck", t0.Add(150*time.Millisecond))
+	require.NoError(t, err)
+	assert.Equal(t, 1, rec.Calls(), "must trigger once threshold elapsed")
+}
+
+// TestDispatcher_SelfHeal_ResetsOnSuccessfulDispatch confirms a
+// successful dispatch invalidates the stuck-since timestamp, so a
+// job that briefly sits at capacity and then drains never trips the
+// heuristic.
+func TestDispatcher_SelfHeal_ResetsOnSuccessfulDispatch(t *testing.T) {
+	lister := &staticJobLister{ids: []string{"job-reset"}}
+	conc := &togglableConcurrency{can: false}
+	d, s, _, _, _, _ := newDispatcherRig(t, lister, conc)
+	d.opts.StuckThreshold = 100 * time.Millisecond
+	rec := &stubReconciler{}
+	d.SetReconciler(rec)
+
+	ctx := context.Background()
+	t0 := time.Now()
+	seedEntry(t, s, "job-reset", "t1", "x.com", t0)
+
+	// Tick once stuck so stuck-since is recorded.
+	_, err := d.dispatchJob(ctx, "job-reset", t0)
+	require.NoError(t, err)
+
+	// Open the gate and let a dispatch succeed before the threshold.
+	conc.set(true)
+	seedEntry(t, s, "job-reset", "t2", "x.com", t0.Add(50*time.Millisecond))
+	n, err := d.dispatchJob(ctx, "job-reset", t0.Add(50*time.Millisecond))
+	require.NoError(t, err)
+	require.Greater(t, n, 0, "expected at least one successful dispatch")
+
+	// Close the gate again, seed more work, advance well past threshold.
+	conc.set(false)
+	seedEntry(t, s, "job-reset", "t3", "x.com", t0.Add(60*time.Millisecond))
+	_, err = d.dispatchJob(ctx, "job-reset", t0.Add(300*time.Millisecond))
+	require.NoError(t, err)
+
+	// Stuck-since reset by the successful dispatch, so the second
+	// stuck window has barely begun. No trigger should fire yet.
+	assert.Equal(t, 0, rec.Calls(),
+		"successful dispatch must reset stuck timer")
+}
+
+// TestDispatcher_SelfHeal_NoTriggerWhenZSETEmpty ensures a job with
+// no due items in its ZSET never trips the heuristic, even after
+// many ticks: the early-return path clears stuck state explicitly.
+func TestDispatcher_SelfHeal_NoTriggerWhenZSETEmpty(t *testing.T) {
+	lister := &staticJobLister{ids: []string{"job-empty"}}
+	conc := &togglableConcurrency{can: false}
+	d, _, _, _, _, _ := newDispatcherRig(t, lister, conc)
+	d.opts.StuckThreshold = 50 * time.Millisecond
+	rec := &stubReconciler{}
+	d.SetReconciler(rec)
+
+	ctx := context.Background()
+	t0 := time.Now()
+
+	// Tick repeatedly with an empty ZSET, well past the threshold.
+	for i := 0; i < 10; i++ {
+		_, err := d.dispatchJob(ctx, "job-empty",
+			t0.Add(time.Duration(i*100)*time.Millisecond))
+		require.NoError(t, err)
+	}
+
+	assert.Equal(t, 0, rec.Calls(),
+		"empty ZSET must never trip the self-heal heuristic")
+}
+
+// TestDispatcher_SelfHeal_RateLimited ensures a continuously-stuck
+// job nudges the reconciler at most once per 2× threshold window —
+// otherwise a job that's genuinely at its concurrency cap could
+// drive a reconcile burst on every dispatcher tick.
+func TestDispatcher_SelfHeal_RateLimited(t *testing.T) {
+	lister := &staticJobLister{ids: []string{"job-rl"}}
+	conc := &togglableConcurrency{can: false}
+	d, s, _, _, _, _ := newDispatcherRig(t, lister, conc)
+	d.opts.StuckThreshold = 100 * time.Millisecond
+	rec := &stubReconciler{}
+	d.SetReconciler(rec)
+
+	ctx := context.Background()
+	t0 := time.Now()
+	seedEntry(t, s, "job-rl", "t1", "x.com", t0)
+
+	// First trip: tick at t=150ms (past threshold) → fires once.
+	_, err := d.dispatchJob(ctx, "job-rl", t0)
+	require.NoError(t, err)
+	_, err = d.dispatchJob(ctx, "job-rl", t0.Add(150*time.Millisecond))
+	require.NoError(t, err)
+	require.Equal(t, 1, rec.Calls(), "expected first trigger past threshold")
+
+	// Tick repeatedly within the rate-limit window — must not refire.
+	for i := 0; i < 5; i++ {
+		_, err := d.dispatchJob(ctx, "job-rl",
+			t0.Add(150*time.Millisecond+time.Duration(i*10)*time.Millisecond))
+		require.NoError(t, err)
+	}
+	assert.Equal(t, 1, rec.Calls(),
+		"must not refire inside 2× threshold window")
+
+	// Past 2× threshold from first trigger (150ms + 200ms = 350ms),
+	// another nudge is allowed.
+	_, err = d.dispatchJob(ctx, "job-rl", t0.Add(360*time.Millisecond))
+	require.NoError(t, err)
+	assert.Equal(t, 2, rec.Calls(),
+		"must refire once rate-limit window has elapsed")
+}
+
+// TestDispatcher_SelfHeal_NilReconcilerTolerated guards the default
+// case: a dispatcher without a reconciler installed must not panic
+// when the capacity gate fires, no matter how long the gate stays
+// shut.
+func TestDispatcher_SelfHeal_NilReconcilerTolerated(t *testing.T) {
+	lister := &staticJobLister{ids: []string{"job-nil"}}
+	conc := &togglableConcurrency{can: false}
+	d, s, _, _, _, _ := newDispatcherRig(t, lister, conc)
+	d.opts.StuckThreshold = 50 * time.Millisecond
+	// Intentionally skip SetReconciler.
+
+	ctx := context.Background()
+	t0 := time.Now()
+	seedEntry(t, s, "job-nil", "t1", "x.com", t0)
+
+	for i := 0; i < 5; i++ {
+		_, err := d.dispatchJob(ctx, "job-nil",
+			t0.Add(time.Duration(i*100)*time.Millisecond))
+		require.NoError(t, err)
+	}
 }

--- a/internal/broker/dispatcher_test.go
+++ b/internal/broker/dispatcher_test.go
@@ -596,6 +596,58 @@ func TestDispatcher_SelfHeal_ResetsOnSuccessfulDispatch(t *testing.T) {
 		"successful dispatch must reset stuck timer")
 }
 
+// TestDispatcher_SelfHeal_ResetsOnCanDispatchTrueEvenIfPaced verifies
+// the stuck timer is cleared the moment CanDispatch returns true,
+// not only on a successful dispatch. Reaching canDispatch=true
+// falsifies the "counter pinned at cap" hypothesis even if the
+// dispatch then loses to pacer pushback or a transient publish error
+// — without this reset, a previous stuck window could carry over and
+// trip the heuristic spuriously the next time CanDispatch flips back
+// to false.
+func TestDispatcher_SelfHeal_ResetsOnCanDispatchTrueEvenIfPaced(t *testing.T) {
+	lister := &staticJobLister{ids: []string{"job-paced"}}
+	conc := &togglableConcurrency{can: false}
+	d, s, pacer, _, _, _ := newDispatcherRig(t, lister, conc)
+	d.opts.StuckThreshold = 100 * time.Millisecond
+	rec := &stubReconciler{}
+	d.SetReconciler(rec)
+
+	ctx := context.Background()
+	t0 := time.Now()
+	seedEntry(t, s, "job-paced", "t1", "slow.com", t0)
+
+	// Establish a stuck timestamp via one capacity-blocked tick.
+	_, err := d.dispatchJob(ctx, "job-paced", t0)
+	require.NoError(t, err)
+
+	// Open the capacity gate but force the pacer to push back so no
+	// dispatch actually lands. dispatched stays 0 — the only path
+	// that clears stuck state is the canDispatch=true branch. The
+	// pacer's first TryAcquire always wins, so we burn that slot
+	// outside the dispatcher to guarantee the subsequent dispatchJob
+	// hits the !paceResult.Acquired branch.
+	conc.set(true)
+	require.NoError(t, pacer.Seed(ctx, "slow.com", 5000, 0, 0))
+	preGate, err := pacer.TryAcquire(ctx, "slow.com")
+	require.NoError(t, err)
+	require.True(t, preGate.Acquired, "pre-gate acquire should succeed")
+	n, err := d.dispatchJob(ctx, "job-paced", t0.Add(50*time.Millisecond))
+	require.NoError(t, err)
+	require.Equal(t, 0, n, "pacer pushback should block dispatch")
+
+	// Slam the gate shut again and tick well past the original
+	// stuck-since timestamp. With the reset, the second stuck window
+	// has barely begun and no trigger should fire.
+	conc.set(false)
+	seedEntry(t, s, "job-paced", "t2", "slow.com", t0.Add(60*time.Millisecond))
+	_, err = d.dispatchJob(ctx, "job-paced", t0.Add(300*time.Millisecond))
+	require.NoError(t, err)
+
+	assert.Equal(t, 0, rec.Calls(),
+		"canDispatch=true must reset stuck timer even when the "+
+			"dispatch loses to pacer pushback")
+}
+
 // TestDispatcher_SelfHeal_NoTriggerWhenZSETEmpty ensures a job with
 // no due items in its ZSET never trips the heuristic, even after
 // many ticks: the early-return path clears stuck state explicitly.

--- a/internal/jobs/stream_worker.go
+++ b/internal/jobs/stream_worker.go
@@ -147,6 +147,14 @@ type StreamWorkerPool struct {
 	// watchdog is wired (e.g. in tests).
 	heartbeat interface{ Tick() }
 
+	// reconcileMu serialises reconcileCounters invocations across the
+	// periodic reconcileLoop and on-demand TriggerReconcile callers so a
+	// flood of triggers collapses onto at most one in-flight reconcile.
+	// We use TryLock rather than a blocking acquire so a triggered
+	// reconcile never queues behind the periodic one — the in-flight
+	// pass already covers the requester.
+	reconcileMu sync.Mutex
+
 	wg     sync.WaitGroup
 	cancel context.CancelFunc
 }
@@ -550,9 +558,34 @@ func (swp *StreamWorkerPool) reconcileLoop(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			swp.reconcileCounters(ctx)
+			swp.runReconcileSerialised(ctx)
 		}
 	}
+}
+
+// TriggerReconcile runs an immediate counter reconcile from the PEL
+// when something upstream (typically the dispatcher's stuck-detection
+// heuristic) suspects the running counter has drifted out of sync
+// with reality. Concurrent callers collapse onto the in-flight pass
+// via TryLock — the contract is "at least one reconcile after the
+// most recent trigger", not "one reconcile per trigger". Returning
+// without running is the correct response when a reconcile is already
+// in flight.
+func (swp *StreamWorkerPool) TriggerReconcile(ctx context.Context) {
+	swp.runReconcileSerialised(ctx)
+}
+
+// runReconcileSerialised wraps reconcileCounters with the package
+// reconcile mutex. Returns true if the reconcile actually ran, false
+// if another reconcile was already in flight and this call collapsed
+// onto it.
+func (swp *StreamWorkerPool) runReconcileSerialised(ctx context.Context) bool {
+	if !swp.reconcileMu.TryLock() {
+		return false
+	}
+	defer swp.reconcileMu.Unlock()
+	swp.reconcileCounters(ctx)
+	return true
 }
 
 // --- reclaim loop ---


### PR DESCRIPTION
## Summary

- Adds a self-heal path so the dispatcher can break out of a wedged-counter
  scenario without waiting for the 120s reconcile loop. When `CanDispatch`
  keeps refusing dispatch for a single job longer than
  `REDIS_DISPATCH_STUCK_THRESHOLD_S` (default 30s) while the schedule ZSET
  still has due tasks, the dispatcher fires an immediate
  `RunningCounters.Reconcile` via the worker pool's new `TriggerReconcile`
  hook.
- Triggers are rate-limited to one per `2× threshold` per job and any
  concurrent triggers collapse onto an in-flight reconcile via `TryLock`,
  so a genuinely-at-capacity job can't drive a reconcile burst.
- Layered on top of the existing 120s `reconcileLoop` (not a replacement) —
  closes the deferred safety-net gap from
  [hover#362](https://github.com/Harvey-AU/hover/pull/362) ("Fix 3" in that
  PR's deferred-work note).

## Implementation notes

- `internal/jobs/stream_worker.go` — `TriggerReconcile(ctx)` calls a new
  `runReconcileSerialised` helper. Both that helper and the periodic
  `reconcileLoop` now `TryLock` a shared `reconcileMu`, so a flood of
  triggers from a 100-job dispatcher fan-out collapses to at most one
  in-flight reconcile.
- `internal/broker/dispatcher.go` — new `Reconciler` interface, optional
  `SetReconciler` setter, and per-job `stuckSince` / `lastTrigger` maps
  (mutex-guarded) populated each time `CanDispatch` returns false inside
  the entries loop. We use the entries-loop position rather than a fresh
  `PendingCount` round-trip because the loop is only entered when
  `DueItems` returned at least one due task — a tighter signal than ZSET
  cardinality (which would also count future-scheduled items). `dispatchJob`
  also clears `stuckSince` on the early-return path (no due items) so a
  job whose work all reschedules into the future doesn't carry an old
  timestamp into the next time items come due.
- `cmd/worker/main.go` — wires `dispatcher.SetReconciler(swp)` and adds a
  compile-time `broker.Reconciler` interface assertion alongside the
  existing `JobLister` / `ConcurrencyChecker` ones.

## Test plan

- [x] `go test ./internal/broker/... ./internal/jobs/... -count=1` passes
- [x] `go test ./internal/broker/... ./internal/jobs/... -count=1 -race` passes
- [x] `bash scripts/security-check.sh` — gosec 0 issues, govulncheck unaffected
- [x] `gofmt`/`goimports` clean on every touched Go file
- [x] Five new tests in `internal/broker/dispatcher_test.go`:
  - fires after threshold elapsed with continuous capacity outcomes
  - resets on a successful dispatch within the window
  - never fires when the ZSET has no due items
  - rate-limit holds: only one trigger per `2× threshold` window
  - tolerates a nil reconciler (default state)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic self-healing: when dispatch is stuck beyond a configurable threshold (default 30s), the system triggers authoritative counter reconciliation to correct job state.
  * Reconciliation is rate-limited and serialized to avoid bursts and concurrent runs during continuous blockage.

* **Tests**
  * Added unit tests validating stuck detection, single-trigger behavior, rate-limiting, and safe handling when no reconciler is present.

* **Documentation**
  * CHANGELOG entry describing the new self-heal/reconcile behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->