### PR TITLE
Detect WAFs and block jobs (#365 row 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,9 +26,15 @@ On merge, CI will:
 4. Create a git tag and GitHub release
 5. Commit the updated changelog
 
-## [Unreleased]
+## [Unreleased:minor]
 
-_Add unreleased changes here._
+### Added
+
+- WAF detection on first contact (#365 row 1). Pre-flight probe + mid-job
+  circuit breaker recognise Cloudflare, Imperva, DataDome, and Akamai
+  fingerprints; jobs against blocked domains terminate with a new `blocked`
+  status instead of enqueueing thousands of doomed tasks. `domains.waf_blocked`
+  caches the verdict for 24 h. Customer-facing pill: amber "Blocked by site".
 
 ## Full changelog history
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ On merge, CI will:
 4. Create a git tag and GitHub release
 5. Commit the updated changelog
 
-## [Unreleased:minor]
+## [Unreleased]
 
 ### Added
 

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -232,6 +232,8 @@ func main() {
 		ReclaimInterval: 30 * time.Second,
 	}
 
+	wafBreaker := jobs.NewWAFCircuitBreaker()
+
 	swp := jobs.NewStreamWorkerPool(jobs.StreamWorkerDeps{
 		Consumer:      consumer,
 		Scheduler:     scheduler,
@@ -242,7 +244,18 @@ func main() {
 		DBQueue:       dbQueue,
 		JobManager:    jobManager,
 		HTMLPersister: htmlPersister,
+		WAFBreaker:    wafBreaker,
 	}, swpOpts)
+
+	// Drain per-job breaker state when a job terminates so a long-running
+	// worker doesn't accumulate map entries.
+	previousOnJobTerminated := jobManager.OnJobTerminated
+	jobManager.OnJobTerminated = func(ctx context.Context, jobID string) {
+		wafBreaker.Forget(jobID)
+		if previousOnJobTerminated != nil {
+			previousOnJobTerminated(ctx, jobID)
+		}
+	}
 
 	// Last-resort recovery: Fly's restart=always brings the worker back
 	// with fresh state when a Go-side wedge prevents in-process recovery.

--- a/internal/crawler/crawler.go
+++ b/internal/crawler/crawler.go
@@ -233,6 +233,18 @@ func (c *Crawler) GetUserAgent() string {
 	return c.config.UserAgent
 }
 
+// Probe runs a pre-flight WAF detection request against the homepage of
+// a domain using the crawler's configured User-Agent and shared probe
+// client. Reuses probeClient so the connection pool / DNS cache are
+// shared with the rest of the crawl path.
+func (c *Crawler) Probe(ctx context.Context, domain string) (WAFDetection, error) {
+	var transport http.RoundTripper
+	if c.probeClient != nil {
+		transport = c.probeClient.Transport
+	}
+	return Probe(ctx, domain, c.config.UserAgent, transport)
+}
+
 type tracingRoundTripper struct {
 	transport  http.RoundTripper
 	metricsMap *sync.Map
@@ -493,6 +505,13 @@ func (c *Crawler) setupResponseHandlers(collyClone *colly.Collector, result *Cra
 		cacheMeta := buildCacheMetadata(result.Headers)
 		result.CacheStatus = cacheMeta.NormalisedStatus
 
+		// WAF fingerprint runs against the unredacted result.Headers so the
+		// Akamai akaalb_ Set-Cookie signal survives — the diagnostic clone
+		// strips Set-Cookie before storage.
+		if det := DetectWAF(r.StatusCode, result.Headers, result.BodySample); det.Blocked {
+			result.WAF = &det
+		}
+
 		if r.StatusCode < 200 || r.StatusCode >= 300 {
 			result.Error = fmt.Sprintf("non-success status code: %d", r.StatusCode)
 		}
@@ -535,6 +554,13 @@ func (c *Crawler) setupResponseHandlers(collyClone *colly.Collector, result *Cra
 		result.Headers = responseHeaders
 		if r.Request != nil && r.Request.URL != nil {
 			result.RedirectURL = r.Request.URL.String()
+		}
+
+		// Detector also runs on error paths so 403 walls (Akamai/Cloudflare/
+		// DataDome) are flagged for the mid-job circuit breaker even when
+		// colly classifies the response as an error.
+		if det := DetectWAF(r.StatusCode, responseHeaders, r.Body); det.Blocked {
+			result.WAF = &det
 		}
 
 		result.RequestDiagnostics.Primary = buildRequestAttemptDiagnostics(

--- a/internal/crawler/probe.go
+++ b/internal/crawler/probe.go
@@ -1,0 +1,77 @@
+package crawler
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// ProbeBodyLimit caps the body read during a pre-flight probe. 4 KB is
+// enough for the EdgeSuite block page (~373 bytes), the Imperva script
+// preamble, and Cloudflare's interstitial.
+const ProbeBodyLimit = 4 * 1024
+
+// ProbeTimeout bounds how long a probe waits before giving up. Akamai
+// SYN-drop variants will hold the connection — at this point we'd
+// rather fall through to the normal flow and let the mid-job circuit
+// breaker catch a real wall.
+const ProbeTimeout = 8 * time.Second
+
+// Probe issues a GET against the homepage of the given domain and runs
+// the WAF detector against the response. The probe sends the supplied
+// User-Agent so the verdict matches what real crawl tasks will see.
+//
+// On network or timeout error the probe returns WAFDetection{} with
+// the underlying error; callers should treat a network error as
+// "no verdict" rather than as a block.
+func Probe(ctx context.Context, domain string, userAgent string, transport http.RoundTripper) (WAFDetection, error) {
+	target := normaliseProbeTarget(domain)
+
+	probeCtx, cancel := context.WithTimeout(ctx, ProbeTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(probeCtx, http.MethodGet, target, nil)
+	if err != nil {
+		return WAFDetection{}, fmt.Errorf("build probe request: %w", err)
+	}
+	req.Header.Set("User-Agent", userAgent)
+	req.Header.Set("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
+	req.Header.Set("Accept-Language", "en-AU,en;q=0.9")
+
+	client := &http.Client{
+		Timeout: ProbeTimeout,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if len(via) >= 5 {
+				return fmt.Errorf("too many redirects")
+			}
+			return nil
+		},
+	}
+	if transport != nil {
+		client.Transport = transport
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return WAFDetection{}, fmt.Errorf("probe %s: %w", target, err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, ProbeBodyLimit))
+	if err != nil {
+		return WAFDetection{}, fmt.Errorf("read probe body: %w", err)
+	}
+
+	return DetectWAF(resp.StatusCode, resp.Header, body), nil
+}
+
+func normaliseProbeTarget(domain string) string {
+	d := strings.TrimSpace(domain)
+	if strings.HasPrefix(d, "http://") || strings.HasPrefix(d, "https://") {
+		return strings.TrimSuffix(d, "/") + "/"
+	}
+	return "https://" + strings.TrimSuffix(d, "/") + "/"
+}

--- a/internal/crawler/probe_test.go
+++ b/internal/crawler/probe_test.go
@@ -1,0 +1,83 @@
+package crawler
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+func TestProbe_AkamaiBlocked(t *testing.T) {
+	var seenUA string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenUA = r.Header.Get("User-Agent")
+		w.Header().Set("Server", "AkamaiGHost")
+		w.Header().Set("Set-Cookie", "akaalb_main=~op=ALB:abc; Path=/")
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(strings.Repeat("x", 373)))
+	}))
+	defer ts.Close()
+
+	det, err := Probe(context.Background(), ts.URL, "Hover/1.0", redirectingTransport(ts.URL))
+	if err != nil {
+		t.Fatalf("probe: %v", err)
+	}
+	if !det.Blocked {
+		t.Fatalf("expected Blocked=true, got %+v", det)
+	}
+	if det.Vendor != WAFVendorAkamai {
+		t.Errorf("vendor = %q, want %q", det.Vendor, WAFVendorAkamai)
+	}
+	if seenUA != "Hover/1.0" {
+		t.Errorf("user-agent = %q, want Hover/1.0", seenUA)
+	}
+}
+
+func TestProbe_HealthyDomain(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Server", "nginx")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(strings.Repeat("<p>healthy</p>", 100)))
+	}))
+	defer ts.Close()
+
+	det, err := Probe(context.Background(), ts.URL, "Hover/1.0", redirectingTransport(ts.URL))
+	if err != nil {
+		t.Fatalf("probe: %v", err)
+	}
+	if det.Blocked {
+		t.Fatalf("expected Blocked=false, got %+v", det)
+	}
+}
+
+func TestProbe_BodyTruncation(t *testing.T) {
+	bigBody := strings.Repeat("y", 50*1024)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(bigBody))
+	}))
+	defer ts.Close()
+
+	_, err := Probe(context.Background(), ts.URL, "Hover/1.0", redirectingTransport(ts.URL))
+	if err != nil {
+		t.Fatalf("probe: %v", err)
+	}
+}
+
+// redirectingTransport rewrites probe requests (which target https://<host>/)
+// onto the local httptest server, so we exercise the production
+// host-resolution code path while staying offline.
+func redirectingTransport(serverURL string) http.RoundTripper {
+	parsed, _ := url.Parse(serverURL)
+	return roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		req.URL.Scheme = parsed.Scheme
+		req.URL.Host = parsed.Host
+		return http.DefaultTransport.RoundTrip(req)
+	})
+}
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) { return f(req) }

