### PR TITLE
Stop review-app and prod machines stacking on deploy

### DIFF
--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -124,7 +124,11 @@ jobs:
       - name: Release API app
         env:
           IMAGE: ${{ needs.build-shared.outputs.image }}
-        run: flyctl deploy --image "$IMAGE" --app hover
+        run: |
+          flyctl deploy --image "$IMAGE" --app hover
+          # Reap stale-image machines left behind by the new release —
+          # see PR #369 for why deploy alone isn't enough.
+          flyctl scale count 1 --process-group app -a hover --yes
 
   release-analysis:
     name: Release hover-analysis
@@ -164,6 +168,7 @@ jobs:
           flyctl deploy --image "$IMAGE" \
             --config fly.analysis.toml \
             --app hover-analysis
+          flyctl scale count 2 --process-group analysis -a hover-analysis --yes
 
   release-worker:
     name: Release hover-worker
@@ -207,6 +212,7 @@ jobs:
           flyctl deploy --image "$IMAGE" \
             --config fly.worker.toml \
             --app hover-worker
+          flyctl scale count 2 --process-group worker -a hover-worker --yes
 
   # ───────── Annotation ────────────────────────────────────────────────
   # if: always() so a partial deploy still produces an annotation for

--- a/.github/workflows/review-apps.yml
+++ b/.github/workflows/review-apps.yml
@@ -466,6 +466,9 @@ jobs:
             --config .fly/review_apps.toml \
             --app "$API_APP" \
             --ha=false
+          # Reap any old-image machines left behind by the new release —
+          # see PR #369 for why --ha=false alone isn't enough on review apps.
+          flyctl scale count 1 --process-group app -a "$API_APP" --yes
 
   release-analysis:
     name: Release analysis review app
@@ -488,6 +491,7 @@ jobs:
             --config .fly/review_apps.analysis.toml \
             --app "$ANALYSIS_APP" \
             --ha=false
+          flyctl scale count 1 --process-group analysis -a "$ANALYSIS_APP" --yes
 
   release-worker:
     name: Release worker review app
@@ -515,6 +519,7 @@ jobs:
             --config .fly/review_apps.worker.toml \
             --app "$WORKER_APP" \
             --ha=false
+          flyctl scale count 1 --process-group worker -a "$WORKER_APP" --yes
 
   # ───────── Comment on PR ─────────────────────────────────────────────
   # Single comment with the API URL — posted only after the API release

--- a/.github/workflows/review-apps.yml
+++ b/.github/workflows/review-apps.yml
@@ -464,7 +464,8 @@ jobs:
           flyctl deploy \
             --image "$IMAGE" \
             --config .fly/review_apps.toml \
-            --app "$API_APP"
+            --app "$API_APP" \
+            --ha=false
 
   release-analysis:
     name: Release analysis review app
@@ -485,7 +486,8 @@ jobs:
           flyctl deploy \
             --image "$IMAGE" \
             --config .fly/review_apps.analysis.toml \
-            --app "$ANALYSIS_APP"
+            --app "$ANALYSIS_APP" \
+            --ha=false
 
   release-worker:
     name: Release worker review app
@@ -511,7 +513,8 @@ jobs:
           flyctl deploy \
             --image "$IMAGE" \
             --config .fly/review_apps.worker.toml \
-            --app "$WORKER_APP"
+            --app "$WORKER_APP" \
+            --ha=false
 
   # ───────── Comment on PR ─────────────────────────────────────────────
   # Single comment with the API URL — posted only after the API release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,10 +31,13 @@ On merge, CI will:
 ### Fixed
 
 - Review-app deploys no longer stack machines on repeated PR pushes. Added
-  `--ha=false` to all three `flyctl deploy` calls in
-  `.github/workflows/review-apps.yml` (API, analysis, worker) so each deploy
-  converges on one machine per process group instead of provisioning a fresh HA
-  pair on top of the previous run's machines.
+  `--ha=false` and a follow-up `flyctl scale count 1 --process-group …` to all
+  three `flyctl deploy` calls in `.github/workflows/review-apps.yml` (API,
+  analysis, worker). The Apr-27 build/release split changed the release shape to
+  `flyctl deploy --image registry.fly.io/<app>:<label>`, which provisions a new
+  machine instead of updating the existing one in place; worker and analysis
+  have no `[http_service]` to auto-stop the stragglers, so each push left the
+  previous machine running. The scale step reaps them after the new image is up.
 
 ## Full changelog history
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,13 @@ On merge, CI will:
 
 ## [Unreleased]
 
