### PR TITLE
Rename crawler UA to drop 'bot' suffix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,13 +30,7 @@ On merge, CI will:
 
 ### Changed
 
-- Crawler user-agent renamed from `HoverBot/1.0` to `Hover/1.0` to reduce naive
-  substring filtering on the word "bot" (e.g. amazon.com, which now returns
-  200). target.com.au and woolworths.com.au remain 403 — both are protected by
-  Akamai Bot Manager and 403 any non-browser UA, so they belong to the row 1
-  WAF-detection / row 3(b) allowlist work tracked in #365, not this rename.
-  Contact URL preserved; robots.txt parser now matches per-bot rules under
-  `User-agent: Hover`. Refs #365.
+- Crawler UA: `HoverBot` → `Hover`. Refs #365.
 - Trimmed narrative comments across recent broker, stream worker, and Lighthouse
   files (13 files, −1,055 lines net). Comment-only; no code logic changed.
   Load-bearing WHYs preserved.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,10 +30,13 @@ On merge, CI will:
 
 ### Changed
 
-- Crawler user-agent renamed from `HoverBot/1.0` to `Hover/1.0` to bypass naive
-  substring filters (e.g. Amazon, target.com.au, woolworths.com.au) that block
-  the word "bot". Contact URL preserved; robots.txt parser now matches per-bot
-  rules under `User-agent: Hover`. Refs #365.
+- Crawler user-agent renamed from `HoverBot/1.0` to `Hover/1.0` to reduce naive
+  substring filtering on the word "bot" (e.g. amazon.com, which now returns
+  200). target.com.au and woolworths.com.au remain 403 — both are protected by
+  Akamai Bot Manager and 403 any non-browser UA, so they belong to the row 1
+  WAF-detection / row 3(b) allowlist work tracked in #365, not this rename.
+  Contact URL preserved; robots.txt parser now matches per-bot rules under
+  `User-agent: Hover`. Refs #365.
 - Trimmed narrative comments across recent broker, stream worker, and Lighthouse
   files (13 files, −1,055 lines net). Comment-only; no code logic changed.
   Load-bearing WHYs preserved.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ On merge, CI will:
 
 ### Changed
 
+- Crawler user-agent renamed from `HoverBot/1.0` to `Hover/1.0` to bypass naive
+  substring filters (e.g. Amazon, target.com.au, woolworths.com.au) that block
+  the word "bot". Contact URL preserved; robots.txt parser now matches per-bot
+  rules under `User-agent: Hover`. Refs #365.
 - Trimmed narrative comments across recent broker, stream worker, and Lighthouse
   files (13 files, −1,055 lines net). Comment-only; no code logic changed.
   Load-bearing WHYs preserved.