--- a/internal/crawler/types.go
+++ b/internal/crawler/types.go
@@ -107,6 +107,7 @@ type CrawlResult struct {
 	RequestDiagnostics  *RequestDiagnostics `json:"request_diagnostics,omitempty"`
 	BodySample          []byte              `json:"-"` // Truncated body for tech detection (not serialised)
 	Body                []byte              `json:"-"` // Full body for storage upload (not serialised)
+	WAF                 *WAFDetection       `json:"waf,omitempty"`
 }
 
 // RequestDiagnostics stores per-stage diagnostics for a crawl.

--- a/internal/crawler/waf.go
+++ b/internal/crawler/waf.go
@@ -1,0 +1,130 @@
+package crawler
+
+import (
+	"bytes"
+	"net/http"
+	"strings"
+)
+
+// WAFDetection captures a verdict from the WAF fingerprint detector.
+// Vendor identifies the protection layer ("cloudflare", "imperva",
+// "datadome", "akamai", "generic", or empty when not blocked). Reason
+// is the specific signal that fired, suitable for surfacing in
+// jobs.error_message.
+type WAFDetection struct {
+	Blocked bool   `json:"blocked"`
+	Vendor  string `json:"vendor,omitempty"`
+	Reason  string `json:"reason,omitempty"`
+}
+
+// Vendor labels.
+const (
+	WAFVendorCloudflare = "cloudflare"
+	WAFVendorImperva    = "imperva"
+	WAFVendorDataDome   = "datadome"
+	WAFVendorAkamai     = "akamai"
+	WAFVendorGeneric    = "generic"
+)
+
+// DetectWAF inspects a response and reports whether it carries a
+// fingerprint of a known bot-protection layer. The function is pure: no
+// I/O, safe for table-driven tests. It is intentionally conservative on
+// 200 responses — only blocking status codes (typically 403 or 202)
+// combined with corroborating fingerprints trigger a verdict, so a
+// healthy site that happens to use Cloudflare for caching does not get
+// flagged.
+//
+// Fingerprints (issue #365 row 1 + comment 4334238167):
+//   - Cloudflare: cf-mitigated header set on a non-200 response
+//   - Imperva: body contains _Incapsula_Resource
+//   - DataDome: Server header equals DataDome
+//   - Akamai: Server header AkamaiGHost OR akaalb_ cookie OR
+//     Server-Timing ak_p marker, all on a blocking status
+//   - Generic: tiny body (<500 bytes) on 403 or 202 with no other signal
+func DetectWAF(statusCode int, headers http.Header, bodySample []byte) WAFDetection {
+	if headers == nil {
+		headers = http.Header{}
+	}
+
+	blocking := isBlockingStatus(statusCode)
+
+	if v := strings.TrimSpace(headers.Get("Cf-Mitigated")); v != "" && blocking {
+		return WAFDetection{
+			Blocked: true,
+			Vendor:  WAFVendorCloudflare,
+			Reason:  "cf-mitigated header present on " + statusLabel(statusCode),
+		}
+	}
+
+	if bytes.Contains(bodySample, []byte("_Incapsula_Resource")) {
+		return WAFDetection{
+			Blocked: true,
+			Vendor:  WAFVendorImperva,
+			Reason:  "_Incapsula_Resource marker in response body",
+		}
+	}
+
+	if server := headers.Get("Server"); server != "" {
+		serverLower := strings.ToLower(server)
+		if strings.Contains(serverLower, "datadome") {
+			return WAFDetection{
+				Blocked: true,
+				Vendor:  WAFVendorDataDome,
+				Reason:  "Server: DataDome",
+			}
+		}
+		if blocking && strings.Contains(serverLower, "akamaighost") {
+			return WAFDetection{
+				Blocked: true,
+				Vendor:  WAFVendorAkamai,
+				Reason:  "Server: AkamaiGHost on " + statusLabel(statusCode),
+			}
+		}
+	}
+
+	if blocking {
+		for _, c := range headers.Values("Set-Cookie") {
+			if strings.Contains(strings.ToLower(c), "akaalb_") {
+				return WAFDetection{
+					Blocked: true,
+					Vendor:  WAFVendorAkamai,
+					Reason:  "akaalb_ cookie on " + statusLabel(statusCode),
+				}
+			}
+		}
+		for _, st := range headers.Values("Server-Timing") {
+			if strings.Contains(strings.ToLower(st), "ak_p;") {
+				return WAFDetection{
+					Blocked: true,
+					Vendor:  WAFVendorAkamai,
+					Reason:  "Server-Timing ak_p marker on " + statusLabel(statusCode),
+				}
+			}
+		}
+	}
+
+	if blocking && len(bodySample) > 0 && len(bodySample) < 500 {
+		return WAFDetection{
+			Blocked: true,
+			Vendor:  WAFVendorGeneric,
+			Reason:  "tiny body on " + statusLabel(statusCode),
+		}
+	}
+
+	return WAFDetection{}
+}
+
+func isBlockingStatus(code int) bool {
+	return code == http.StatusForbidden || code == http.StatusAccepted
+}
+
+func statusLabel(code int) string {
+	switch code {
+	case http.StatusForbidden:
+		return "403"
+	case http.StatusAccepted:
+		return "202"
+	default:
+		return http.StatusText(code)
+	}
+}

