### PR TITLE
Document case-based crawl handling

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,6 +110,9 @@ For detailed, authoritative rules and onboarding:
 - `CHANGELOG.md`
 - `SECURITY.md`
 - `docs/architecture/ARCHITECTURE.md`
+- `docs/architecture/CRAWL_HANDLING.md` — case → action policy (what we do to a
+  job and its tasks for each domain/page condition). Add a row when you add a
+  case.
 - `docs/architecture/CONFIG_REFERENCE.md`
 - `docs/architecture/DATABASE.md`
 - `docs/architecture/API.md`

--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ See [Roadmap.md](./Roadmap.md) for detailed progress tracking.
 - [API Reference](docs/architecture/API.md)
 - [Configuration Reference](docs/architecture/CONFIG_REFERENCE.md)
 - [Architecture Overview](docs/architecture/ARCHITECTURE.md)
+- [Crawl Handling Cases](docs/architecture/CRAWL_HANDLING.md) — what we do for
+  each domain/page condition
 - [Supabase Realtime](docs/development/SUPABASE-REALTIME.md)
 - [Observability & Tracing](docs/operations/OBSERVABILITY.md)
 - [All Documentation →](docs/)

--- a/docs/architecture/API.md
+++ b/docs/architecture/API.md
@@ -322,7 +322,9 @@ Authorization: Bearer <token>
 
 - `page` - Page number (default: 1)
 - `limit` - Results per page (default: 50, max: 100)
-- `status` - Filter by task status: `pending`, `running`, `completed`, `failed`
+- `status` - Filter by task status: `waiting`, `pending`, `running`,
+  `completed`, `failed`, `skipped` (see [`CRAWL_HANDLING.md`](CRAWL_HANDLING.md)
+  for what each means)
 - `status_code` - Filter by HTTP status code: `200`, `404`, `500`, etc.
 - `min_response_time` - Minimum response time in milliseconds
 - `max_response_time` - Maximum response time in milliseconds

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -174,6 +174,9 @@ waiting → pending → running → completed
   counter update on the parent job row and remove the message from the stream's
   pending entries list.
 