--- a/internal/crawler/config.go
+++ b/internal/crawler/config.go
@@ -31,7 +31,7 @@ func DefaultConfig() *Config {
 		DefaultTimeout: 30 * time.Second,
 		MaxConcurrency: getEnvInt("GNH_CRAWLER_MAX_CONCURRENCY", 10),
 		RateLimit:      5, // Maximum no. of times per second (minimum delay 1/ratelimit)
-		UserAgent:      "HoverBot/1.0 (+https://www.goodnative.co/hover)",
+		UserAgent:      "Hover/1.0 (+https://www.goodnative.co/hover)",
 		RetryAttempts:  3,
 		RetryDelay:     500 * time.Millisecond,
 		SkipCachedURLs: false, // Default to crawling all URLs

--- a/internal/crawler/robots.go
+++ b/internal/crawler/robots.go
@@ -19,7 +19,7 @@ type RobotsRules struct {
 	AllowPatterns    []string // override DisallowPatterns
 }
 
-// Precedence: HoverBot-specific section if present, else wildcard (*).
+// Precedence: Hover-specific section if present, else wildcard (*).
 // Aggressive SEO crawler sections (AhrefsBot, MJ12bot, ...) are intentionally
 // not matched — they often carry punitive 10s delays meant for them.
 func ParseRobotsTxt(ctx context.Context, domain string, userAgent string, transport ...http.RoundTripper) (*RobotsRules, error) {
@@ -93,7 +93,7 @@ func parseRobotsTxtContent(r io.Reader, userAgent string) (*RobotsRules, error) 
 	var inWildcardSection bool
 	var foundSpecificSection bool
 
-	// e.g. "HoverBot/1.0" -> "hoverbot"
+	// e.g. "Hover/1.0" -> "hover"
 	botName := strings.ToLower(strings.Split(userAgent, "/")[0])
 
 	wildcardRules := &RobotsRules{

--- a/internal/crawler/robots_test.go
+++ b/internal/crawler/robots_test.go
@@ -16,13 +16,13 @@ func TestParseRobotsTxtContent(t *testing.T) {
 		wantAllow    []string
 	}{
 		{
-			name: "HoverBot specific rules",
+			name: "Hover specific rules",
 			robotsTxt: `
 User-agent: *
 Crawl-delay: 1
 Disallow: /admin
 
-User-agent: HoverBot
+User-agent: Hover
 Crawl-delay: 5
 Disallow: /checkout
 Disallow: /cart
@@ -30,7 +30,7 @@ Allow: /cart/view
 
 Sitemap: https://example.com/sitemap.xml
 `,
-			userAgent:    "HoverBot/1.0 (+https://www.goodnative.co/bot)",
+			userAgent:    "Hover/1.0 (+https://www.goodnative.co/hover)",
 			wantDelay:    5,
 			wantSitemaps: []string{"https://example.com/sitemap.xml"},
 			wantDisallow: []string{"/checkout", "/cart"},
@@ -47,7 +47,7 @@ Disallow: /tmp/
 Sitemap: https://example.com/sitemap1.xml
 Sitemap: https://example.com/sitemap2.xml
 `,
-			userAgent:    "HoverBot/1.0",
+			userAgent:    "Hover/1.0",
 			wantDelay:    10,
 			wantSitemaps: []string{"https://example.com/sitemap1.xml", "https://example.com/sitemap2.xml"},
 			wantDisallow: []string{"/private/", "/tmp/"},
@@ -64,7 +64,7 @@ User-agent: Bingbot
 Crawl-delay: 3
 Disallow: /nobing
 `,
-			userAgent:    "HoverBot/1.0",
+			userAgent:    "Hover/1.0",
 			wantDelay:    0,
 			wantSitemaps: []string{},
 			wantDisallow: []string{},
@@ -84,7 +84,7 @@ Disallow: /checkout
 Disallow: /cart
 Allow: /cart/view
 `,
-			userAgent:    "HoverBot/1.0",
+			userAgent:    "Hover/1.0",
 			wantDelay:    1,
 			wantSitemaps: []string{"https://example.com/sitemap.xml"},
 			wantDisallow: []string{"/admin"},


### PR DESCRIPTION
## Summary

- Renames the crawler user-agent from `HoverBot/1.0 (+https://www.goodnative.co/hover)` to `Hover/1.0 (+https://www.goodnative.co/hover)` to bypass naive substring filters that block the word "bot" (Amazon today; rest of issue #365 row 3 going forward).
- Updates the robots.txt parser comments and the per-bot test fixtures (`User-agent: Hover` instead of `User-agent: HoverBot`). The bot-name extraction in `internal/crawler/robots.go` already derives the name from the UA string, so the rename automatically routes per-bot rules to `hover`.
- Refs #365 (row 3, "UA rename"). Smallest, lowest-risk item in the action plan; ships first.

## Probe results (`HoverBot/1.0` vs `Hover/1.0`)

| Domain | Old UA | New UA |
|---|---|---|
| amazon.com | 503 | **200** ✓ |
| target.com.au | 403 | 403 |
| woolworths.com.au | 403 | 403 |

Amazon flips as expected. The two AU retailers do **not** flip — both respond `Server: AkamaiGHost` with `akaalb_*` ALB cookies and 403 *any* non-browser UA, including the Googlebot string. That's full Akamai Bot Manager, not a "bot" substring filter, so they belong to row 1 of #365 (WAF detection / pre-flight) plus row 3(b) (customer-side allowlist outreach), not row 3(a) (this PR). Detail in [#365 comment](https://github.com/Harvey-AU/hover/issues/365#issuecomment-4334238167).

## Test plan

- [x] `go test ./internal/crawler/...` passes locally (existing robots tests updated, all green).
- [x] `gofmt -w` and `goimports -w` on all touched files; pre-commit format/lint/security gates passed.
- [x] Curl probe against amazon.com returns 200 with the new UA (was 503).
- [x] Curl probe against target.com.au and woolworths.com.au reproduced — confirmed Akamai-fingerprinted, deferred to row 1/3(b).
- [ ] CI green on this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changed**
  * Crawler user-agent updated from "HoverBot/1.0" to "Hover/1.0" to improve compatibility with strict bot filters while keeping the contact URL.
  * Robots.txt matching now recognizes the refined "Hover" agent identity when applying per-agent rules, ensuring intended crawl rules are applied.

* **Documentation**
  * Changelog updated to reflect the user-agent rename and the adjusted matching behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->