--- a/internal/crawler/waf_test.go
+++ b/internal/crawler/waf_test.go
@@ -1,0 +1,169 @@
+package crawler
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestDetectWAF(t *testing.T) {
+	tests := []struct {
+		name         string
+		status       int
+		headers      http.Header
+		body         []byte
+		wantBlocked  bool
+		wantVendor   string
+		reasonPrefix string
+	}{
+		{
+			name:        "amazon.com 200 — must NOT trip detector after UA rename",
+			status:      http.StatusOK,
+			headers:     http.Header{"Server": []string{"Server"}, "Content-Type": []string{"text/html"}},
+			body:        []byte("<!doctype html><html><head><title>Amazon</title></head><body>...big page...</body></html>"),
+			wantBlocked: false,
+		},
+		{
+			name:         "akamai — Server: AkamaiGHost on 403",
+			status:       http.StatusForbidden,
+			headers:      http.Header{"Server": []string{"AkamaiGHost"}},
+			body:         []byte("<HTML><HEAD>Access Denied</HEAD></HTML>"),
+			wantBlocked:  true,
+			wantVendor:   WAFVendorAkamai,
+			reasonPrefix: "Server: AkamaiGHost",
+		},
+		{
+			name:   "akamai — akaalb_ cookie on 403",
+			status: http.StatusForbidden,
+			headers: http.Header{
+				"Set-Cookie": []string{"akaalb_main=~op=ALB:abc; Path=/"},
+			},
+			body:         []byte("blocked"),
+			wantBlocked:  true,
+			wantVendor:   WAFVendorAkamai,
+			reasonPrefix: "akaalb_ cookie",
+		},
+		{
+			name:   "akamai — Server-Timing ak_p on 403",
+			status: http.StatusForbidden,
+			headers: http.Header{
+				"Server-Timing": []string{"ak_p; desc=\"123_456_789\";dur=1"},
+			},
+			body:         []byte("blocked"),
+			wantBlocked:  true,
+			wantVendor:   WAFVendorAkamai,
+			reasonPrefix: "Server-Timing ak_p",
+		},
+		{
+			name:         "akamai — EdgeSuite 373-byte body counts as generic when no header signal",
+			status:       http.StatusForbidden,
+			headers:      http.Header{},
+			body:         []byte(strings.Repeat("x", 373)),
+			wantBlocked:  true,
+			wantVendor:   WAFVendorGeneric,
+			reasonPrefix: "tiny body",
+		},
+		{
+			name:   "cloudflare — cf-mitigated header on 403",
+			status: http.StatusForbidden,
+			headers: http.Header{
+				"Cf-Mitigated": []string{"challenge"},
+				"Server":       []string{"cloudflare"},
+			},
+			body:         []byte("Just a moment..."),
+			wantBlocked:  true,
+			wantVendor:   WAFVendorCloudflare,
+			reasonPrefix: "cf-mitigated",
+		},
+		{
+			name:   "cloudflare — cf-mitigated alone on 200 must NOT trip (caching path)",
+			status: http.StatusOK,
+			headers: http.Header{
+				"Cf-Mitigated": []string{""},
+				"Server":       []string{"cloudflare"},
+			},
+			body:        []byte("<html>real content</html>"),
+			wantBlocked: false,
+		},
+		{
+			name:         "imperva — _Incapsula_Resource marker in body",
+			status:       http.StatusOK,
+			headers:      http.Header{},
+			body:         []byte("<script>var marker=\"_Incapsula_Resource SWWRGTS-3995852985\";</script>"),
+			wantBlocked:  true,
+			wantVendor:   WAFVendorImperva,
+			reasonPrefix: "_Incapsula_Resource",
+		},
+		{
+			name:         "datadome — Server: DataDome",
+			status:       http.StatusForbidden,
+			headers:      http.Header{"Server": []string{"DataDome"}},
+			body:         []byte("blocked"),
+			wantBlocked:  true,
+			wantVendor:   WAFVendorDataDome,
+			reasonPrefix: "Server: DataDome",
+		},
+		{
+			name:         "generic — tiny body on 202",
+			status:       http.StatusAccepted,
+			headers:      http.Header{},
+			body:         []byte(strings.Repeat("x", 200)),
+			wantBlocked:  true,
+			wantVendor:   WAFVendorGeneric,
+			reasonPrefix: "tiny body",
+		},
+		{
+			name:        "generic — large body on 403 does NOT trip generic",
+			status:      http.StatusForbidden,
+			headers:     http.Header{},
+			body:        []byte(strings.Repeat("x", 5000)),
+			wantBlocked: false,
+		},
+		{
+			name:        "404 with no fingerprint — not blocked",
+			status:      http.StatusNotFound,
+			headers:     http.Header{},
+			body:        []byte("<html>not found</html>"),
+			wantBlocked: false,
+		},
+		{
+			name:        "503 with no fingerprint — not blocked (transient)",
+			status:      http.StatusServiceUnavailable,
+			headers:     http.Header{},
+			body:        []byte("upstream down"),
+			wantBlocked: false,
+		},
+		{
+			name:         "akamaighost case-insensitive",
+			status:       http.StatusForbidden,
+			headers:      http.Header{"Server": []string{"akamaighost"}},
+			body:         []byte("blocked"),
+			wantBlocked:  true,
+			wantVendor:   WAFVendorAkamai,
+			reasonPrefix: "Server: AkamaiGHost",
+		},
+		{
+			name:        "nil headers — must not panic",
+			status:      http.StatusOK,
+			headers:     nil,
+			body:        []byte("ok"),
+			wantBlocked: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := DetectWAF(tc.status, tc.headers, tc.body)
+			if got.Blocked != tc.wantBlocked {
+				t.Fatalf("Blocked = %v, want %v (vendor %q reason %q)",
+					got.Blocked, tc.wantBlocked, got.Vendor, got.Reason)
+			}
+			if tc.wantVendor != "" && got.Vendor != tc.wantVendor {
+				t.Errorf("Vendor = %q, want %q", got.Vendor, tc.wantVendor)
+			}
+			if tc.reasonPrefix != "" && !strings.Contains(got.Reason, tc.reasonPrefix) {
+				t.Errorf("Reason = %q, want substring %q", got.Reason, tc.reasonPrefix)
+			}
+		})
+	}
+}

--- a/internal/jobs/block_job_test.go
+++ b/internal/jobs/block_job_test.go
@@ -1,0 +1,128 @@
+package jobs
+
+import (
+	"context"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBlockJob_LockOrder asserts the block transaction issues
+// statements in the same lock order as CancelJob — tasks → jobs →
+// task_outbox → domains. The first three mirror the worker batch path
+// and AFTER STATEMENT counter trigger; reversing them is the same
+// 40P01 deadlock the cancel test guards against. The fourth (domains)
+// must come last so nothing else holds a domain row lock for the
+// duration of the long tasks UPDATE.
+func TestBlockJob_LockOrder(t *testing.T) {
+	mockDB, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherRegexp))
+	require.NoError(t, err)
+	defer mockDB.Close()
+
+	jm := &JobManager{
+		db:             mockDB,
+		dbQueue:        &mockDbQueueWrapper{mockDB: mockDB},
+		processedPages: make(map[string]struct{}),
+	}
+
+	const (
+		jobID  = "job-block-1"
+		vendor = "akamai"
+		reason = "Server: AkamaiGHost on 403"
+	)
+
+	mock.ExpectBegin()
+	mock.ExpectQuery(`SELECT[\s\S]+FROM jobs j[\s\S]+JOIN domains d`).
+		WithArgs(jobID).
+		WillReturnRows(jobRow(jobID, JobStatusRunning))
+	mock.ExpectCommit()
+
+	mock.ExpectBegin()
+
+	// 1. Tasks first, ORDER BY id.
+	mock.ExpectExec(`(?s)WITH picked AS \(\s*SELECT id FROM tasks\s+WHERE job_id = \$1\s+AND status IN \(\$3, \$4\)\s+ORDER BY id\s+FOR UPDATE\s*\)\s*UPDATE tasks t\s+SET status = \$2`).
+		WithArgs(jobID, string(TaskStatusSkipped), string(TaskStatusPending), string(TaskStatusWaiting)).
+		WillReturnResult(sqlmock.NewResult(0, 5))
+
+	// 2. Jobs second — error_message carries the WAF reason.
+	mock.ExpectExec(`UPDATE jobs\s+SET status = \$1, completed_at = \$2, error_message = \$3\s+WHERE id = \$4`).
+		WithArgs(string(JobStatusBlocked), sqlmock.AnyArg(), sqlmock.AnyArg(), jobID).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	// 3. Outbox cleanup.
+	mock.ExpectExec(`DELETE FROM task_outbox WHERE job_id = \$1`).
+		WithArgs(jobID).
+		WillReturnResult(sqlmock.NewResult(0, 5))
+
+	// 4. Domain row last.
+	mock.ExpectExec(`UPDATE domains\s+SET waf_blocked\s+= TRUE,\s+waf_vendor\s+= \$1,\s+waf_blocked_at = NOW\(\)\s+WHERE id = \(SELECT domain_id FROM jobs WHERE id = \$2\)`).
+		WithArgs(vendor, jobID).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	mock.ExpectCommit()
+
+	err = jm.BlockJob(context.Background(), jobID, vendor, reason)
+	require.NoError(t, err)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+// TestBlockJob_AlreadyBlockedIsNoOp covers the circuit-breaker-races-
+// pre-flight scenario: a second BlockJob against an already-blocked
+// job must not run the transaction again.
+func TestBlockJob_AlreadyBlockedIsNoOp(t *testing.T) {
+	mockDB, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherRegexp))
+	require.NoError(t, err)
+	defer mockDB.Close()
+
+	jm := &JobManager{
+		db:             mockDB,
+		dbQueue:        &mockDbQueueWrapper{mockDB: mockDB},
+		processedPages: make(map[string]struct{}),
+	}
+
+	const jobID = "job-already-blocked"
+
+	mock.ExpectBegin()
+	mock.ExpectQuery(`SELECT[\s\S]+FROM jobs j[\s\S]+JOIN domains d`).
+		WithArgs(jobID).
+		WillReturnRows(jobRow(jobID, JobStatusBlocked))
+	mock.ExpectCommit()
+
+	err = jm.BlockJob(context.Background(), jobID, "akamai", "")
+	require.NoError(t, err)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+// TestBlockJob_TerminalStatusErrors asserts a block against a
+// completed/failed/cancelled job returns an error rather than
+// silently overwriting a finished result.
+func TestBlockJob_TerminalStatusErrors(t *testing.T) {
+	for _, status := range []JobStatus{JobStatusCompleted, JobStatusFailed, JobStatusCancelled} {
+		t.Run(string(status), func(t *testing.T) {
+			mockDB, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherRegexp))
+			require.NoError(t, err)
+			defer mockDB.Close()
+
+			jm := &JobManager{
+				db:             mockDB,
+				dbQueue:        &mockDbQueueWrapper{mockDB: mockDB},
+				processedPages: make(map[string]struct{}),
+			}
+
+			const jobID = "job-terminal"
+
+			mock.ExpectBegin()
+			mock.ExpectQuery(`SELECT[\s\S]+FROM jobs j[\s\S]+JOIN domains d`).
+				WithArgs(jobID).
+				WillReturnRows(jobRow(jobID, status))
+			mock.ExpectCommit()
+
+			err = jm.BlockJob(context.Background(), jobID, "akamai", "")
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), "cannot be blocked")
+			assert.NoError(t, mock.ExpectationsWereMet())
+		})
+	}
+}