+For the case → action mapping ("when X happens to a domain or page, what do we
+do to the job and tasks?") see [`CRAWL_HANDLING.md`](CRAWL_HANDLING.md).
+
 ### Job Counters (Trigger-Maintained)
 
 `jobs.completed_tasks`, `failed_tasks`, `skipped_tasks`, `running_tasks`,

--- a/docs/architecture/CONFIG_REFERENCE.md
+++ b/docs/architecture/CONFIG_REFERENCE.md
@@ -367,14 +367,14 @@ current delay per domain via `bee.broker.pacer_delay_ms`.
 
 **Source:** `internal/archive/archive.go`, `fly.toml`
 
-| Env var / constant       | Production value     | Default | What it controls                                                          |
-| ------------------------ | -------------------- | ------- | ------------------------------------------------------------------------- |
-| `ARCHIVE_PROVIDER`       | **r2** (`fly.toml`)  | —       | Storage backend (`r2` or `s3`)                                            |
-| `ARCHIVE_BUCKET`         | (`fly.toml`)         | —       | Bucket name for archived HTML                                             |
-| `ARCHIVE_RETENTION_JOBS` | **3** (`fly.toml`)   | —       | Last N terminal jobs (completed/failed/cancelled) kept hot per domain/org |
-| `ARCHIVE_INTERVAL`       | **1m** (`fly.toml`)  | —       | Sweep frequency                                                           |
-| `ARCHIVE_BATCH_SIZE`     | **100** (`fly.toml`) | —       | Archive candidates processed per sweep                                    |
-| `ARCHIVE_CONCURRENCY`    | **5** (`fly.toml`)   | —       | Parallel R2 uploads per sweep                                             |
+| Env var / constant       | Production value     | Default | What it controls                                                                  |
+| ------------------------ | -------------------- | ------- | --------------------------------------------------------------------------------- |
+| `ARCHIVE_PROVIDER`       | **r2** (`fly.toml`)  | —       | Storage backend (`r2` or `s3`)                                                    |
+| `ARCHIVE_BUCKET`         | (`fly.toml`)         | —       | Bucket name for archived HTML                                                     |
+| `ARCHIVE_RETENTION_JOBS` | **3** (`fly.toml`)   | —       | Last N terminal jobs (completed/failed/cancelled/blocked) kept hot per domain/org |
+| `ARCHIVE_INTERVAL`       | **1m** (`fly.toml`)  | —       | Sweep frequency                                                                   |
+| `ARCHIVE_BATCH_SIZE`     | **100** (`fly.toml`) | —       | Archive candidates processed per sweep                                            |
+| `ARCHIVE_CONCURRENCY`    | **5** (`fly.toml`)   | —       | Parallel R2 uploads per sweep                                                     |
 
 ---
 

--- a/docs/architecture/CRAWL_HANDLING.md
+++ b/docs/architecture/CRAWL_HANDLING.md
@@ -1,0 +1,130 @@
+# Crawl handling — case table
+
+A flat list of "what does Hover do when X happens?" Each row is a case (a domain
+or page condition) and the action(s) we take on the **job** and on the **task**
+that surfaced the case.
+
+Optimised for skim-reading and incremental growth: when a new case becomes
+interesting, add a row. Don't expand the conceptual prose unless multiple rows
+need the same explanation.
+
+For state machine internals (full transition rules, lock ordering, trigger
+semantics) see [`internal/jobs/manager.go`](../../internal/jobs/manager.go)
+`ValidateStatusTransition` — that's the single source of truth.
+
+---
+
+## Domain-level cases
+
+Decided at job creation, pre-flight probe, or mid-crawl via the circuit breaker.
+
+| Case                                  | How detected                                                                                                                          | Action on job                                                                                                                                                                                           | Action on tasks                                                                                                                                | Source                                                   |
+| ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
+| **Healthy domain**                    | Pre-flight `/` returns 200, no WAF fingerprint                                                                                        | Status proceeds: `pending` → `initialising` → `running`                                                                                                                                                 | Discovery enqueues normally                                                                                                                    | `internal/jobs/manager.go` `setupJobURLDiscovery`        |
+| **WAF wall (immediate)**              | Pre-flight `/` returns recognised fingerprint (Cloudflare/Imperva/DataDome/Akamai)                                                    | Status → `blocked`, `error_message` carries vendor + reason                                                                                                                                             | Zero enqueued                                                                                                                                  | `internal/crawler/waf.go`, `BlockJob`                    |
+| **WAF wall (cached)**                 | `domains.waf_blocked = true` AND `waf_blocked_at` within 24 h                                                                         | Status → `blocked` set in same tx as job INSERT (synchronous, no probe)                                                                                                                                 | Zero enqueued                                                                                                                                  | `setupJobDatabase` cache-hit branch                      |
+| **WAF wall (mid-crawl)**              | 2 consecutive task responses with WAF fingerprints (configurable: `GNH_WAF_CIRCUIT_BREAKER_THRESHOLD`)                                | Status → `blocked` via async `BlockJob`; `domains.waf_blocked = true`, `waf_vendor` set                                                                                                                 | Pending/waiting → `skipped`; in-flight finish naturally; sitemap loop aborts at next batch boundary; further `EnqueueURLs` calls become no-ops | `internal/jobs/waf_circuit_breaker.go`                   |
+| **Robots.txt disallows `/`**          | `validateRootURLAccess` finds `Disallow: /` matches our UA section                                                                    | Status → `failed`, `error_message = "Root path (/) is disallowed by robots.txt"`                                                                                                                        | Zero enqueued                                                                                                                                  | `validateRootURLAccess`                                  |
+| **Robots.txt unreachable**            | `DiscoverSitemapsAndRobots` returns network error                                                                                     | Status → `failed`, `error_message = "Failed to fetch robots.txt: <err>"`                                                                                                                                | Zero enqueued                                                                                                                                  | `validateRootURLAccess`                                  |
+| **Robots.txt with crawl-delay**       | `Crawl-delay: <n>` in our UA section                                                                                                  | Stamped on `domains.crawl_delay_seconds`                                                                                                                                                                | All tasks paced through `DomainPacer` honouring delay                                                                                          | `internal/crawler/robots.go`, `internal/broker/pacer.go` |
+| **Existing active job**               | Same domain + org has a job in `pending`/`initialising`/`running`/`paused`                                                            | New job creation cancels the existing one first, then proceeds                                                                                                                                          | Existing job's pending/waiting tasks → `skipped`; outbox cleared                                                                               | `handleExistingJobs` → `CancelJob`                       |
+| **Domain unreachable (DNS/TCP/TLS)**  | Probe network error                                                                                                                   | Probe error logged as warning, **discovery proceeds** as if probe passed (transient errors must not block legitimate jobs); subsequent task failures will surface via the circuit breaker if persistent | Discovery proceeds; per-task failures classified as transient and retried                                                                      | `runWAFPreflight`                                        |
+| **User cancellation**                 | `POST /v1/jobs/:id/cancel`                                                                                                            | Status → `cancelled`; `error_message` cleared/preserved                                                                                                                                                 | Pending/waiting → `skipped`; outbox cleared; in-flight finish naturally                                                                        | `CancelJob`                                              |
+| **Quota exhausted (org daily limit)** | `get_daily_quota_remaining` returns 0 inside `EnqueueURLs`                                                                            | Job not transitioned (continues to drain existing tasks); new URLs not enqueued                                                                                                                         | Already-pending tasks proceed; new URLs from sitemap/links are dropped (or shifted to `waiting` if concurrency-limited)                        | `internal/db/queue.go` `EnqueueURLs`                     |
+| **Job already terminal (any reason)** | `EnqueueURLs` reads `jobs.status` under `FOR UPDATE OF j` and finds it in {`completed`, `failed`, `cancelled`, `archived`, `blocked`} | No status change                                                                                                                                                                                        | Insert is a no-op; sitemap loop also short-circuits at next batch via `isJobInTerminalStatus`                                                  | `internal/db/queue.go` terminal-status guard             |
+
+---
+
+## Page-level cases
+
+Decided per-task by the worker after the HTTP response (or error) returns. Row
+order is roughly response-frequency.
+
+| Case                                       | How detected                                                                       | Task action                                                                                 | Job-level effect                                                                                | Notes                                                                       |
+| ------------------------------------------ | ---------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| **2xx OK with content**                    | Status 200–299 + non-empty body                                                    | Status → `completed`, response stored, links extracted if `find_links` enabled              | Counter increments                                                                              | Happy path                                                                  |
+| **2xx with empty / SPA shell**             | 200, body present but `<p>` and `<a>` counts ~0                                    | Status → `completed` (currently treated as success)                                         | Counter increments                                                                              | **Limitation**: data-quality miss, not a wasted resource. Issue #365 row 5. |
+| **3xx redirect (same registrable domain)** | 301/302/303/307/308 to same eTLD+1                                                 | Followed up to redirect cap; final response classified                                      | Counter increments on final step                                                                | `validateCrawlRequest`                                                      |
+| **3xx redirect (cross-domain)**            | 3xx pointing off-site                                                              | Status → `completed` with `redirect_url` recorded; new URL **not** enqueued unless explicit | Counter increments                                                                              | Subdomain-cross-link policy is per-job                                      |
+| **404 Not Found**                          | Status 404                                                                         | Status → `failed`, `error_message = "non-success status code: 404"`                         | Counter increments (failed)                                                                     | No retry — terminal class                                                   |
+| **410 Gone**                               | Status 410                                                                         | Status → `failed`                                                                           | Counter increments (failed)                                                                     | Treated like 404 currently                                                  |
+| **403 with WAF fingerprint**               | 403 + recognised vendor signal (Cloudflare/Imperva/DataDome/Akamai)                | Status → `failed`, marked rate-limited, `result.WAF` populated                              | Counter increments; **circuit breaker observes** — N consecutive trips → `BlockJob`             | See domain-level "WAF wall (mid-crawl)"                                     |
+| **403 without WAF fingerprint**            | 403, no recognised signal, body ≥ 500 B                                            | Status → `failed`, marked rate-limited, retried with backoff up to `MaxBlockingRetries`     | Counter increments                                                                              | Could be auth gate, geo-fence, or unrecognised WAF                          |
+| **403 with tiny body**                     | 403, body 1–499 B                                                                  | `result.WAF` set to generic vendor; same retry/breaker handling as above                    | Counter increments                                                                              | Catches unfingerprinted WAF blocks                                          |
+| **429 Too Many Requests**                  | Status 429                                                                         | Status → `failed`, marked rate-limited; honour `Retry-After` if present; retry with backoff | Counter increments (failed); **`DomainPacer` adapts**, slowing future dispatches for the domain | `internal/broker/pacer.go`                                                  |
+| **5xx server error**                       | Status 500–599 (excl. 503 with rate-limit signal)                                  | Status → `failed`, retried with backoff                                                     | Counter increments (failed)                                                                     | Transient class — keeps retrying within budget                              |
+| **Timeout (TTFB)**                         | No first byte within timeout                                                       | Status → `failed`, transient class, retried                                                 | Counter increments (failed)                                                                     |                                                                             |
+| **Timeout (body read)**                    | First byte received but read stalls                                                | Status → `failed`, transient class, retried                                                 | Counter increments (failed)                                                                     |                                                                             |
+| **TLS / certificate error**                | Handshake failure                                                                  | Status → `failed`, terminal class, NOT retried                                              | Counter increments (failed)                                                                     | Repeat retries won't fix a cert problem                                     |
+| **DNS / TCP error**                        | Connect-time failure                                                               | Status → `failed`, transient class, retried                                                 | Counter increments (failed)                                                                     |                                                                             |
+| **Robots.txt disallows path**              | `IsPathAllowed` returns false at discovery                                         | URL **not enqueued** as a task                                                              | No counter change                                                                               | Filtered at link-discovery / sitemap-parse, never becomes a task row        |
+| **Cross-subdomain link discovered**        | Link extracted from page points to a sibling subdomain                             | Enqueued only if `allow_cross_subdomain_links` is set on the job                            | If allowed, counter increments via `found_tasks`                                                | Per-job toggle                                                              |
+| **Discovered link already crawled**        | `processedPages` map already records the page ID                                   | Skipped at discovery — no DB round-trip                                                     | No counter change                                                                               | In-process dedupe; survives across batches within a job                     |
+| **Discovered link exceeds `max_pages`**    | `currentTaskCount + pendingCount + waitingCount >= max_pages`                      | URL **not enqueued** (overflow) — does NOT materialise as a `skipped` task row              | `total_tasks` doesn't grow; dashboard counts stay accurate                                      | `classifyEnqueuedTask` overflow path                                        |
+| **Stale running task (worker crash)**      | Task in `running` state past `TaskStaleTimeout` (3 min) without a worker heartbeat | Reclaimed by `XAUTOCLAIM`, redelivered, retry counter incremented                           | If retry budget exhausted → dead-lettered as `failed`                                           | `reclaimStaleMessages`                                                      |
+
+---
+
+## Job statuses (reference)
+
+Defined in [`internal/jobs/types.go`](../../internal/jobs/types.go).
+
+| Status         | Meaning                                                            | Terminal?              |
+| -------------- | ------------------------------------------------------------------ | ---------------------- |
+| `pending`      | Created, no tasks yet                                              | No                     |
+| `initialising` | Discovery in progress (sitemap parsing)                            | No                     |
+| `running`      | Tasks dispatching                                                  | No                     |
+| `paused`       | Manually paused; tasks not dispatching                             | No                     |
+| `completed`    | All tasks reached terminal state, total > 0                        | Yes                    |
+| `failed`       | System / discovery error before/during execution                   | Yes                    |
+| `cancelled`    | User cancellation (or auto-cancel from a duplicate-domain new job) | Yes                    |
+| `blocked`      | WAF detected (pre-flight or mid-crawl); not retried automatically  | Yes                    |
+| `archived`     | Soft-deleted from active views                                     | Yes (already terminal) |
+
+Allowed transitions are enforced by `ValidateStatusTransition`. Terminal jobs
+can be restarted by transitioning back to `running` (e.g. customer manually
+retries a `blocked` job after requesting an allowlist from the site owner).
+
+---
+
+## Task statuses (reference)
+
+Defined in [`internal/jobs/types.go`](../../internal/jobs/types.go).
+
+| Status      | Meaning                                                              |
+| ----------- | -------------------------------------------------------------------- |
+| `waiting`   | Concurrency-limited; will be promoted to `pending` when a slot opens |
+| `pending`   | Ready for dispatch                                                   |
+| `running`   | Picked up by a worker, in flight                                     |
+| `completed` | Finished successfully (any 2xx)                                      |
+| `failed`    | Finished with error (4xx/5xx/timeout/etc.) — may have retried first  |
+| `skipped`   | Cancelled or blocked before execution                                |
+
+---
+
+## Domains table (reference)
+
+Schema in [`docs/architecture/DATABASE.md`](DATABASE.md) and the migrations
+under [`supabase/migrations/`](../../supabase/migrations/).
+
+| Column                                      | Set by                                         | Used by                                         |
+| ------------------------------------------- | ---------------------------------------------- | ----------------------------------------------- |
+| `crawl_delay_seconds`                       | `validateRootURLAccess` reading `Crawl-delay:` | `DomainPacer` for per-domain throttling         |
+| `adaptive_delay_seconds` / `_floor_seconds` | Pacer's adaptive backoff on 429s               | Pacer dispatch decisions                        |
+| `waf_blocked`                               | `BlockJob` (pre-flight or circuit breaker)     | `setupJobDatabase` cached-flag fast path        |
+| `waf_vendor`                                | `BlockJob`                                     | Customer-facing reason on subsequent jobs       |
+| `waf_blocked_at`                            | `BlockJob`                                     | Cache TTL (24 h) — older verdicts are re-probed |
+
+---
+
+## Adding a new case
+
+1. Add a row to the appropriate table above.
+2. If it changes job/task status semantics, also update
+   `ValidateStatusTransition` and the relevant counter trigger in
+   `supabase/migrations/`.
+3. If it's a per-task outcome class, the natural home for the classification is
+   `internal/jobs/executor.go` `buildErrorOutcome` or `buildSuccessOutcome`.
+4. Add a test in the package that owns the policy (`internal/jobs/*_test.go` for
+   status transitions, `internal/crawler/*_test.go` for response
+   classification).

--- a/docs/architecture/DATABASE.md
+++ b/docs/architecture/DATABASE.md
@@ -131,17 +131,37 @@ connections including those from the connection pool.
 
 #### Domains Table
 
-Stores unique domain names with integer primary keys for normalisation.
+Stores unique domain names with integer primary keys for normalisation, plus
+per-domain pacing state and WAF cache flags.
 
 ```sql
 CREATE TABLE domains (
     id SERIAL PRIMARY KEY,
     name VARCHAR(255) UNIQUE NOT NULL,
+    crawl_delay_seconds INTEGER,
+    adaptive_delay_seconds INTEGER NOT NULL DEFAULT 0,
+    adaptive_delay_floor_seconds INTEGER NOT NULL DEFAULT 0,
+    waf_blocked BOOLEAN NOT NULL DEFAULT FALSE,
+    waf_vendor TEXT,
+    waf_blocked_at TIMESTAMPTZ,
     created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
 );
 
 CREATE INDEX idx_domains_name ON domains(name);
+CREATE INDEX idx_domains_waf_blocked ON domains(waf_blocked)
+    WHERE waf_blocked = TRUE;
 ```
+
+| Column                                      | Set by                                         | Used by                                         |
+| ------------------------------------------- | ---------------------------------------------- | ----------------------------------------------- |
+| `crawl_delay_seconds`                       | `validateRootURLAccess` reading `Crawl-delay:` | `DomainPacer` for per-domain throttling         |
+| `adaptive_delay_seconds` / `_floor_seconds` | Pacer's adaptive backoff on 429s               | Pacer dispatch decisions                        |
+| `waf_blocked`                               | `BlockJob` (pre-flight or circuit breaker)     | `setupJobDatabase` cached-flag fast path        |
+| `waf_vendor`                                | `BlockJob`                                     | Customer-facing reason on subsequent jobs       |
+| `waf_blocked_at`                            | `BlockJob`                                     | Cache TTL (24 h) — older verdicts are re-probed |
+
+For how each column drives crawl behaviour see
+[`CRAWL_HANDLING.md`](CRAWL_HANDLING.md).
 
 #### Pages Table
 
@@ -196,11 +216,22 @@ CREATE INDEX idx_jobs_created_at ON jobs(created_at);
 
 **Status Values:**
 
-- `pending` - Job created but not started
-- `running` - Job actively processing tasks
-- `completed` - All tasks finished successfully
-- `cancelled` - Job manually cancelled
-- `failed` - Job failed due to system error
+- `pending` - Job created, no tasks yet
+- `initialising` - Discovery in progress (sitemap parsing)
+- `running` - Tasks dispatching
+- `paused` - Manually paused; tasks not dispatching
+- `completed` - All tasks reached a terminal state
+- `failed` - System / discovery error before or during execution
+- `cancelled` - User cancellation (or auto-cancel from a duplicate-domain new
+  job)
+- `blocked` - WAF detected (pre-flight or mid-crawl); not retried automatically
+- `archived` - Soft-deleted from active views
+
+For the full case → action table (which conditions transition a job to which
+status, and what happens to its tasks), see
+[`CRAWL_HANDLING.md`](CRAWL_HANDLING.md). Allowed transitions are enforced by
+`ValidateStatusTransition` in
+[`internal/jobs/manager.go`](../../internal/jobs/manager.go).
 
 **Task Counters:**
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -8,6 +8,10 @@ System design, database schema, and API specifications for Hover.
 
 - **[ARCHITECTURE.md](./ARCHITECTURE.md)** - System design, components, worker
   pools, and job lifecycle
+- **[CRAWL_HANDLING.md](./CRAWL_HANDLING.md)** - Case → action table: what we do
+  to a job and its tasks for every domain or page condition (WAF walls,
+  robots.txt outcomes, response codes, timeouts, etc.). **Add a row when you add
+  a case.**
 - **[CONFIG_REFERENCE.md](./CONFIG_REFERENCE.md)** - Every configurable dial:
   env vars, hardcoded constants, and their relationships
 - **[DATABASE.md](./DATABASE.md)** - PostgreSQL schema, queries, and performance

--- a/internal/crawler/waf.go
+++ b/internal/crawler/waf.go
@@ -41,6 +41,10 @@ const (
 //   - Akamai: Server header AkamaiGHost OR akaalb_ cookie OR
 //     Server-Timing ak_p marker, all on a blocking status
 //   - Generic: tiny body (<500 bytes) on 403 or 202 with no other signal
+//
+// When you add a new fingerprint, add a corresponding row to the
+// "WAF wall" entries in docs/architecture/CRAWL_HANDLING.md so the
+// case → action policy stays current.
 func DetectWAF(statusCode int, headers http.Header, bodySample []byte) WAFDetection {
 	if headers == nil {
 		headers = http.Header{}

--- a/internal/crawler/waf.go
+++ b/internal/crawler/waf.go
@@ -42,9 +42,7 @@ const (
 //     Server-Timing ak_p marker, all on a blocking status
 //   - Generic: tiny body (<500 bytes) on 403 or 202 with no other signal
 //
-// When you add a new fingerprint, add a corresponding row to the
-// "WAF wall" entries in docs/architecture/CRAWL_HANDLING.md so the
-// case → action policy stays current.
+// New fingerprint: also add a "WAF wall" row [CRAWL_HANDLING.md].
 func DetectWAF(statusCode int, headers http.Header, bodySample []byte) WAFDetection {
 	if headers == nil {
 		headers = http.Header{}

--- a/internal/jobs/manager.go
+++ b/internal/jobs/manager.go
@@ -1233,6 +1233,10 @@ func (jm *JobManager) CalculateJobProgress(job *Job) float64 {
 	return float64(processedTasks) / float64(job.TotalTasks) * 100.0
 }
 
+// ValidateStatusTransition is the single source of truth for legal job
+// state transitions. The case → action mapping that motivates each
+// allowed edge lives in docs/architecture/CRAWL_HANDLING.md. When you
+// add or change an edge here, update that doc in the same change.
 func (jm *JobManager) ValidateStatusTransition(from, to JobStatus) error {
 	// Allow restart from terminal states.
 	if to == JobStatusRunning && (from == JobStatusCompleted || from == JobStatusCancelled || from == JobStatusFailed || from == JobStatusBlocked) {

--- a/internal/jobs/manager.go
+++ b/internal/jobs/manager.go
@@ -1233,10 +1233,7 @@ func (jm *JobManager) CalculateJobProgress(job *Job) float64 {
 	return float64(processedTasks) / float64(job.TotalTasks) * 100.0
 }
 
-// ValidateStatusTransition is the single source of truth for legal job
-// state transitions. The case → action mapping that motivates each
-// allowed edge lives in docs/architecture/CRAWL_HANDLING.md. When you
-// add or change an edge here, update that doc in the same change.
+// Allowed-edge rationale and case → action mapping: [CRAWL_HANDLING.md].
 func (jm *JobManager) ValidateStatusTransition(from, to JobStatus) error {
 	// Allow restart from terminal states.
 	if to == JobStatusRunning && (from == JobStatusCompleted || from == JobStatusCancelled || from == JobStatusFailed || from == JobStatusBlocked) {

--- a/internal/jobs/types.go
+++ b/internal/jobs/types.go
@@ -4,6 +4,15 @@ import (
 	"time"
 )
 
+// JobStatus is the canonical job state enum. Adding a new value here
+// requires three coordinated changes:
+//   - extend ValidateStatusTransition in manager.go with allowed
+//     transitions to/from the new state,
+//   - if the new state is terminal, add it to terminalJobStatuses in
+//     internal/db/queue.go and to the status preservation list in the
+//     statement-level counter trigger,
+//   - add a row to docs/architecture/CRAWL_HANDLING.md describing the
+//     case that triggers it and what happens to the job's tasks.
 type JobStatus string
 
 const (

--- a/internal/jobs/types.go
+++ b/internal/jobs/types.go
@@ -4,15 +4,8 @@ import (
 	"time"
 )
 
-// JobStatus is the canonical job state enum. Adding a new value here
-// requires three coordinated changes:
-//   - extend ValidateStatusTransition in manager.go with allowed
-//     transitions to/from the new state,
-//   - if the new state is terminal, add it to terminalJobStatuses in
-//     internal/db/queue.go and to the status preservation list in the
-//     statement-level counter trigger,
-//   - add a row to docs/architecture/CRAWL_HANDLING.md describing the
-//     case that triggers it and what happens to the job's tasks.
+// New value: also update ValidateStatusTransition + (if terminal)
+// terminalJobStatuses + trigger preserve list + [CRAWL_HANDLING.md] row.
 type JobStatus string
 
 const (


### PR DESCRIPTION
## Summary

Adds a flat case → action table covering how Hover handles each domain
or page condition we encounter. Optimised for skim-reading and
incremental growth: each row is a case, each row tells you what
happens to the **job** and what happens to the **task** that surfaced
the case, with a pointer to the source code.

## What's in it

- **`docs/architecture/CRAWL_HANDLING.md`** (new) — three tables:
  - **Domain-level cases** (12 rows): healthy, WAF wall variants, robots.txt outcomes, existing-active-job, quota, cancellation, terminal job, etc.
  - **Page-level cases** (~20 rows): 2xx with content, 2xx empty/SPA shell, redirects, 4xx/5xx, WAF responses (with vs without fingerprint), 429, timeouts, TLS errors, robots.txt-disallowed paths, cross-subdomain links, dedupe, max_pages overflow, stale-task reclaim.
  - **Reference tables** for job statuses, task statuses, and `domains` table columns.
- **`DATABASE.md`** updates: complete (and accurate) job-status list, new `domains` columns documented, cross-link to `CRAWL_HANDLING.md`.
- **`ARCHITECTURE.md`** update: Task Lifecycle section points to the new doc.

## Why

The job-status list in `DATABASE.md` was stale (5 statuses listed; 9
actually exist in code), and `domains.waf_blocked` / `waf_vendor` /
`waf_blocked_at` weren't documented anywhere. As we add more cases
(row 4 of #365 will introduce `failure_class`, row 2 will add Shopify-
specific handling), there needs to be a single skim-able place to
answer "what happens when X?". Tables grow well; long-form prose
doesn't.

## Note on dependency

A few rows reference behaviour shipping in #368 (the `EnqueueURLs`
terminal-status guard, the lowered breaker default of 2). If #368
merges first, the doc is accurate on day one; if this lands first the
doc is slightly aspirational on those rows for the duration. No code
changes here, so either order is safe.

## Test plan

- [ ] Render the doc on GitHub and check the tables format correctly.
- [ ] Verify the case rows match production behaviour (spot-check 2-3 of each table).
- [ ] Confirm cross-links from `DATABASE.md` and `ARCHITECTURE.md` resolve.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Crawl Handling reference enumerating domain/page cases, recovery rules, and job/task status mappings.
  * Expanded architecture and database docs to describe per-domain crawl pacing, WAF verdict caching, and an expanded job lifecycle.
  * Updated API and config docs: task status options now include waiting/skipped; archival retention now counts blocked jobs; indexes and doc indices updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->