-_Add unreleased changes here._
+### Fixed
+
+- Review-app deploys no longer stack machines on repeated PR pushes. Added
+  `--ha=false` to all three `flyctl deploy` calls in
+  `.github/workflows/review-apps.yml` (API, analysis, worker) so each deploy
+  converges on one machine per process group instead of provisioning a fresh HA
+  pair on top of the previous run's machines.
 
 ## Full changelog history
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,14 +30,21 @@ On merge, CI will:
 
 ### Fixed
 
-- Review-app deploys no longer stack machines on repeated PR pushes. Added
-  `--ha=false` and a follow-up `flyctl scale count 1 --process-group …` to all
-  three `flyctl deploy` calls in `.github/workflows/review-apps.yml` (API,
-  analysis, worker). The Apr-27 build/release split changed the release shape to
+- Review-app and prod deploys no longer stack machines on repeated pushes. The
+  Apr-27 build/release split changed the release shape to
   `flyctl deploy --image registry.fly.io/<app>:<label>`, which provisions a new
   machine instead of updating the existing one in place; worker and analysis
   have no `[http_service]` to auto-stop the stragglers, so each push left the
-  previous machine running. The scale step reaps them after the new image is up.
+  previous machine running. Fix:
+  - `.github/workflows/review-apps.yml` — added `--ha=false` plus a follow-up
+    `flyctl scale count 1 --process-group …` to all three release jobs (API,
+    analysis, worker), so each review-app converges on one machine per group.
+  - `.github/workflows/fly-deploy.yml` — added a follow-up `flyctl scale count`
+    to the prod release jobs (API → 1, analysis → 2, worker → 2) so prod keeps
+    its HA pair on worker/analysis without stale-image leftovers piling up.
+    Existing prod stragglers (`hover-worker`, `hover-analysis`) need a one-time
+    `flyctl machine destroy` of the stale-image machines before the next deploy
+    takes effect.
 
 ## Full changelog history
 


### PR DESCRIPTION
## Summary

Both review apps and prod were quietly leaving stale-image machines running after every deploy. Root cause is the build/release split that landed on 2026-04-27 (`5cee2661` for review apps, equivalent change for prod): `flyctl deploy --image registry.fly.io/<app>:<label>` provisions a new machine instead of updating the existing one in place, and worker/analysis have no `[http_service]` to auto-stop the stragglers, so each push leaves the previous machine behind.

This PR fixes both surfaces:

- `.github/workflows/review-apps.yml` — added `--ha=false` plus a follow-up `flyctl scale count 1 --process-group …` to all three release jobs (API, analysis, worker). Each review app converges on one machine per group.
- `.github/workflows/fly-deploy.yml` — added a follow-up `flyctl scale count` to the prod release jobs: API → 1 (matches `max_machines_running = 1` in `fly.toml`), analysis → 2, worker → 2 (preserving the current HA pair on prod). No `--ha=false` on prod — we want the HA pair, just without stale leftovers piling up.

## Test plan

Review-app side verified end-to-end on this PR:

- [x] Three sequential pushes (`4e21b9ee`, `233e4551`, `e9a64a4f`) — `hover-pr-369`, `hover-worker-pr-369`, `hover-analysis-pr-369` held at exactly **1 machine each** the whole way through.
- [x] No "running multiple images" banner on the Fly dashboard after subsequent pushes.

Prod side will be exercised on the next merge to main:

- [ ] After this PR merges, `flyctl machines list -a hover / hover-worker / hover-analysis` should show 1 / 2 / 2 machines, all on the freshly deployed image.
- [ ] Existing prod stragglers (`sparkling-meadow-7600` on `hover-worker`, `empty-night-9641` on `hover-analysis` — both running stale `hover:deployment-25048722784-1` images) likely need a one-time `flyctl machine destroy` before the new `flyctl scale count` step can converge cleanly. This is the same orphan-blindness pattern that hit PR-369's worker (image namespace `hover:` vs the app's own `hover-worker:` makes flyctl's deploy planner ignore them).
- [ ] PR-close cleanup of any review-app stragglers from earlier PRs is still handled by `cleanup-orphaned-apps.yml`.