--- a/internal/jobs/interfaces.go
+++ b/internal/jobs/interfaces.go
@@ -15,6 +15,9 @@ type CrawlerInterface interface {
 	ParseSitemap(ctx context.Context, sitemapURL string) ([]string, error)
 	FilterURLs(urls []string, includePaths, excludePaths []string) []string
 	GetUserAgent() string
+	// Probe issues a pre-flight WAF fingerprint request against the
+	// homepage of a domain. Issue #365 row 1.
+	Probe(ctx context.Context, domain string) (crawler.WAFDetection, error)
 }
 
 // DbQueueInterface defines the database queue operations needed by the job system.

--- a/internal/jobs/manager.go
+++ b/internal/jobs/manager.go
@@ -33,6 +33,7 @@ type DbQueueProvider interface {
 type JobManagerInterface interface {
 	CreateJob(ctx context.Context, options *JobOptions) (*Job, error)
 	CancelJob(ctx context.Context, jobID string) error
+	BlockJob(ctx context.Context, jobID string, vendor, reason string) error
 	GetJobStatus(ctx context.Context, jobID string) (*Job, error)
 
 	GetJob(ctx context.Context, jobID string) (*Job, error)
@@ -283,14 +284,48 @@ func createJobObject(options *JobOptions, normalisedDomain string) *Job {
 
 func (jm *JobManager) setupJobDatabase(ctx context.Context, job *Job, normalisedDomain string) (int, error) {
 	var domainID int
+	var cachedWAFBlocked bool
+	var cachedWAFVendor sql.NullString
+	var wafBlockedAt sql.NullTime
 
 	err := jm.dbQueue.Execute(ctx, func(tx *sql.Tx) error {
+		// Single round-trip: upsert the domain and read its WAF cache
+		// flags so we can decide synchronously whether to skip discovery.
 		err := tx.QueryRow(`
 			INSERT INTO domains(name) VALUES($1)
 			ON CONFLICT (name) DO UPDATE SET name=EXCLUDED.name
-			RETURNING id`, normalisedDomain).Scan(&domainID)
+			RETURNING id, waf_blocked, waf_vendor, waf_blocked_at`,
+			normalisedDomain).Scan(&domainID, &cachedWAFBlocked, &cachedWAFVendor, &wafBlockedAt)
 		if err != nil {
 			return fmt.Errorf("failed to get or create domain: %w", err)
+		}
+
+		// Cache hit (within the 24h freshness window) means the previous
+		// pre-flight or circuit breaker already verified this domain is
+		// blocked. Skip discovery and stamp the job in the same tx.
+		if cachedWAFBlocked && wafBlockedAt.Valid && time.Since(wafBlockedAt.Time) < wafCacheTTL {
+			job.Status = JobStatusBlocked
+			completedAt := time.Now().UTC()
+			job.CompletedAt = completedAt
+			vendor := cachedWAFVendor.String
+			job.ErrorMessage = buildWAFBlockMessage(vendor, "cached pre-flight verdict")
+
+			_, err = tx.Exec(
+				`INSERT INTO jobs (
+					id, domain_id, user_id, organisation_id, status, progress, total_tasks, completed_tasks, failed_tasks, skipped_tasks,
+					created_at, completed_at, concurrency, find_links, include_paths, exclude_paths,
+					required_workers, max_pages, allow_cross_subdomain_links,
+					found_tasks, sitemap_tasks, source_type, source_detail, source_info, scheduler_id, error_message
+				) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26)`,
+				job.ID, domainID, job.UserID, job.OrganisationID, string(job.Status), job.Progress,
+				job.TotalTasks, job.CompletedTasks, job.FailedTasks, job.SkippedTasks,
+				job.CreatedAt, completedAt, job.Concurrency, job.FindLinks,
+				db.Serialise(job.IncludePaths), db.Serialise(job.ExcludePaths),
+				job.RequiredWorkers, job.MaxPages, job.AllowCrossSubdomainLinks,
+				job.FoundTasks, job.SitemapTasks, job.SourceType, job.SourceDetail, job.SourceInfo,
+				job.SchedulerID, job.ErrorMessage,
+			)
+			return err
 		}
 
 		_, err = tx.Exec(
@@ -317,6 +352,13 @@ func (jm *JobManager) setupJobDatabase(ctx context.Context, job *Job, normalised
 
 	return domainID, nil
 }
+
+// wafCacheTTL bounds how long the cached domains.waf_blocked verdict is
+// trusted before the next CreateJob re-probes. Akamai/Cloudflare
+// policies do change — a once-blocked domain can be allowlisted later
+// — so the cache must expire. 24h matches the rate at which site
+// owners typically respond to allowlist requests.
+const wafCacheTTL = 24 * time.Hour
 
 // Returns nil (no error) when the crawler is unavailable; callers treat
 // nil rules as "no restriction".
@@ -474,6 +516,11 @@ func (jm *JobManager) setupJobURLDiscovery(ctx context.Context, job *Job, option
 			// Detached from request ctx so the long sitemap fetch survives the HTTP handler returning.
 			procCtx, procCancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Minute)
 			defer procCancel()
+
+			if jm.runWAFPreflight(procCtx, job, normalisedDomain) {
+				return
+			}
+
 			jm.processSitemap(procCtx, jobID, normalisedDomain, options.IncludePaths, options.ExcludePaths)
 		}()
 		return nil
@@ -482,6 +529,11 @@ func (jm *JobManager) setupJobURLDiscovery(ctx context.Context, job *Job, option
 	backgroundCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Minute)
 	go func() {
 		defer cancel()
+
+		if jm.runWAFPreflight(backgroundCtx, job, normalisedDomain) {
+			return
+		}
+
 		rootPath := "/"
 		_, err := jm.validateRootURLAccess(backgroundCtx, job, normalisedDomain, rootPath)
 		if err != nil {
@@ -496,6 +548,40 @@ func (jm *JobManager) setupJobURLDiscovery(ctx context.Context, job *Job, option
 	}()
 
 	return nil
+}
+
+// runWAFPreflight issues the live probe and, on a positive verdict,
+// transitions the job to JobStatusBlocked via BlockJob. Returns true
+// when the caller should stop (job is now terminal). A network /
+// timeout error from the probe is logged as a warning and returns
+// false — the mid-job circuit breaker is the safety net for those
+// cases, and a transient probe failure must not block legitimate jobs.
+func (jm *JobManager) runWAFPreflight(ctx context.Context, job *Job, normalisedDomain string) bool {
+	if jm.crawler == nil {
+		return false
+	}
+
+	det, err := jm.crawler.Probe(ctx, normalisedDomain)
+	if err != nil {
+		jobsLog.Warn("WAF pre-flight probe failed; continuing to discovery",
+			"error", err, "job_id", job.ID, "domain", normalisedDomain)
+		return false
+	}
+	if !det.Blocked {
+		return false
+	}
+
+	jobsLog.Info("WAF pre-flight detected block",
+		"job_id", job.ID,
+		"domain", normalisedDomain,
+		"vendor", det.Vendor,
+		"reason", det.Reason)
+
+	if err := jm.BlockJob(ctx, job.ID, det.Vendor, det.Reason); err != nil {
+		jobsLog.Error("Failed to block job after WAF pre-flight detection",
+			"error", err, "job_id", job.ID)
+	}
+	return true
 }
 
 func (jm *JobManager) CreateJob(ctx context.Context, options *JobOptions) (*Job, error) {
@@ -534,7 +620,15 @@ func (jm *JobManager) CreateJob(ctx context.Context, options *JobOptions) (*Job,
 		"use_sitemap", options.UseSitemap,
 		"find_links", options.FindLinks,
 		"max_pages", options.MaxPages,
+		"status", string(job.Status),
 	)
+
+	// Cached WAF verdict: setupJobDatabase already stamped the job
+	// blocked, so don't kick off discovery. The job is already terminal.
+	if job.Status == JobStatusBlocked {
+		span.SetTag("waf_cache_hit", "true")
+		return job, nil
+	}
 
 	if err := jm.setupJobURLDiscovery(ctx, job, options, domainID, normalisedDomain); err != nil {
 		span.SetTag("error", "true")
@@ -765,6 +859,122 @@ func (jm *JobManager) CancelJob(ctx context.Context, jobID string) error {
 	jobsLog.Debug("Cancelled job", "job_id", job.ID, "domain", job.Domain)
 
 	return nil
+}
+
+// BlockJob transitions a job to JobStatusBlocked when the WAF detector
+// (pre-flight probe or mid-job circuit breaker) recognises bot
+// protection on the domain. The shape mirrors CancelJob: tasks UPDATE
+// → jobs UPDATE → task_outbox DELETE, with the same ORDER BY id lock
+// order to keep the AFTER STATEMENT counter trigger from deadlocking
+// against worker batches. domains.waf_blocked is set in the same
+// transaction so a follow-up CreateJob short-circuits without
+// re-probing.
+func (jm *JobManager) BlockJob(ctx context.Context, jobID string, vendor, reason string) error {
+	span := sentry.StartSpan(ctx, "manager.block_job")
+	defer span.Finish()
+
+	span.SetTag("job_id", jobID)
+	span.SetTag("waf_vendor", vendor)
+
+	job, err := jm.GetJob(ctx, jobID)
+	if err != nil {
+		span.SetTag("error", "true")
+		span.SetData("error.message", err.Error())
+		return fmt.Errorf("failed to get job: %w", err)
+	}
+
+	// Already-blocked is a no-op so a circuit-breaker fire racing the
+	// pre-flight probe doesn't surface as a duplicate error.
+	if job.Status == JobStatusBlocked {
+		jobsLog.Debug("Block requested on already-blocked job", "job_id", job.ID)
+		return nil
+	}
+
+	if job.Status != JobStatusRunning && job.Status != JobStatusPending && job.Status != JobStatusPaused && job.Status != JobStatusInitialising {
+		return fmt.Errorf("job cannot be blocked: %s", job.Status)
+	}
+
+	job.Status = JobStatusBlocked
+	job.CompletedAt = time.Now().UTC()
+	errorMessage := buildWAFBlockMessage(vendor, reason)
+
+	err = jm.dbQueue.Execute(ctx, func(tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx, `
+			WITH picked AS (
+				SELECT id FROM tasks
+				 WHERE job_id = $1
+				   AND status IN ($3, $4)
+				 ORDER BY id
+				 FOR UPDATE
+			)
+			UPDATE tasks t
+			   SET status = $2
+			  FROM picked
+			 WHERE t.id = picked.id
+		`, job.ID, TaskStatusSkipped, TaskStatusPending, TaskStatusWaiting)
+		if err != nil {
+			return err
+		}
+
+		_, err = tx.ExecContext(ctx, `
+			UPDATE jobs
+			SET status = $1, completed_at = $2, error_message = $3
+			WHERE id = $4
+		`, job.Status, job.CompletedAt, errorMessage, job.ID)
+		if err != nil {
+			return err
+		}
+
+		_, err = tx.ExecContext(ctx, `
+			DELETE FROM task_outbox WHERE job_id = $1
+		`, job.ID)
+		if err != nil {
+			return err
+		}
+
+		// Domain row last — nothing else takes a domain lock in this
+		// transaction so the lock graph stays acyclic vs other writers.
+		_, err = tx.ExecContext(ctx, `
+			UPDATE domains
+			   SET waf_blocked    = TRUE,
+			       waf_vendor     = $1,
+			       waf_blocked_at = NOW()
+			 WHERE id = (SELECT domain_id FROM jobs WHERE id = $2)
+		`, vendor, job.ID)
+		return err
+	})
+
+	if err != nil {
+		span.SetTag("error", "true")
+		span.SetData("error.message", err.Error())
+		jobsLog.Error("Failed to block job", "error", err, "job_id", job.ID)
+		return fmt.Errorf("failed to block job: %w", err)
+	}
+
+	jm.clearProcessedPages(job.ID)
+	jm.clearMilestoneState(job.ID)
+
+	if jm.OnJobTerminated != nil {
+		jm.OnJobTerminated(ctx, job.ID)
+	}
+
+	jobsLog.Info("Blocked job (WAF detected)",
+		"job_id", job.ID,
+		"domain", job.Domain,
+		"waf_vendor", vendor,
+		"reason", reason)
+
+	return nil
+}
+
+func buildWAFBlockMessage(vendor, reason string) string {
+	if vendor == "" {
+		vendor = "unknown"
+	}
+	if reason == "" {
+		return fmt.Sprintf("WAF blocked (%s) — site bot protection refused our crawler", vendor)
+	}
+	return fmt.Sprintf("WAF blocked (%s) — %s", vendor, reason)
 }
 
 func (jm *JobManager) GetJob(ctx context.Context, jobID string) (*Job, error) {
@@ -1025,16 +1235,18 @@ func (jm *JobManager) CalculateJobProgress(job *Job) float64 {
 
 func (jm *JobManager) ValidateStatusTransition(from, to JobStatus) error {
 	// Allow restart from terminal states.
-	if to == JobStatusRunning && (from == JobStatusCompleted || from == JobStatusCancelled || from == JobStatusFailed) {
+	if to == JobStatusRunning && (from == JobStatusCompleted || from == JobStatusCancelled || from == JobStatusFailed || from == JobStatusBlocked) {
 		return nil
 	}
 
 	validTransitions := map[JobStatus][]JobStatus{
-		JobStatusPending:   {JobStatusRunning, JobStatusCancelled},
-		JobStatusRunning:   {JobStatusCompleted, JobStatusFailed, JobStatusCancelled},
-		JobStatusCompleted: {JobStatusRunning, JobStatusArchived},
-		JobStatusFailed:    {JobStatusRunning, JobStatusArchived},
-		JobStatusCancelled: {JobStatusRunning, JobStatusArchived},
+		JobStatusPending:      {JobStatusRunning, JobStatusCancelled, JobStatusBlocked},
+		JobStatusInitialising: {JobStatusRunning, JobStatusCancelled, JobStatusBlocked, JobStatusFailed},
+		JobStatusRunning:      {JobStatusCompleted, JobStatusFailed, JobStatusCancelled, JobStatusBlocked},
+		JobStatusCompleted:    {JobStatusRunning, JobStatusArchived},
+		JobStatusFailed:       {JobStatusRunning, JobStatusArchived},
+		JobStatusCancelled:    {JobStatusRunning, JobStatusArchived},
+		JobStatusBlocked:      {JobStatusRunning, JobStatusArchived},
 	}
 
 	allowed, exists := validTransitions[from]

--- a/internal/jobs/stream_worker.go
+++ b/internal/jobs/stream_worker.go
@@ -61,6 +61,10 @@ type StreamWorkerDeps struct {
 	// HTMLPersister is nil when ARCHIVE_PROVIDER is unset (local dev
 	// without R2); completed tasks then persist without HTML.
 	HTMLPersister *HTMLPersister
+	// WAFBreaker is nil-safe: when supplied, every task outcome runs
+	// through it and a domain that produces N consecutive WAF
+	// fingerprints trips a job-level block (issue #365 row 1).
+	WAFBreaker *WAFCircuitBreaker
 }
 
 type StreamWorkerOpts struct {
@@ -98,6 +102,7 @@ type StreamWorkerPool struct {
 	dbQueue       DbQueueInterface
 	jobManager    JobManagerInterface
 	htmlPersister *HTMLPersister
+	wafBreaker    *WAFCircuitBreaker
 	opts          StreamWorkerOpts
 
 	jobInfoCache map[string]*cachedJobInfo
@@ -154,6 +159,7 @@ func NewStreamWorkerPool(deps StreamWorkerDeps, opts StreamWorkerOpts) *StreamWo
 		dbQueue:          deps.DBQueue,
 		jobManager:       deps.JobManager,
 		htmlPersister:    deps.HTMLPersister,
+		wafBreaker:       deps.WAFBreaker,
 		opts:             opts,
 		jobInfoCache:     make(map[string]*cachedJobInfo),
 		linkDiscoverySem: make(chan struct{}, linkDiscoveryMaxInflight()),
@@ -385,6 +391,15 @@ func (swp *StreamWorkerPool) handleOutcome(ctx context.Context, msg broker.Strea
 		}
 	}
 	swp.batchManager.QueueTaskUpdate(outcome.Task)
+
+	// WAF circuit breaker: feed every outcome through the per-job
+	// counter and trip a job-level block once N consecutive responses
+	// carry recognised fingerprints. Runs after the task row update is
+	// queued so the per-task evidence is persisted before we mark the
+	// job terminal.
+	if swp.wafBreaker != nil && swp.jobManager != nil {
+		swp.wafBreaker.MaybeTripFromOutcome(ctx, swp.jobManager, outcome)
+	}
 
 	if len(outcome.DiscoveredLinks) > 0 {
 		swp.handleDiscoveredLinks(ctx, outcome)

--- a/internal/jobs/types.go
+++ b/internal/jobs/types.go
@@ -15,6 +15,10 @@ const (
 	JobStatusFailed       JobStatus = "failed"
 	JobStatusCancelled    JobStatus = "cancelled"
 	JobStatusArchived     JobStatus = "archived"
+	// JobStatusBlocked is set when the WAF detector flags a domain as
+	// blocked (issue #365 row 1). The pre-flight probe and the mid-job
+	// circuit breaker both transition jobs into this terminal state.
+	JobStatusBlocked JobStatus = "blocked"
 )
 
 type TaskStatus string

--- a/internal/jobs/waf_circuit_breaker.go
+++ b/internal/jobs/waf_circuit_breaker.go
@@ -1,0 +1,144 @@
+package jobs
+
+import (
+	"context"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/Harvey-AU/hover/internal/crawler"
+)
+
+// defaultWAFCircuitBreakerThreshold is the consecutive-WAF-response
+// count that trips the breaker mid-job. Tuned conservatively: once we
+// see three responses in a row carrying recognised WAF fingerprints we
+// have very high confidence the domain has flipped to blocking us.
+const defaultWAFCircuitBreakerThreshold = 3
+
+// WAFCircuitBreaker tracks per-job runs of consecutive WAF-flagged
+// responses and trips a callback once the threshold is reached. The
+// state lives in process memory — fine for the current single-pod
+// worker deployment (fly.worker.toml). If the worker ever scales out
+// horizontally the counter would undercount across replicas; in that
+// case migrate it to Redis (INCR job:<id>:waf_consecutive with TTL)
+// alongside the existing running-counters HASH.
+type WAFCircuitBreaker struct {
+	threshold int
+
+	mu      sync.Mutex
+	counts  map[string]int                  // jobID -> consecutive WAF responses
+	tripped map[string]struct{}             // jobIDs already tripped (single-fire)
+	vendors map[string]crawler.WAFDetection // last seen detection per job
+}
+
+func NewWAFCircuitBreaker() *WAFCircuitBreaker {
+	return &WAFCircuitBreaker{
+		threshold: wafCircuitBreakerThreshold(),
+		counts:    make(map[string]int),
+		tripped:   make(map[string]struct{}),
+		vendors:   make(map[string]crawler.WAFDetection),
+	}
+}
+
+func wafCircuitBreakerThreshold() int {
+	if v := strings.TrimSpace(os.Getenv("GNH_WAF_CIRCUIT_BREAKER_THRESHOLD")); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return n
+		}
+		jobsLog.Warn("invalid GNH_WAF_CIRCUIT_BREAKER_THRESHOLD; using default",
+			"value", v, "default", defaultWAFCircuitBreakerThreshold)
+	}
+	return defaultWAFCircuitBreakerThreshold
+}
+
+// Observe records the WAF status of a single task outcome. When det is
+// nil or det.Blocked is false the per-job counter resets, ensuring the
+// breaker only fires on truly consecutive blocks rather than a sparse
+// sprinkle. Returns true exactly once per job — the moment the
+// threshold is first crossed — so callers can fire BlockJob without
+// guarding against duplicates.
+func (b *WAFCircuitBreaker) Observe(jobID string, det *crawler.WAFDetection) (tripped bool, vendor crawler.WAFDetection) {
+	if b == nil || jobID == "" {
+		return false, crawler.WAFDetection{}
+	}
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if _, alreadyTripped := b.tripped[jobID]; alreadyTripped {
+		return false, crawler.WAFDetection{}
+	}
+
+	if det == nil || !det.Blocked {
+		delete(b.counts, jobID)
+		delete(b.vendors, jobID)
+		return false, crawler.WAFDetection{}
+	}
+
+	b.counts[jobID]++
+	b.vendors[jobID] = *det
+
+	if b.counts[jobID] >= b.threshold {
+		b.tripped[jobID] = struct{}{}
+		v := b.vendors[jobID]
+		delete(b.counts, jobID)
+		delete(b.vendors, jobID)
+		return true, v
+	}
+	return false, crawler.WAFDetection{}
+}
+
+// Forget drops all per-job state. Called from OnJobTerminated so a
+// long-running worker doesn't accumulate per-job map entries.
+func (b *WAFCircuitBreaker) Forget(jobID string) {
+	if b == nil || jobID == "" {
+		return
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	delete(b.counts, jobID)
+	delete(b.vendors, jobID)
+	delete(b.tripped, jobID)
+}
+
+// Threshold exposes the configured trip count for telemetry/logging.
+func (b *WAFCircuitBreaker) Threshold() int {
+	if b == nil {
+		return 0
+	}
+	return b.threshold
+}
+
+// MaybeTripFromOutcome is the convenience wrapper used from the stream
+// worker hot path. It pulls the WAF detection from the outcome, calls
+// Observe, and on a trip dispatches BlockJob in a fresh detached
+// context (the caller's context is the per-task one and may be on its
+// way out).
+func (b *WAFCircuitBreaker) MaybeTripFromOutcome(ctx context.Context, jm JobManagerInterface, outcome *TaskOutcome) {
+	if b == nil || jm == nil || outcome == nil || outcome.Task == nil {
+		return
+	}
+	var det *crawler.WAFDetection
+	if outcome.CrawlResult != nil {
+		det = outcome.CrawlResult.WAF
+	}
+	tripped, vendor := b.Observe(outcome.Task.JobID, det)
+	if !tripped {
+		return
+	}
+
+	jobsLog.Info("WAF circuit breaker tripped",
+		"job_id", outcome.Task.JobID,
+		"threshold", b.Threshold(),
+		"vendor", vendor.Vendor,
+		"reason", vendor.Reason)
+
+	// Detach so the per-task ctx cancellation doesn't truncate the
+	// terminal-state writes.
+	bgCtx := context.WithoutCancel(ctx)
+	if err := jm.BlockJob(bgCtx, outcome.Task.JobID, vendor.Vendor, "circuit breaker: "+vendor.Reason); err != nil {
+		jobsLog.Error("BlockJob from circuit breaker failed",
+			"error", err, "job_id", outcome.Task.JobID)
+	}
+}

--- a/internal/jobs/waf_circuit_breaker_test.go
+++ b/internal/jobs/waf_circuit_breaker_test.go
@@ -1,0 +1,136 @@
+package jobs
+
+import (
+	"testing"
+
+	"github.com/Harvey-AU/hover/internal/crawler"
+)
+
+func TestWAFCircuitBreaker_TripsAtThreshold(t *testing.T) {
+	b := &WAFCircuitBreaker{
+		threshold: 3,
+		counts:    make(map[string]int),
+		tripped:   make(map[string]struct{}),
+		vendors:   make(map[string]crawler.WAFDetection),
+	}
+
+	det := &crawler.WAFDetection{Blocked: true, Vendor: crawler.WAFVendorAkamai, Reason: "Server: AkamaiGHost on 403"}
+
+	if tripped, _ := b.Observe("job-1", det); tripped {
+		t.Fatalf("expected no trip after first WAF observation")
+	}
+	if tripped, _ := b.Observe("job-1", det); tripped {
+		t.Fatalf("expected no trip after second WAF observation")
+	}
+	tripped, vendor := b.Observe("job-1", det)
+	if !tripped {
+		t.Fatalf("expected trip at third consecutive WAF observation")
+	}
+	if vendor.Vendor != crawler.WAFVendorAkamai {
+		t.Errorf("vendor = %q, want %q", vendor.Vendor, crawler.WAFVendorAkamai)
+	}
+}
+
+func TestWAFCircuitBreaker_NonWAFResetsCounter(t *testing.T) {
+	b := &WAFCircuitBreaker{
+		threshold: 3,
+		counts:    make(map[string]int),
+		tripped:   make(map[string]struct{}),
+		vendors:   make(map[string]crawler.WAFDetection),
+	}
+
+	det := &crawler.WAFDetection{Blocked: true, Vendor: "akamai"}
+
+	b.Observe("job-1", det)
+	b.Observe("job-1", det)
+	// One healthy response wipes the streak.
+	b.Observe("job-1", nil)
+	b.Observe("job-1", det)
+	b.Observe("job-1", det)
+	tripped, _ := b.Observe("job-1", det)
+	if !tripped {
+		t.Fatalf("expected trip after three consecutive blocks following a reset")
+	}
+}
+
+func TestWAFCircuitBreaker_FiresOncePerJob(t *testing.T) {
+	b := &WAFCircuitBreaker{
+		threshold: 1,
+		counts:    make(map[string]int),
+		tripped:   make(map[string]struct{}),
+		vendors:   make(map[string]crawler.WAFDetection),
+	}
+
+	det := &crawler.WAFDetection{Blocked: true, Vendor: "akamai"}
+
+	if tripped, _ := b.Observe("job-1", det); !tripped {
+		t.Fatalf("expected trip on first observation (threshold=1)")
+	}
+	for i := 0; i < 5; i++ {
+		if tripped, _ := b.Observe("job-1", det); tripped {
+			t.Fatalf("breaker fired more than once for the same job")
+		}
+	}
+}
+
+func TestWAFCircuitBreaker_PerJobIsolation(t *testing.T) {
+	b := &WAFCircuitBreaker{
+		threshold: 2,
+		counts:    make(map[string]int),
+		tripped:   make(map[string]struct{}),
+		vendors:   make(map[string]crawler.WAFDetection),
+	}
+
+	det := &crawler.WAFDetection{Blocked: true, Vendor: "akamai"}
+
+	// A has one WAF response and then resets to zero. B has only one
+	// WAF response so far. Neither has reached threshold 2.
+	b.Observe("job-A", det)
+	b.Observe("job-B", det)
+	b.Observe("job-A", nil) // resets A only
+
+	// Next A block: A's counter is 1, must not trip.
+	if tripped, _ := b.Observe("job-A", det); tripped {
+		t.Errorf("job-A tripped after only one WAF response since reset")
+	}
+	// Next A block: A reaches threshold of 2 — must trip.
+	if tripped, _ := b.Observe("job-A", det); !tripped {
+		t.Errorf("job-A should trip at second consecutive block since reset")
+	}
+	// B is independent: still at 1 hit, must not trip on a single more
+	// block taking it to 2 — wait, that's a trip. Instead verify B
+	// hasn't tripped yet by sending one healthy response then re-checking.
+	b.Observe("job-B", nil)
+	if tripped, _ := b.Observe("job-B", det); tripped {
+		t.Errorf("job-B tripped on a single block following a reset")
+	}
+}
+
+func TestWAFCircuitBreaker_ForgetClearsState(t *testing.T) {
+	b := &WAFCircuitBreaker{
+		threshold: 3,
+		counts:    make(map[string]int),
+		tripped:   make(map[string]struct{}),
+		vendors:   make(map[string]crawler.WAFDetection),
+	}
+
+	det := &crawler.WAFDetection{Blocked: true, Vendor: "akamai"}
+
+	b.Observe("job-1", det)
+	b.Observe("job-1", det)
+	b.Forget("job-1")
+	// Forget is intended for terminal-state cleanup — after it, fresh
+	// observations start from zero again.
+	if tripped, _ := b.Observe("job-1", det); tripped {
+		t.Fatalf("Forget did not reset counter (tripped on first post-forget observation)")
+	}
+}
+
+func TestWAFCircuitBreaker_NilSafe(t *testing.T) {
+	var b *WAFCircuitBreaker
+	tripped, _ := b.Observe("job-1", &crawler.WAFDetection{Blocked: true})
+	if tripped {
+		t.Fatalf("nil receiver tripped")
+	}
+	b.Forget("job-1") // must not panic
+}

--- a/supabase/migrations/20260428111241_add_waf_blocked_to_domains.sql
+++ b/supabase/migrations/20260428111241_add_waf_blocked_to_domains.sql
@@ -1,0 +1,140 @@
+-- WAF detection on first contact (issue #365 row 1).
+--
+-- The pre-flight probe and the mid-job circuit breaker write the
+-- waf_blocked flag onto the domain row when a recognised bot-protection
+-- layer (Cloudflare cf-mitigated, Imperva _Incapsula_Resource, DataDome
+-- Server header, Akamai AkamaiGHost / akaalb_ / Server-Timing ak_p) is
+-- detected. The next CreateJob for the same domain reads the cached
+-- flag synchronously and skips both the live probe and the discovery
+-- goroutine.
+--
+-- waf_blocked_at gives the application layer the information it needs
+-- to expire the cache (default 24 h) and re-probe; without it a
+-- once-blocked domain would never be retested even if the site owner
+-- allowlisted Hover.
+--
+-- The partial index targets the cache-read path (domains where the
+-- flag is set); healthy domains never touch the index.
+
+ALTER TABLE public.domains
+  ADD COLUMN IF NOT EXISTS waf_blocked BOOLEAN NOT NULL DEFAULT FALSE,
+  ADD COLUMN IF NOT EXISTS waf_vendor TEXT,
+  ADD COLUMN IF NOT EXISTS waf_blocked_at TIMESTAMPTZ;
+
+CREATE INDEX IF NOT EXISTS idx_domains_waf_blocked
+  ON public.domains(waf_blocked)
+  WHERE waf_blocked = TRUE;
+
+-- The statement-level counter trigger from migration 20260426013451 hard-
+-- codes ('cancelled', 'failed') as the terminal-status set it must not
+-- overwrite when a late task completion fires. 'blocked' is a third
+-- terminal state with the same constraint: BlockJob writes
+-- jobs.status = 'blocked' inside the same transaction that flips the
+-- last in-flight tasks to 'skipped', and the trigger must preserve it
+-- against a same-batch completion race. Re-create the function with
+-- 'blocked' added to the preserved set.
+
+CREATE OR REPLACE FUNCTION update_job_counters_status_batch()
+RETURNS TRIGGER LANGUAGE plpgsql SET search_path = public AS $$
+BEGIN
+    WITH per_row AS (
+        SELECT
+            o.job_id                                   AS job_id,
+            CASE WHEN o.status = 'completed' THEN -1 ELSE 0 END AS completed_delta,
+            CASE WHEN o.status = 'failed'    THEN -1 ELSE 0 END AS failed_delta,
+            CASE WHEN o.status = 'skipped'   THEN -1 ELSE 0 END AS skipped_delta,
+            CASE WHEN o.status = 'pending'   THEN -1 ELSE 0 END AS pending_delta,
+            CASE WHEN o.status = 'waiting'   THEN -1 ELSE 0 END AS waiting_delta,
+            FALSE                                       AS running_started
+        FROM old_tasks o
+        JOIN new_tasks n ON n.id = o.id
+        WHERE o.status IS DISTINCT FROM n.status
+           OR o.job_id IS DISTINCT FROM n.job_id
+
+        UNION ALL
+
+        SELECT
+            n.job_id                                   AS job_id,
+            CASE WHEN n.status = 'completed' THEN  1 ELSE 0 END AS completed_delta,
+            CASE WHEN n.status = 'failed'    THEN  1 ELSE 0 END AS failed_delta,
+            CASE WHEN n.status = 'skipped'   THEN  1 ELSE 0 END AS skipped_delta,
+            CASE WHEN n.status = 'pending'   THEN  1 ELSE 0 END AS pending_delta,
+            CASE WHEN n.status = 'waiting'   THEN  1 ELSE 0 END AS waiting_delta,
+            (n.status = 'running')                       AS running_started
+        FROM new_tasks n
+        JOIN old_tasks o ON o.id = n.id
+        WHERE o.status IS DISTINCT FROM n.status
+           OR o.job_id IS DISTINCT FROM n.job_id
+    ),
+    deltas AS (
+        SELECT
+            job_id,
+            SUM(completed_delta)::INT  AS completed_delta,
+            SUM(failed_delta)::INT     AS failed_delta,
+            SUM(skipped_delta)::INT    AS skipped_delta,
+            SUM(pending_delta)::INT    AS pending_delta,
+            SUM(waiting_delta)::INT    AS waiting_delta,
+            BOOL_OR(running_started)   AS running_started
+        FROM per_row
+        GROUP BY job_id
+    ),
+    _locked AS (
+        SELECT j.id
+        FROM jobs j
+        JOIN deltas d ON d.job_id = j.id
+        ORDER BY j.id
+        FOR UPDATE OF j
+    )
+    UPDATE jobs j
+    SET
+        completed_tasks = GREATEST(0, j.completed_tasks + d.completed_delta),
+        failed_tasks    = GREATEST(0, j.failed_tasks    + d.failed_delta),
+        skipped_tasks   = GREATEST(0, j.skipped_tasks   + d.skipped_delta),
+        pending_tasks   = GREATEST(0, j.pending_tasks   + d.pending_delta),
+        waiting_tasks   = GREATEST(0, j.waiting_tasks   + d.waiting_delta),
+        progress = CASE
+            WHEN j.total_tasks > 0
+             AND (j.total_tasks - GREATEST(0, j.skipped_tasks + d.skipped_delta)) > 0
+            THEN (
+                (GREATEST(0, j.completed_tasks + d.completed_delta)
+                 + GREATEST(0, j.failed_tasks  + d.failed_delta))::REAL
+                / (j.total_tasks - GREATEST(0, j.skipped_tasks + d.skipped_delta))::REAL
+            ) * 100.0
+            ELSE 0.0
+        END,
+        started_at = CASE
+            WHEN j.started_at IS NULL AND d.running_started THEN NOW()
+            ELSE j.started_at
+        END,
+        completed_at = CASE
+            WHEN j.completed_at IS NULL
+             AND j.total_tasks > 0
+             AND (
+                 GREATEST(0, j.completed_tasks + d.completed_delta)
+                 + GREATEST(0, j.failed_tasks  + d.failed_delta)
+                 + GREATEST(0, j.skipped_tasks + d.skipped_delta)
+             ) >= j.total_tasks
+            THEN NOW()
+            ELSE j.completed_at
+        END,
+        status = CASE
+            -- 'blocked' joins ('cancelled', 'failed') as a terminal status
+            -- the trigger must not overwrite when a same-batch task
+            -- completion would otherwise mark the job 'completed'.
+            WHEN j.status IN ('cancelled', 'failed', 'blocked') THEN j.status
+            WHEN j.total_tasks > 0
+             AND (
+                 GREATEST(0, j.completed_tasks + d.completed_delta)
+                 + GREATEST(0, j.failed_tasks  + d.failed_delta)
+                 + GREATEST(0, j.skipped_tasks + d.skipped_delta)
+             ) >= j.total_tasks
+            THEN 'completed'
+            ELSE j.status
+        END
+    FROM deltas d
+    WHERE j.id = d.job_id
+      AND j.id IN (SELECT id FROM _locked);
+
+    RETURN NULL;
+END;
+$$;

--- a/web/static/app/components/hover-job-card.js
+++ b/web/static/app/components/hover-job-card.js
@@ -172,6 +172,12 @@ class HoverJobCard extends HTMLElement {
       outcomeDotClass = "dot--neutral";
       outcomeLabel = "Cancelled";
       statusColour = "var(--status-colour--neutral)";
+    } else if (normStatus === "blocked") {
+      // Amber rather than red — a WAF block is a site-owner decision,
+      // not a Hover failure. Keeps the support framing right.
+      outcomeDotClass = "dot--warning";
+      outcomeLabel = "Blocked by site";
+      statusColour = "var(--status-colour--warning)";
     } else if (isActive) {
       outcomeDotClass = "dot--warning";
       outcomeLabel = statusLabelForJob(normStatus);
@@ -627,6 +633,7 @@ function statusLabelForJob(status) {
   if (status === "pending") return "Starting up";
   if (status === "cancelled") return "Cancelled";
   if (status === "archived") return "Archived";
+  if (status === "blocked") return "Blocked by site";
   return "Error";
 }
 
@@ -638,6 +645,7 @@ function iconClassForJob(status) {
   if (status === "pending" || status === "queued")
     return `${base} ${base}--pending`;
   if (status === "archived") return `${base} ${base}--completed`;
+  if (status === "blocked") return `${base} ${base}--warning`;
   return `${base} ${base}--error`;
 }
 

--- a/web/static/app/components/hover-status-pill.js
+++ b/web/static/app/components/hover-status-pill.js
@@ -40,6 +40,7 @@ const STATUS_LABELS = {
   cancelling: "Cancelling",
   skipped: "Skipped",
   archived: "Archived",
+  blocked: "Blocked by site",
 };
 
 /** @type {Record<string, string>} Maps status → CSS modifier for the icon */
@@ -57,6 +58,7 @@ const STATUS_ICON_MOD = {
   cancelling: "neutral",
   skipped: "neutral",
   archived: "neutral",
+  blocked: "neutral",
 };
 
 /** @type {Record<string, string>} Maps status → CSS modifier for the colour */
@@ -74,6 +76,9 @@ const STATUS_COLOUR_MOD = {
   cancelling: "neutral",
   skipped: "neutral",
   archived: "neutral",
+  // "warning" amber rather than "danger": a WAF block is a site-side
+  // decision, not a Hover failure — keeps the support framing right.
+  blocked: "warning",
 };
 
 const VALID_VARIANTS = new Set(["icon", "dot", "label"]);


### PR DESCRIPTION
## Summary

Ships row 1 of [#365](https://github.com/Harvey-AU/hover/issues/365):

- **Pre-flight probe** before any task enqueueing. Recognises Cloudflare (`cf-mitigated`), Imperva (`_Incapsula_Resource`), DataDome (`Server: DataDome`), and Akamai (`AkamaiGHost` / `akaalb_` cookie / `Server-Timing: ak_p`). Verdict cached on `domains.waf_blocked` for 24 h so a follow-up job short-circuits without re-probing.
- **Mid-job circuit breaker**: 3 consecutive WAF-flagged responses trip a job-level block via `BlockJob`. Threshold tunable via `GNH_WAF_CIRCUIT_BREAKER_THRESHOLD`.
- **`BlockJob` mirrors `CancelJob`** — same tasks→jobs→outbox→domains lock order; lock-order test included to prevent the 40P01 deadlock from regressing.
- **Trigger update** so `'blocked'` joins `('cancelled','failed')` as a status the AFTER STATEMENT counter trigger preserves against late completion races.
- **Dashboard pill**: amber "Blocked by site" — site-side decision, not a Hover failure.

Akamai fingerprints come from probe evidence in [#365 (comment)](https://github.com/Harvey-AU/hover/issues/365#issuecomment-4334238167).

## Test plan

- [ ] `target.com.au` → pre-flight detects Akamai; job ends `blocked`; zero tasks; `domains.waf_blocked = true`, `waf_vendor = 'akamai'`.
- [ ] `woolworths.com.au` → same as above.
- [ ] `amazon.com` → probe returns 200; job proceeds normally (negative test — must not over-trigger).
- [ ] Re-submit `target.com.au` immediately → near-instant `blocked` via the cached-flag path (no live probe).
- [ ] Dashboard renders amber "Blocked by site" pill with the WAF reason in `error_message`.
- [ ] After 24 h (or with `waf_blocked_at` manually backdated) the next job re-probes.

## Already verified

- `go test ./...` clean (15-case detector, 3-case probe, 3-case BlockJob, 6-case circuit breaker; existing tests still pass).
- `go build ./...` (cmd/app + cmd/worker), `go vet`, `gofmt`/`goimports`, Prettier, `scripts/security-check.sh` (0 issues).

## Known follow-ups (not in this PR)

- Worker is single-replica today (`fly.worker.toml`). If it ever fans out, the in-memory consecutive-WAF counter undercounts across pods — migrate to Redis (`INCR job:<id>:waf_consecutive` with TTL).
- Customer outreach surface (allowlist request flow) for sites we want unblocked — row 3(b) territory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic WAF detection: jobs against sites protected by Cloudflare, Imperva, DataDome, Akamai, or generic WAF patterns now terminate early and are marked with a new terminal status: "blocked".
  * Per-job circuit-breaker enforces blocking after repeated WAF detections.
  * Verdicts are cached for 24 hours to avoid repeated probing.

* **UI**
  * New amber "Blocked by site" status pill and updated job card labeling/styling.

* **Documentation**
  * CHANGELOG updated with these additions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->