### PR TITLE
Queue-based autoscaling for worker and analysis

### DIFF
--- a/.fly/review_apps.analysis.toml
+++ b/.fly/review_apps.analysis.toml
@@ -57,6 +57,13 @@ primary_region = "syd"
 [deploy]
   strategy = "immediate"
 
+# Expose the OTel Prometheus exporter to Fly's managed Prometheus so the
+# per-PR autoscaler (hover-autoscaler-analysis-pr-N) can read lighthouse
+# backlog without needing Grafana Cloud Basic-Auth credentials.
+[metrics]
+  port = 9464
+  path = "/metrics"
+
 # Keep the machine restarting after crashes — see fly.analysis.toml for
 # the rationale.
 [[restart]]

--- a/.fly/review_apps.autoscaler-analysis.toml
+++ b/.fly/review_apps.autoscaler-analysis.toml
@@ -1,0 +1,31 @@
+# Per-PR fly-autoscaler instance for hover-analysis-pr-<N>.
+#
+# Production equivalent: fly.autoscaler-analysis.toml.
+# Per-PR app name: hover-autoscaler-analysis-pr-<PR_NUMBER>.
+#
+# Target-specific config (FAS_APP_NAME, FAS_PROMETHEUS_QUERY,
+# FAS_STARTED_MACHINE_COUNT, FAS_API_TOKEN, FAS_PROMETHEUS_TOKEN) is staged
+# via flyctl secrets set in the review-apps workflow's provision job.
+
+primary_region = "syd"
+
+[build]
+  image = "flyio/fly-autoscaler:0.3.1"
+
+[env]
+  FAS_REGIONS = "syd"
+  FAS_INTERVAL = "60s"
+  FAS_PROMETHEUS_ADDRESS = "https://api.fly.io/prometheus/personal"
+  FAS_PROMETHEUS_METRIC_NAME = "lighthouse_backlog"
+
+[metrics]
+  port = 9090
+  path = "/metrics"
+
+[[restart]]
+  policy = "always"
+
+[[vm]]
+  memory = "256mb"
+  cpu_kind = "shared"
+  cpus = 1

--- a/.fly/review_apps.autoscaler-worker.toml
+++ b/.fly/review_apps.autoscaler-worker.toml
@@ -1,0 +1,32 @@
+# Per-PR fly-autoscaler instance for hover-worker-pr-<N>.
+#
+# Production equivalent: fly.autoscaler-worker.toml.
+# Per-PR app name: hover-autoscaler-worker-pr-<PR_NUMBER>.
+#
+# All target-specific config (FAS_APP_NAME, FAS_PROMETHEUS_QUERY,
+# FAS_STARTED_MACHINE_COUNT, FAS_API_TOKEN, FAS_PROMETHEUS_TOKEN) is staged
+# via flyctl secrets set in the review-apps workflow's provision job. This
+# TOML carries only the static, environment-agnostic defaults.
+
+primary_region = "syd"
+
+[build]
+  image = "flyio/fly-autoscaler:0.3.1"
+
+[env]
+  FAS_REGIONS = "syd"
+  FAS_INTERVAL = "60s"
+  FAS_PROMETHEUS_ADDRESS = "https://api.fly.io/prometheus/personal"
+  FAS_PROMETHEUS_METRIC_NAME = "worker_backlog"
+
+[metrics]
+  port = 9090
+  path = "/metrics"
+
+[[restart]]
+  policy = "always"
+
+[[vm]]
+  memory = "256mb"
+  cpu_kind = "shared"
+  cpus = 1

--- a/.fly/review_apps.worker.toml
+++ b/.fly/review_apps.worker.toml
@@ -95,6 +95,13 @@ primary_region = "syd"
 [deploy]
   strategy = "immediate"
 
+# Expose the OTel Prometheus exporter to Fly's managed Prometheus so the
+# per-PR autoscaler (hover-autoscaler-worker-pr-N) can read backlog metrics
+# without needing Grafana Cloud Basic-Auth credentials.
+[metrics]
+  port = 9464
+  path = "/metrics"
+
 # Keep the machine restarting after crashes. Without this, Fly's default
 # on-failure policy gives up after 10 retries — so a transient outage
 # (Redis unreachable, DB not ready yet) can leave the preview worker

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,7 @@
+# Whitelist custom self-hosted runner labels so actionlint doesn't flag
+# them as unknown. This repo uses Blacksmith (https://blacksmith.sh/) for
+# faster CI runners; their labels follow the pattern
+# `blacksmith-<vcpus>vcpu-<os>`.
+self-hosted-runner:
+  labels:
+    - blacksmith-4vcpu-ubuntu-2404

--- a/.github/actions/fly-setup/action.yml
+++ b/.github/actions/fly-setup/action.yml
@@ -84,6 +84,18 @@ runs:
           op://Good Native/hover-stripe/STRIPE_WEBHOOK_SECRET
         STRIPE_PUBLISHABLE_KEY:
           op://Good Native/hover-stripe/STRIPE_PUBLISHABLE_KEY
+        # fly-autoscaler runtime tokens. Production uses app-scoped deploy
+        # tokens for least privilege; review apps reuse the org-scoped
+        # FLY_API_TOKEN above (no separate review-app secrets needed).
+        # Provision FAS_API_TOKEN_WORKER/ANALYSIS via:
+        #   fly tokens create deploy -a hover-worker
+        #   fly tokens create deploy -a hover-analysis
+        # FAS_PROMETHEUS_TOKEN via:
+        #   fly tokens create readonly
+        FAS_API_TOKEN_WORKER: op://Good Native/hover-fly/FAS_API_TOKEN_WORKER
+        FAS_API_TOKEN_ANALYSIS:
+          op://Good Native/hover-fly/FAS_API_TOKEN_ANALYSIS
+        FAS_PROMETHEUS_TOKEN: op://Good Native/hover-fly/FAS_PROMETHEUS_TOKEN
 
     - uses: superfly/flyctl-actions/setup-flyctl@63da3ecc5e2793b98a3f2519b3d75d4f4c11cec2 # pinned
 

--- a/.github/actions/fly-setup/action.yml
+++ b/.github/actions/fly-setup/action.yml
@@ -84,18 +84,11 @@ runs:
           op://Good Native/hover-stripe/STRIPE_WEBHOOK_SECRET
         STRIPE_PUBLISHABLE_KEY:
           op://Good Native/hover-stripe/STRIPE_PUBLISHABLE_KEY
-        # fly-autoscaler runtime tokens. Production uses app-scoped deploy
-        # tokens for least privilege; review apps reuse the org-scoped
-        # FLY_API_TOKEN above (no separate review-app secrets needed).
-        # Provision FAS_API_TOKEN_WORKER/ANALYSIS via:
-        #   fly tokens create deploy -a hover-worker
-        #   fly tokens create deploy -a hover-analysis
-        # FAS_PROMETHEUS_TOKEN via:
-        #   fly tokens create readonly
-        FAS_API_TOKEN_WORKER: op://Good Native/hover-fly/FAS_API_TOKEN_WORKER
-        FAS_API_TOKEN_ANALYSIS:
-          op://Good Native/hover-fly/FAS_API_TOKEN_ANALYSIS
-        FAS_PROMETHEUS_TOKEN: op://Good Native/hover-fly/FAS_PROMETHEUS_TOKEN
+        # fly-autoscaler runtime tokens (FAS_API_TOKEN_WORKER, FAS_API_TOKEN_ANALYSIS,
+        # FAS_PROMETHEUS_TOKEN) are loaded inline by the production-only
+        # release-autoscaler-* jobs in fly-deploy.yml — keeping them out of
+        # this shared composite means review-app CI doesn't need the
+        # 1Password fields to exist.
 
     - uses: superfly/flyctl-actions/setup-flyctl@63da3ecc5e2793b98a3f2519b3d75d4f4c11cec2 # pinned
 

--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -254,6 +254,18 @@ jobs:
 
       - name: Sync secrets to autoscaler app
         run: |
+          # Guard against blank tokens. 1Password's load-secrets-action
+          # fails loudly on missing fields, but an empty-but-present field
+          # would otherwise stage a blank FAS_API_TOKEN and silently break
+          # autoscaler authentication after deploy.
+          if [ -z "$FAS_API_TOKEN_WORKER" ]; then
+            echo "❌ FAS_API_TOKEN_WORKER is empty. Check op://Good Native/hover-fly/FAS_API_TOKEN_WORKER" >&2
+            exit 1
+          fi
+          if [ -z "$FAS_PROMETHEUS_TOKEN" ]; then
+            echo "❌ FAS_PROMETHEUS_TOKEN is empty. Check op://Good Native/hover-fly/FAS_PROMETHEUS_TOKEN" >&2
+            exit 1
+          fi
           flyctl secrets set \
             --app hover-autoscaler-worker \
             FAS_API_TOKEN="$FAS_API_TOKEN_WORKER" \
@@ -290,6 +302,18 @@ jobs:
 
       - name: Sync secrets to autoscaler app
         run: |
+          # Guard against blank tokens. 1Password's load-secrets-action
+          # fails loudly on missing fields, but an empty-but-present field
+          # would otherwise stage a blank FAS_API_TOKEN and silently break
+          # autoscaler authentication after deploy.
+          if [ -z "$FAS_API_TOKEN_ANALYSIS" ]; then
+            echo "❌ FAS_API_TOKEN_ANALYSIS is empty. Check op://Good Native/hover-fly/FAS_API_TOKEN_ANALYSIS" >&2
+            exit 1
+          fi
+          if [ -z "$FAS_PROMETHEUS_TOKEN" ]; then
+            echo "❌ FAS_PROMETHEUS_TOKEN is empty. Check op://Good Native/hover-fly/FAS_PROMETHEUS_TOKEN" >&2
+            exit 1
+          fi
           flyctl secrets set \
             --app hover-autoscaler-analysis \
             FAS_API_TOKEN="$FAS_API_TOKEN_ANALYSIS" \

--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -167,11 +167,15 @@ jobs:
       - name: Release analysis app
         env:
           IMAGE: ${{ needs.build-analysis.outputs.image }}
+          IMAGE_LABEL: deployment-${{ github.run_id }}-${{ github.run_attempt }}
         run: |
           flyctl deploy --image "$IMAGE" \
             --config fly.analysis.toml \
             --app hover-analysis
-          flyctl scale count 1 --process-group analysis -a hover-analysis --yes
+          # Reconcile pre-provisioned pool: reap stale-image machines (the
+          # purpose of the historical `flyctl scale count 1` line — see
+          # PR #369) and top up to 10 stopped clones for fly-autoscaler.
+          bash scripts/fly-reconcile-pool.sh hover-analysis "$IMAGE_LABEL" 10
 
   release-worker:
     name: Release hover-worker
@@ -211,11 +215,69 @@ jobs:
         # both binaries, fly.worker.toml selects the worker entrypoint.
         env:
           IMAGE: ${{ needs.build-shared.outputs.image }}
+          IMAGE_LABEL: deployment-${{ github.run_id }}-${{ github.run_attempt }}
         run: |
           flyctl deploy --image "$IMAGE" \
             --config fly.worker.toml \
             --app hover-worker
-          flyctl scale count 1 --process-group worker -a hover-worker --yes
+          # Reconcile pre-provisioned pool: reap stale-image machines (the
+          # purpose of the historical `flyctl scale count 1` line — see
+          # PR #369) and top up to 5 stopped clones for fly-autoscaler.
+          bash scripts/fly-reconcile-pool.sh hover-worker "$IMAGE_LABEL" 5
+
+  # ───────── Autoscaler release ────────────────────────────────────────
+  # fly-autoscaler 0.3.x targets one Fly app per autoscaler instance, so
+  # worker and analysis each get their own app. Both jobs run after their
+  # target's release succeeds — if the target's pool isn't reconciled,
+  # fly-autoscaler has no machines to start/stop. They run in parallel
+  # since the two autoscaler apps are independent.
+  release-autoscaler-worker:
+    name: Release hover-autoscaler-worker
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    needs: [release-worker]
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/fly-setup
+        with:
+          op-service-account-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+
+      - name: Sync secrets to autoscaler app
+        run: |
+          flyctl secrets set \
+            --app hover-autoscaler-worker \
+            FAS_API_TOKEN="$FAS_API_TOKEN_WORKER" \
+            FAS_PROMETHEUS_TOKEN="$FAS_PROMETHEUS_TOKEN" \
+            --stage
+
+      - name: Deploy hover-autoscaler-worker
+        run: |
+          flyctl deploy \
+            --config fly.autoscaler-worker.toml \
+            --app hover-autoscaler-worker
+
+  release-autoscaler-analysis:
+    name: Release hover-autoscaler-analysis
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    needs: [release-analysis]
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/fly-setup
+        with:
+          op-service-account-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+
+      - name: Sync secrets to autoscaler app
+        run: |
+          flyctl secrets set \
+            --app hover-autoscaler-analysis \
+            FAS_API_TOKEN="$FAS_API_TOKEN_ANALYSIS" \
+            FAS_PROMETHEUS_TOKEN="$FAS_PROMETHEUS_TOKEN" \
+            --stage
+
+      - name: Deploy hover-autoscaler-analysis
+        run: |
+          flyctl deploy \
+            --config fly.autoscaler-analysis.toml \
+            --app hover-autoscaler-analysis
 
   # ───────── Annotation ────────────────────────────────────────────────
   # if: always() so a partial deploy still produces an annotation for
@@ -224,7 +286,14 @@ jobs:
   annotate:
     name: Post deploy annotation to Grafana
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    needs: [release-api, release-analysis, release-worker]
+    needs:
+      [
+        release-api,
+        release-analysis,
+        release-worker,
+        release-autoscaler-worker,
+        release-autoscaler-analysis,
+      ]
     if: always()
     steps:
       - name: Load Grafana annotation secrets

--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -167,11 +167,17 @@ jobs:
       - name: Release analysis app
         env:
           IMAGE: ${{ needs.build-analysis.outputs.image }}
-          IMAGE_LABEL: deployment-${{ github.run_id }}-${{ github.run_attempt }}
         run: |
           flyctl deploy --image "$IMAGE" \
             --config fly.analysis.toml \
             --app hover-analysis
+          # Derive IMAGE_LABEL from the built image tag rather than
+          # github.run_attempt — if this release job is retried, run_attempt
+          # bumps but build-analysis.outputs.image still points to the
+          # prior build's tag. Recomputing IMAGE_LABEL from run_attempt
+          # would cause the reconciler to mistake the just-deployed
+          # machines for stragglers and destroy them.
+          IMAGE_LABEL="${IMAGE##*:}"
           # Reconcile pre-provisioned pool: reap stale-image machines (the
           # purpose of the historical `flyctl scale count 1` line — see
           # PR #369) and top up to 10 stopped clones for fly-autoscaler.
@@ -215,11 +221,13 @@ jobs:
         # both binaries, fly.worker.toml selects the worker entrypoint.
         env:
           IMAGE: ${{ needs.build-shared.outputs.image }}
-          IMAGE_LABEL: deployment-${{ github.run_id }}-${{ github.run_attempt }}
         run: |
           flyctl deploy --image "$IMAGE" \
             --config fly.worker.toml \
             --app hover-worker
+          # Derive IMAGE_LABEL from the built image tag rather than
+          # github.run_attempt — see release-analysis for rationale.
+          IMAGE_LABEL="${IMAGE##*:}"
           # Reconcile pre-provisioned pool: reap stale-image machines (the
           # purpose of the historical `flyctl scale count 1` line — see
           # PR #369) and top up to 5 stopped clones for fly-autoscaler.

--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -241,6 +241,17 @@ jobs:
         with:
           op-service-account-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
 
+      - name: Load fly-autoscaler tokens from 1Password
+        # Loaded inline (not in the shared fly-setup composite) so review-app
+        # CI doesn't need these 1Password fields to exist.
+        uses: 1password/load-secrets-action@v2
+        with:
+          export-env: true
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          FAS_API_TOKEN_WORKER: op://Good Native/hover-fly/FAS_API_TOKEN_WORKER
+          FAS_PROMETHEUS_TOKEN: op://Good Native/hover-fly/FAS_PROMETHEUS_TOKEN
+
       - name: Sync secrets to autoscaler app
         run: |
           flyctl secrets set \
@@ -264,6 +275,18 @@ jobs:
       - uses: ./.github/actions/fly-setup
         with:
           op-service-account-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+
+      - name: Load fly-autoscaler tokens from 1Password
+        # Loaded inline (not in the shared fly-setup composite) so review-app
+        # CI doesn't need these 1Password fields to exist.
+        uses: 1password/load-secrets-action@v2
+        with:
+          export-env: true
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          FAS_API_TOKEN_ANALYSIS:
+            op://Good Native/hover-fly/FAS_API_TOKEN_ANALYSIS
+          FAS_PROMETHEUS_TOKEN: op://Good Native/hover-fly/FAS_PROMETHEUS_TOKEN
 
       - name: Sync secrets to autoscaler app
         run: |

--- a/.github/workflows/review-apps.yml
+++ b/.github/workflows/review-apps.yml
@@ -449,7 +449,7 @@ jobs:
             --app "$AUTOSCALER_ANALYSIS_APP" \
             FAS_APP_NAME="$ANALYSIS_APP" \
             FAS_PROMETHEUS_QUERY="$ANALYSIS_QUERY" \
-            FAS_STARTED_MACHINE_COUNT="max(1, min(10, ceil(lighthouse_backlog / 150)))" \
+            FAS_STARTED_MACHINE_COUNT="max(1, min(10, ceil(lighthouse_backlog / 25)))" \
             FAS_API_TOKEN="$FLY_API_TOKEN" \
             FAS_PROMETHEUS_TOKEN="$FLY_API_TOKEN" \
             --stage

--- a/.github/workflows/review-apps.yml
+++ b/.github/workflows/review-apps.yml
@@ -430,8 +430,11 @@ jobs:
           # Fly's Prometheus query endpoint identically. Production uses
           # app-scoped deploy tokens for least privilege; review apps prefer
           # the org token to avoid token-creation churn per PR.
+          # bee_broker_* metrics come from the worker's broker probe, so
+          # both queries filter by WORKER_APP — we're scaling analysis
+          # based on metrics emitted by worker.
           WORKER_QUERY="sum(bee_broker_stream_length{app=\"${WORKER_APP}\",stream_type=\"worker\"}) + sum(bee_broker_scheduled_zset_depth{app=\"${WORKER_APP}\"})"
-          ANALYSIS_QUERY="sum(bee_broker_stream_length{app=\"${ANALYSIS_APP}\",stream_type=\"lighthouse\"})"
+          ANALYSIS_QUERY="sum(bee_broker_stream_length{app=\"${WORKER_APP}\",stream_type=\"lighthouse\"})"
 
           flyctl secrets set \
             --app "$AUTOSCALER_WORKER_APP" \

--- a/.github/workflows/review-apps.yml
+++ b/.github/workflows/review-apps.yml
@@ -437,7 +437,7 @@ jobs:
             --app "$AUTOSCALER_WORKER_APP" \
             FAS_APP_NAME="$WORKER_APP" \
             FAS_PROMETHEUS_QUERY="$WORKER_QUERY" \
-            FAS_STARTED_MACHINE_COUNT="max(1, min(5, ceil(worker_backlog / 600)))" \
+            FAS_STARTED_MACHINE_COUNT="max(1, min(5, ceil(worker_backlog / 100000)))" \
             FAS_API_TOKEN="$FLY_API_TOKEN" \
             FAS_PROMETHEUS_TOKEN="$FLY_API_TOKEN" \
             --stage

--- a/.github/workflows/review-apps.yml
+++ b/.github/workflows/review-apps.yml
@@ -56,6 +56,9 @@ jobs:
       api_app: ${{ steps.naming.outputs.api_app }}
       worker_app: ${{ steps.naming.outputs.worker_app }}
       analysis_app: ${{ steps.naming.outputs.analysis_app }}
+      autoscaler_worker_app: ${{ steps.naming.outputs.autoscaler_worker_app }}
+      autoscaler_analysis_app:
+        ${{ steps.naming.outputs.autoscaler_analysis_app }}
       api_url: ${{ steps.naming.outputs.api_url }}
     steps:
       - uses: actions/checkout@v6
@@ -95,6 +98,8 @@ jobs:
             echo "api_app=hover-pr-${PR_NUMBER}"
             echo "worker_app=hover-worker-pr-${PR_NUMBER}"
             echo "analysis_app=hover-analysis-pr-${PR_NUMBER}"
+            echo "autoscaler_worker_app=hover-autoscaler-worker-pr-${PR_NUMBER}"
+            echo "autoscaler_analysis_app=hover-autoscaler-analysis-pr-${PR_NUMBER}"
             echo "api_url=https://hover-pr-${PR_NUMBER}.fly.dev"
           } >> "$GITHUB_OUTPUT"
 
@@ -279,10 +284,14 @@ jobs:
           API_APP: ${{ steps.naming.outputs.api_app }}
           WORKER_APP: ${{ steps.naming.outputs.worker_app }}
           ANALYSIS_APP: ${{ steps.naming.outputs.analysis_app }}
+          AUTOSCALER_WORKER_APP:
+            ${{ steps.naming.outputs.autoscaler_worker_app }}
+          AUTOSCALER_ANALYSIS_APP:
+            ${{ steps.naming.outputs.autoscaler_analysis_app }}
         run: |
           # Exact match on app name (column 1). grep -q does substring
           # matching, so hover-pr-12 would falsely match PR 123.
-          for APP in "$API_APP" "$WORKER_APP" "$ANALYSIS_APP"; do
+          for APP in "$API_APP" "$WORKER_APP" "$ANALYSIS_APP" "$AUTOSCALER_WORKER_APP" "$AUTOSCALER_ANALYSIS_APP"; do
             if ! flyctl apps list | awk 'NR>1 {print $1}' | grep -Fxq "$APP"; then
               echo "Creating: $APP"
               flyctl apps create "$APP" --org personal
@@ -402,6 +411,46 @@ jobs:
             GRAFANA_CLOUD_API_KEY="$GRAFANA_CLOUD_API_KEY" \
             --stage
 
+      - name: Stage secrets on autoscaler review apps
+        env:
+          AUTOSCALER_WORKER_APP:
+            ${{ steps.naming.outputs.autoscaler_worker_app }}
+          AUTOSCALER_ANALYSIS_APP:
+            ${{ steps.naming.outputs.autoscaler_analysis_app }}
+          WORKER_APP: ${{ steps.naming.outputs.worker_app }}
+          ANALYSIS_APP: ${{ steps.naming.outputs.analysis_app }}
+        run: |
+          # FAS_APP_NAME and FAS_PROMETHEUS_QUERY embed the per-PR target
+          # name so the review-app autoscaler only acts on its own PR's
+          # workers/analysis machines and reads only its own metrics from
+          # Fly's Prometheus. FAS_STARTED_MACHINE_COUNT mirrors prod.
+          #
+          # Tokens reuse the org-scoped FLY_API_TOKEN (already loaded by
+          # fly-setup): FlyV1 macaroons authenticate the Machines API and
+          # Fly's Prometheus query endpoint identically. Production uses
+          # app-scoped deploy tokens for least privilege; review apps prefer
+          # the org token to avoid token-creation churn per PR.
+          WORKER_QUERY="sum(bee_broker_stream_length{app=\"${WORKER_APP}\",stream_type=\"worker\"}) + sum(bee_broker_scheduled_zset_depth{app=\"${WORKER_APP}\"})"
+          ANALYSIS_QUERY="sum(bee_broker_stream_length{app=\"${ANALYSIS_APP}\",stream_type=\"lighthouse\"})"
+
+          flyctl secrets set \
+            --app "$AUTOSCALER_WORKER_APP" \
+            FAS_APP_NAME="$WORKER_APP" \
+            FAS_PROMETHEUS_QUERY="$WORKER_QUERY" \
+            FAS_STARTED_MACHINE_COUNT="max(1, min(5, ceil(worker_backlog / 600)))" \
+            FAS_API_TOKEN="$FLY_API_TOKEN" \
+            FAS_PROMETHEUS_TOKEN="$FLY_API_TOKEN" \
+            --stage
+
+          flyctl secrets set \
+            --app "$AUTOSCALER_ANALYSIS_APP" \
+            FAS_APP_NAME="$ANALYSIS_APP" \
+            FAS_PROMETHEUS_QUERY="$ANALYSIS_QUERY" \
+            FAS_STARTED_MACHINE_COUNT="max(1, min(10, ceil(lighthouse_backlog / 150)))" \
+            FAS_API_TOKEN="$FLY_API_TOKEN" \
+            FAS_PROMETHEUS_TOKEN="$FLY_API_TOKEN" \
+            --stage
+
   # ───────── Build phase ───────────────────────────────────────────────
   # Two image builds run in parallel, mirroring fly-deploy.yml. The shared
   # image carries both API and worker binaries (Dockerfile lines 19–20),
@@ -503,13 +552,16 @@ jobs:
         env:
           IMAGE: ${{ needs.build-analysis.outputs.image }}
           ANALYSIS_APP: ${{ needs.provision.outputs.analysis_app }}
+          IMAGE_LABEL: ${{ needs.provision.outputs.image_label }}
         run: |
           flyctl deploy \
             --image "$IMAGE" \
             --config .fly/review_apps.analysis.toml \
             --app "$ANALYSIS_APP" \
             --ha=false
-          flyctl scale count 1 --process-group analysis -a "$ANALYSIS_APP" --yes
+          # Reconcile pre-provisioned pool: reap stale-image machines and
+          # top up to 10 stopped clones for the per-PR autoscaler.
+          bash scripts/fly-reconcile-pool.sh "$ANALYSIS_APP" "$IMAGE_LABEL" 10
 
   release-worker:
     name: Release worker review app
@@ -531,13 +583,63 @@ jobs:
         env:
           IMAGE: ${{ needs.build-shared.outputs.image }}
           WORKER_APP: ${{ needs.provision.outputs.worker_app }}
+          IMAGE_LABEL: ${{ needs.provision.outputs.image_label }}
         run: |
           flyctl deploy \
             --image "$IMAGE" \
             --config .fly/review_apps.worker.toml \
             --app "$WORKER_APP" \
             --ha=false
-          flyctl scale count 1 --process-group worker -a "$WORKER_APP" --yes
+          # Reconcile pre-provisioned pool: reap stale-image machines and
+          # top up to 5 stopped clones for the per-PR autoscaler.
+          bash scripts/fly-reconcile-pool.sh "$WORKER_APP" "$IMAGE_LABEL" 5
+
+  # ───────── Autoscaler release ────────────────────────────────────────
+  # One fly-autoscaler app per target (worker / analysis), each scoped to
+  # its own per-PR target via secrets staged in the provision job. They
+  # run after their target's pool is reconciled so the autoscaler always
+  # has machines to start/stop on first poll.
+  release-autoscaler-worker:
+    name: Release worker autoscaler review app
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    needs: [provision, release-worker]
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/fly-setup
+        with:
+          op-service-account-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          validate-redis-url: "false"
+
+      - name: Deploy worker autoscaler review app
+        env:
+          AUTOSCALER_WORKER_APP:
+            ${{ needs.provision.outputs.autoscaler_worker_app }}
+        run: |
+          flyctl deploy \
+            --config .fly/review_apps.autoscaler-worker.toml \
+            --app "$AUTOSCALER_WORKER_APP" \
+            --ha=false
+
+  release-autoscaler-analysis:
+    name: Release analysis autoscaler review app
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    needs: [provision, release-analysis]
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/fly-setup
+        with:
+          op-service-account-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          validate-redis-url: "false"
+
+      - name: Deploy analysis autoscaler review app
+        env:
+          AUTOSCALER_ANALYSIS_APP:
+            ${{ needs.provision.outputs.autoscaler_analysis_app }}
+        run: |
+          flyctl deploy \
+            --config .fly/review_apps.autoscaler-analysis.toml \
+            --app "$AUTOSCALER_ANALYSIS_APP" \
+            --ha=false
 
   # ───────── Comment on PR ─────────────────────────────────────────────
   # Single comment with the API URL — posted only after the API release
@@ -586,6 +688,28 @@ jobs:
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           FLY_API_TOKEN: op://Good Native/hover-fly/FLY_API_TOKEN
+
+      - name: Destroy Autoscaler Review Apps
+        # Tear the autoscalers down BEFORE their targets so they cannot
+        # issue Machines API start/stop calls against apps mid-destroy.
+        env:
+          PR_NUMBER: ${{ github.event.number }}
+        run: |
+          for APP_NAME in "hover-autoscaler-worker-pr-${PR_NUMBER}" "hover-autoscaler-analysis-pr-${PR_NUMBER}"; do
+            if ! APP_LIST=$(flyctl apps list); then
+              echo "❌ flyctl apps list failed — cannot determine cleanup state" >&2
+              exit 1
+            fi
+            if echo "$APP_LIST" | awk 'NR>1 {print $1}' | grep -Fxq "$APP_NAME"; then
+              if ! flyctl apps destroy "$APP_NAME" --yes; then
+                echo "❌ Failed to destroy autoscaler review app: $APP_NAME"
+                exit 1
+              fi
+              echo "✅ Destroyed autoscaler review app: $APP_NAME"
+            else
+              echo "ℹ️ Autoscaler review app does not exist, nothing to clean up: $APP_NAME"
+            fi
+          done
 
       - name: Destroy Analysis Review App
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,32 @@ On merge, CI will:
 
 ## [Unreleased]
 
-_Add unreleased changes here._
+### Added
+
+- Queue-based autoscaling for `hover-worker` and `hover-analysis` via two
+  `flyio/fly-autoscaler:0.3.1` instances. Each polls Fly's managed Prometheus
+  every 60s and starts/stops a pre-provisioned machine pool (5 worker, 10
+  analysis) based on Redis stream backlog. Replaces the static
+  `flyctl scale count 1` lines on both apps. Pre-provisioning + start/stop mode
+  (rather than create/destroy) preserves graceful shutdowns. Per-PR autoscaler
+  variants deploy + tear down with the rest of the review-app lifecycle.
+- New `bee_broker_unclamped_scale_target{stream_type=worker|lighthouse}` gauge
+  surfacing the autoscaler's desired count before its `MAX` clamp, so a Grafana
+  alert can detect chronic saturation ("we'd want N machines but are capped at
+  the pool size").
+- New `[metrics]` blocks on `fly.worker.toml`, `fly.analysis.toml`, and their
+  review-app variants so Fly's managed Prometheus auto-scrapes the OTel exporter
+  at `:9464`. Existing Alloy → Grafana Cloud push is unchanged.
+
+### Changed
+
+- `internal/broker/probe.go` now pipelines the lighthouse stream's `XLEN` and
+  `XPENDING` alongside the worker stream, so `bee_broker_stream_length` and
+  `bee_broker_consumer_pending` carry a `stream_type` attribute.
+- The two `flyctl scale count 1` lines on `hover-worker` and `hover-analysis`
+  release jobs are replaced with `scripts/fly-reconcile-pool.sh`, which reaps
+  stale-image machines (preserving the original PR #369 purpose) and tops up the
+  pre-provisioned pool to its target size.
 
 ## Full changelog history
 

--- a/docs/architecture/CONFIG_REFERENCE.md
+++ b/docs/architecture/CONFIG_REFERENCE.md
@@ -1,6 +1,6 @@
 # Configuration Reference
 
-Last reviewed: 2026-04-21
+Last reviewed: 2026-05-01
 
 Every configurable dial in the application — env vars, hardcoded constants, and
 their relationships. Values reflect production unless noted. For the flat
@@ -390,3 +390,49 @@ Background loops that run independently of the worker pool.
 | `schedulerBatchSize`      | 50    | Max schedulers fetched per tick                                |
 | `completionCheckInterval` | 30s   | How often completed jobs are detected and finalised            |
 | `healthCheckInterval`     | 5 min | How often stale job health is checked                          |
+
+---
+
+## Fly autoscaler
+
+**Source:** `fly.autoscaler-worker.toml`, `fly.autoscaler-analysis.toml`,
+`scripts/fly-reconcile-pool.sh`, `.github/workflows/fly-deploy.yml`,
+`.github/workflows/review-apps.yml`
+
+Two `flyio/fly-autoscaler:0.3.1` instances (one per scaled app) poll Fly's
+managed Prometheus and start/stop machines from a pre-provisioned pool. Pool
+sizing is enforced by the release jobs via `fly-reconcile-pool.sh` — the
+reconciler reaps stale-image machines and tops the pool back up to the target
+count after every deploy.
+
+| Dial                                   | Production value | What it controls                                                              |
+| -------------------------------------- | ---------------- | ----------------------------------------------------------------------------- |
+| `FAS_INTERVAL`                         | 60s              | Poll cadence against Fly's managed Prometheus                                 |
+| `FAS_PROMETHEUS_ADDRESS`               | hardcoded        | `https://api.fly.io/prometheus/personal`                                      |
+| Worker pool ceiling                    | **5**            | Top-up target for `hover-worker` (set in workflow)                            |
+| Worker divisor                         | **100,000**      | `ceil(worker_backlog / 100000)` — set high to keep worker autoscaling dormant |
+| Analysis pool ceiling                  | **10**           | Top-up target for `hover-analysis` (set in workflow)                          |
+| Lighthouse divisor                     | **25**           | `ceil(lighthouse_backlog / 25)` — sized off observed audit p50 ~30s           |
+| `scaleTargetWorkerTasksPerMachine`     | 100,000          | Mirrors the worker divisor; powers `bee_broker_unclamped_scale_target`        |
+| `scaleTargetLighthouseTasksPerMachine` | 25               | Mirrors the lighthouse divisor; powers `bee_broker_unclamped_scale_target`    |
+
+The full expression on each app is
+`max(1, min(POOL_CEILING, ceil(BACKLOG / DIVISOR)))`. With `MIN=1` the pool
+always retains a started machine; with the `min(POOL_CEILING, ...)` clamp the
+desired count cannot exceed the pre-provisioned pool size.
+
+Worker autoscaling is plumbed but effectively dormant — workers are I/O-bound
+and per-job concurrency is bounded by the stream-worker pool config above, so
+adding worker machines doesn't help and risks DB-pool contention. The high
+divisor (100,000) keeps natural traffic at `MIN=1`. If a real saturation case
+emerges, lower the divisor in `fly.autoscaler-worker.toml`.
+
+Saturation against the pool ceiling is observable via
+`bee_broker_unclamped_scale_target{stream_type=worker|lighthouse}` — the desired
+count without the `min(POOL_CEILING, ...)` clamp. Alert on
+`max_over_time(...) > POOL_CEILING` to know when to raise the ceiling.
+
+Per-PR review apps run their own pair of autoscalers
+(`hover-autoscaler-worker-pr-N`, `hover-autoscaler-analysis-pr-N`) with the same
+dials. Per-PR target app names and Prometheus queries are staged via
+`flyctl secrets set` in the review-apps workflow's `provision` job.

--- a/fly.analysis.toml
+++ b/fly.analysis.toml
@@ -68,6 +68,14 @@ primary_region = 'syd'
 [deploy]
   strategy = "immediate"
 
+# Fly's managed Prometheus scrapes every machine that declares this block.
+# bee_broker_* + bee_lighthouse_* metrics from the OTel exporter at :9464
+# land in https://api.fly.io/prometheus/personal so fly-autoscaler can read
+# them. Alloy's separate push to Grafana Cloud is unaffected.
+[metrics]
+  port = 9464
+  path = "/metrics"
+
 [processes]
   # Launch via start-analysis.sh so the Alloy metrics sidecar runs
   # alongside the analysis binary. Running ./analysis directly skips

--- a/fly.autoscaler-analysis.toml
+++ b/fly.autoscaler-analysis.toml
@@ -1,0 +1,35 @@
+# fly.autoscaler-analysis.toml — fly-autoscaler instance scaling hover-analysis.
+#
+# Mirror of fly.autoscaler-worker.toml; see that file for the auth model and
+# mode rationale. Pool ceiling is 10 (vs 5 for worker) because lighthouse
+# audits are the bottleneck during large crawls — see the merge-gate notes.
+
+app = "hover-autoscaler-analysis"
+primary_region = "syd"
+
+[build]
+  image = "flyio/fly-autoscaler:0.3.1"
+
+[env]
+  FAS_APP_NAME = "hover-analysis"
+  FAS_REGIONS = "syd"
+  FAS_INTERVAL = "60s"
+
+  FAS_PROMETHEUS_ADDRESS = "https://api.fly.io/prometheus/personal"
+  FAS_PROMETHEUS_METRIC_NAME = "lighthouse_backlog"
+  FAS_PROMETHEUS_QUERY = "sum(bee_broker_stream_length{app=\"hover-analysis\",stream_type=\"lighthouse\"})"
+
+  # 150 lighthouse tasks per machine before a scale-up trigger. Cap at 10.
+  FAS_STARTED_MACHINE_COUNT = "max(1, min(10, ceil(lighthouse_backlog / 150)))"
+
+[metrics]
+  port = 9090
+  path = "/metrics"
+
+[[restart]]
+  policy = "always"
+
+[[vm]]
+  memory = "256mb"
+  cpu_kind = "shared"
+  cpus = 1

--- a/fly.autoscaler-analysis.toml
+++ b/fly.autoscaler-analysis.toml
@@ -17,7 +17,11 @@ primary_region = "syd"
 
   FAS_PROMETHEUS_ADDRESS = "https://api.fly.io/prometheus/personal"
   FAS_PROMETHEUS_METRIC_NAME = "lighthouse_backlog"
-  FAS_PROMETHEUS_QUERY = "sum(bee_broker_stream_length{app=\"hover-analysis\",stream_type=\"lighthouse\"})"
+  # The broker probe only runs in the worker (cmd/worker/main.go), so the
+  # metric is emitted with app=hover-worker. We're scaling hover-analysis
+  # based on metrics emitted by hover-worker — that's intentional, and the
+  # filter must match the emitter, not the target.
+  FAS_PROMETHEUS_QUERY = "sum(bee_broker_stream_length{app=\"hover-worker\",stream_type=\"lighthouse\"})"
 
   # 150 lighthouse tasks per machine before a scale-up trigger. Cap at 10.
   FAS_STARTED_MACHINE_COUNT = "max(1, min(10, ceil(lighthouse_backlog / 150)))"

--- a/fly.autoscaler-analysis.toml
+++ b/fly.autoscaler-analysis.toml
@@ -23,8 +23,11 @@ primary_region = "syd"
   # filter must match the emitter, not the target.
   FAS_PROMETHEUS_QUERY = "sum(bee_broker_stream_length{app=\"hover-worker\",stream_type=\"lighthouse\"})"
 
-  # 150 lighthouse tasks per machine before a scale-up trigger. Cap at 10.
-  FAS_STARTED_MACHINE_COUNT = "max(1, min(10, ceil(lighthouse_backlog / 150)))"
+  # 25 lighthouse tasks per machine before a scale-up trigger. Cap at 10.
+  # Sized off observed audit durations (p50 ~30s, p90 ~65s) so a single
+  # machine drains ~25 tasks in roughly 12-15 minutes — adding capacity
+  # past that keeps user-perceived wait inside that band.
+  FAS_STARTED_MACHINE_COUNT = "max(1, min(10, ceil(lighthouse_backlog / 25)))"
 
 [metrics]
   port = 9090

--- a/fly.autoscaler-worker.toml
+++ b/fly.autoscaler-worker.toml
@@ -31,11 +31,13 @@ primary_region = "syd"
   FAS_PROMETHEUS_METRIC_NAME = "worker_backlog"
   FAS_PROMETHEUS_QUERY = "sum(bee_broker_stream_length{app=\"hover-worker\",stream_type=\"worker\"}) + sum(bee_broker_scheduled_zset_depth{app=\"hover-worker\"})"
 
-  # Started-machine count (start/stop existing pool, never create new).
-  # min(MAX, ceil(backlog / 600)) caps at the pool size; max(...,1) keeps a
-  # warm worker at idle. fly-autoscaler clamps further to len(pool) so a
-  # malformed expression cannot exceed the pre-provisioned ceiling.
-  FAS_STARTED_MACHINE_COUNT = "max(1, min(5, ceil(worker_backlog / 600)))"
+  # Worker autoscaling is plumbed but effectively dormant. The crawl
+  # workers are I/O-bound and per-job concurrency is bounded by
+  # GNH_MAX_WORKERS, so adding worker machines doesn't help (and risks
+  # hurting via DB-pool contention). The divisor is set high enough that
+  # natural traffic stays at MIN=1; if a real saturation case emerges, the
+  # plumbing is here to dial it in by lowering the divisor.
+  FAS_STARTED_MACHINE_COUNT = "max(1, min(5, ceil(worker_backlog / 100000)))"
 
 [metrics]
   port = 9090

--- a/fly.autoscaler-worker.toml
+++ b/fly.autoscaler-worker.toml
@@ -1,0 +1,50 @@
+# fly.autoscaler-worker.toml — fly-autoscaler instance scaling hover-worker.
+#
+# fly-autoscaler 0.3.x targets a single Fly app per autoscaler instance, so
+# the worker and analysis apps each get their own autoscaler app. This one
+# starts/stops machines on hover-worker based on the crawl backlog measured
+# by the broker probe.
+#
+# Auth model:
+# - FAS_API_TOKEN — deploy token scoped to hover-worker, lets the autoscaler
+#   call the Machines API. Loaded from 1Password via flyctl secrets in CI.
+# - FAS_PROMETHEUS_TOKEN — read-only token for Fly's managed Prometheus.
+#
+# Mode: FAS_STARTED_MACHINE_COUNT (start/stop pre-provisioned pool). The
+# pool size on hover-worker is the hard cap on horizontal scaling — see
+# the merge-gate notes for pool sizing (5 worker machines).
+
+app = "hover-autoscaler-worker"
+primary_region = "syd"
+
+[build]
+  image = "flyio/fly-autoscaler:0.3.1"
+
+[env]
+  FAS_APP_NAME = "hover-worker"
+  FAS_REGIONS = "syd"
+  FAS_INTERVAL = "60s"
+
+  # Fly's managed Prometheus. Auto-scrapes worker machines via the
+  # [metrics] block in fly.worker.toml. Token is FlyV1 readonly.
+  FAS_PROMETHEUS_ADDRESS = "https://api.fly.io/prometheus/personal"
+  FAS_PROMETHEUS_METRIC_NAME = "worker_backlog"
+  FAS_PROMETHEUS_QUERY = "sum(bee_broker_stream_length{app=\"hover-worker\",stream_type=\"worker\"}) + sum(bee_broker_scheduled_zset_depth{app=\"hover-worker\"})"
+
+  # Started-machine count (start/stop existing pool, never create new).
+  # min(MAX, ceil(backlog / 600)) caps at the pool size; max(...,1) keeps a
+  # warm worker at idle. fly-autoscaler clamps further to len(pool) so a
+  # malformed expression cannot exceed the pre-provisioned ceiling.
+  FAS_STARTED_MACHINE_COUNT = "max(1, min(5, ceil(worker_backlog / 600)))"
+
+[metrics]
+  port = 9090
+  path = "/metrics"
+
+[[restart]]
+  policy = "always"
+
+[[vm]]
+  memory = "256mb"
+  cpu_kind = "shared"
+  cpus = 1

--- a/fly.worker.toml
+++ b/fly.worker.toml
@@ -125,6 +125,15 @@ primary_region = 'syd'
 [deploy]
   strategy = "immediate"
 
+# Fly's managed Prometheus scrapes every machine that declares this block.
+# bee_broker_* + bee_worker_* metrics from the OTel exporter at :9464 land
+# in https://api.fly.io/prometheus/personal so fly-autoscaler can read them
+# without Grafana Cloud Basic-Auth gymnastics. Alloy's separate push to
+# Grafana Cloud is unaffected.
+[metrics]
+  port = 9464
+  path = "/metrics"
+
 [processes]
   # Launch via start.sh so the Alloy metrics sidecar runs alongside the
   # worker binary. Running ./worker directly skips Alloy, which silently

--- a/internal/broker/probe.go
+++ b/internal/broker/probe.go
@@ -127,7 +127,11 @@ func (p *Probe) probeJobs(ctx context.Context) {
 	}
 
 	// Per-job labels removed to bound Mimir series cardinality.
+	// anySuccess gates publication so a whole-Redis outage produces a
+	// series gap rather than zero readings — otherwise the new
+	// fly-autoscaler reads worker_backlog=0 and falsely scales down.
 	var totals observability.BrokerStreamStats
+	anySuccess := false
 	for _, jobID := range jobIDs {
 		if ctx.Err() != nil {
 			return
@@ -136,11 +140,15 @@ func (p *Probe) probeJobs(ctx context.Context) {
 		if !ok {
 			continue
 		}
+		anySuccess = true
 		totals.WorkerStreamLength += stats.workerStreamLen
 		totals.WorkerScheduledDepth += stats.workerZDepth
 		totals.WorkerPending += stats.workerPending
 		totals.LighthouseStreamLength += stats.lighthouseStreamLen
 		totals.LighthousePending += stats.lighthousePending
+	}
+	if !anySuccess && len(jobIDs) > 0 {
+		return
 	}
 	observability.RecordBrokerStreamStats(ctx, totals)
 }

--- a/internal/broker/probe.go
+++ b/internal/broker/probe.go
@@ -132,38 +132,54 @@ func (p *Probe) probeJobs(ctx context.Context) {
 		if ctx.Err() != nil {
 			return
 		}
-		streamLen, zDepth, pendingCount, ok := p.probeJob(ctx, jobID)
+		stats, ok := p.probeJob(ctx, jobID)
 		if !ok {
 			continue
 		}
-		totals.StreamLength += streamLen
-		totals.ScheduledDepth += zDepth
-		totals.Pending += pendingCount
+		totals.WorkerStreamLength += stats.workerStreamLen
+		totals.WorkerScheduledDepth += stats.workerZDepth
+		totals.WorkerPending += stats.workerPending
+		totals.LighthouseStreamLength += stats.lighthouseStreamLen
+		totals.LighthousePending += stats.lighthousePending
 	}
 	observability.RecordBrokerStreamStats(ctx, totals)
 }
 
+type jobProbeStats struct {
+	workerStreamLen     int64
+	workerZDepth        int64
+	workerPending       int64
+	lighthouseStreamLen int64
+	lighthousePending   int64
+}
+
 // One pipelined RTT per job. ok=false on non-NOGROUP errors so a Redis
 // outage produces a series gap, not false zeroes.
-func (p *Probe) probeJob(ctx context.Context, jobID string) (streamLen, zDepth, pendingCount int64, ok bool) {
+func (p *Probe) probeJob(ctx context.Context, jobID string) (jobProbeStats, bool) {
 	pipe := p.client.rdb.Pipeline()
-	streamLenCmd := pipe.XLen(ctx, StreamKey(jobID))
+	workerStreamCmd := pipe.XLen(ctx, StreamKey(jobID))
 	zsetCmd := pipe.ZCard(ctx, ScheduleKey(jobID))
-	pendingCmd := pipe.XPending(ctx, StreamKey(jobID), ConsumerGroup(jobID))
+	workerPendingCmd := pipe.XPending(ctx, StreamKey(jobID), ConsumerGroup(jobID))
+	lighthouseStreamCmd := pipe.XLen(ctx, LighthouseStreamKey(jobID))
+	lighthousePendingCmd := pipe.XPending(ctx, LighthouseStreamKey(jobID), LighthouseConsumerGroup(jobID))
 
 	if _, err := pipe.Exec(ctx); err != nil {
-		// NOGROUP is expected before the first dispatch.
+		// NOGROUP is expected before the first dispatch on either stream.
 		if !isNoGroupErr(err) {
 			brokerLog.Debug("broker probe pipeline error", "error", err, "job_id", jobID)
-			return 0, 0, 0, false
+			return jobProbeStats{}, false
 		}
 	}
 
-	streamLen, _ = streamLenCmd.Result()
-	zDepth, _ = zsetCmd.Result()
-
-	if pending, err := pendingCmd.Result(); err == nil && pending != nil {
-		pendingCount = pending.Count
+	var stats jobProbeStats
+	stats.workerStreamLen, _ = workerStreamCmd.Result()
+	stats.workerZDepth, _ = zsetCmd.Result()
+	if pending, err := workerPendingCmd.Result(); err == nil && pending != nil {
+		stats.workerPending = pending.Count
 	}
-	return streamLen, zDepth, pendingCount, true
+	stats.lighthouseStreamLen, _ = lighthouseStreamCmd.Result()
+	if pending, err := lighthousePendingCmd.Result(); err == nil && pending != nil {
+		stats.lighthousePending = pending.Count
+	}
+	return stats, true
 }

--- a/internal/observability/observability.go
+++ b/internal/observability/observability.go
@@ -1137,8 +1137,14 @@ type BrokerStreamStats struct {
 // fly-autoscaler thresholds. Kept in code so the unclamped_scale_target
 // gauge can be derived from the same backlog signal the autoscaler uses,
 // and a Grafana saturation alert can compare it against MAX.
+//
+// Worker autoscaling is plumbed but effectively dormant — workers are
+// I/O-bound and per-job concurrency is bounded by GNH_MAX_WORKERS, so
+// horizontal worker scaling doesn't help. The divisor here mirrors the
+// fly-autoscaler config (fly.autoscaler-worker.toml) so the saturation
+// gauge stays consistent with what the autoscaler is actually doing.
 const (
-	scaleTargetWorkerTasksPerMachine     = 600
+	scaleTargetWorkerTasksPerMachine     = 100000
 	scaleTargetLighthouseTasksPerMachine = 150
 )
 

--- a/internal/observability/observability.go
+++ b/internal/observability/observability.go
@@ -128,12 +128,13 @@ var (
 	fdLimitGauge    metric.Int64Gauge
 	fdPressureGauge metric.Float64Gauge
 
-	brokerStreamLengthGauge    metric.Int64Gauge
-	brokerScheduledDepthGauge  metric.Int64Gauge
-	brokerConsumerPendingGauge metric.Int64Gauge
-	brokerOutboxBacklogGauge   metric.Int64Gauge
-	brokerOutboxAgeGauge       metric.Float64Gauge
-	brokerRedisPingHistogram   metric.Float64Histogram
+	brokerStreamLengthGauge         metric.Int64Gauge
+	brokerScheduledDepthGauge       metric.Int64Gauge
+	brokerConsumerPendingGauge      metric.Int64Gauge
+	brokerUnclampedScaleTargetGauge metric.Float64Gauge
+	brokerOutboxBacklogGauge        metric.Int64Gauge
+	brokerOutboxAgeGauge            metric.Float64Gauge
+	brokerRedisPingHistogram        metric.Float64Histogram
 
 	brokerDispatchCounter    metric.Int64Counter
 	brokerOutboxSweepCounter metric.Int64Counter
@@ -988,6 +989,14 @@ func initBrokerInstruments(meterProvider *sdkmetric.MeterProvider) error {
 		return err
 	}
 
+	brokerUnclampedScaleTargetGauge, err = meter.Float64Gauge(
+		"bee.broker.unclamped_scale_target",
+		metric.WithDescription("Desired machine count for this stream type before fly-autoscaler MAX clamp; saturation alert fires when this exceeds MAX"),
+	)
+	if err != nil {
+		return err
+	}
+
 	brokerOutboxBacklogGauge, err = meter.Int64Gauge(
 		"bee.broker.outbox_backlog",
 		metric.WithDescription("Rows currently in task_outbox awaiting dispatch"),
@@ -1113,23 +1122,67 @@ func initBrokerInstruments(meterProvider *sdkmetric.MeterProvider) error {
 
 // Pre-aggregated across active jobs; the per-job job.id label was dropped
 // for Mimir cardinality and dashboards already used sum(...).
+//
+// Worker covers the crawl stream (XLEN), schedule ZSET (ZCARD), and worker
+// consumer-group pending. Lighthouse covers only the lighthouse stream and
+// its consumer-group pending — there is no lighthouse ZSET.
 type BrokerStreamStats struct {
-	StreamLength   int64
-	ScheduledDepth int64
-	Pending        int64
+	WorkerStreamLength     int64
+	WorkerScheduledDepth   int64
+	WorkerPending          int64
+	LighthouseStreamLength int64
+	LighthousePending      int64
 }
+
+// fly-autoscaler thresholds. Kept in code so the unclamped_scale_target
+// gauge can be derived from the same backlog signal the autoscaler uses,
+// and a Grafana saturation alert can compare it against MAX.
+const (
+	scaleTargetWorkerTasksPerMachine     = 600
+	scaleTargetLighthouseTasksPerMachine = 150
+)
+
+var (
+	streamTypeWorker     = attribute.String("stream_type", "worker")
+	streamTypeLighthouse = attribute.String("stream_type", "lighthouse")
+)
 
 // Per-job drill-down lives on traces/logs (which carry job_id), not metrics.
 func RecordBrokerStreamStats(ctx context.Context, s BrokerStreamStats) {
+	workerOpt := metric.WithAttributes(streamTypeWorker)
+	lighthouseOpt := metric.WithAttributes(streamTypeLighthouse)
+
 	if brokerStreamLengthGauge != nil {
-		brokerStreamLengthGauge.Record(ctx, s.StreamLength)
+		brokerStreamLengthGauge.Record(ctx, s.WorkerStreamLength, workerOpt)
+		brokerStreamLengthGauge.Record(ctx, s.LighthouseStreamLength, lighthouseOpt)
 	}
 	if brokerScheduledDepthGauge != nil {
-		brokerScheduledDepthGauge.Record(ctx, s.ScheduledDepth)
+		brokerScheduledDepthGauge.Record(ctx, s.WorkerScheduledDepth)
 	}
 	if brokerConsumerPendingGauge != nil {
-		brokerConsumerPendingGauge.Record(ctx, s.Pending)
+		brokerConsumerPendingGauge.Record(ctx, s.WorkerPending, workerOpt)
+		brokerConsumerPendingGauge.Record(ctx, s.LighthousePending, lighthouseOpt)
 	}
+	if brokerUnclampedScaleTargetGauge != nil {
+		workerBacklog := s.WorkerStreamLength + s.WorkerScheduledDepth
+		lighthouseBacklog := s.LighthouseStreamLength
+		brokerUnclampedScaleTargetGauge.Record(ctx, ceilDiv(workerBacklog, scaleTargetWorkerTasksPerMachine), workerOpt)
+		brokerUnclampedScaleTargetGauge.Record(ctx, ceilDiv(lighthouseBacklog, scaleTargetLighthouseTasksPerMachine), lighthouseOpt)
+	}
+}
+
+// ceilDiv returns ⌈n/d⌉ as a float64 with a floor of 1 — fly-autoscaler's
+// expression has MIN=1, so the unclamped gauge mirrors that lower bound and
+// only the upper-bound saturation against MAX is interesting for alerting.
+func ceilDiv(n, d int64) float64 {
+	if d <= 0 || n <= 0 {
+		return 1
+	}
+	v := (n + d - 1) / d
+	if v < 1 {
+		return 1
+	}
+	return float64(v)
 }
 
 func RecordBrokerOutbox(ctx context.Context, backlog int64, oldestAgeSeconds float64) {

--- a/internal/observability/observability.go
+++ b/internal/observability/observability.go
@@ -1145,7 +1145,7 @@ type BrokerStreamStats struct {
 // gauge stays consistent with what the autoscaler is actually doing.
 const (
 	scaleTargetWorkerTasksPerMachine     = 100000
-	scaleTargetLighthouseTasksPerMachine = 150
+	scaleTargetLighthouseTasksPerMachine = 25
 )
 
 var (

--- a/scripts/fly-reconcile-pool.sh
+++ b/scripts/fly-reconcile-pool.sh
@@ -101,6 +101,22 @@ fi
 # machine in stopped state.
 MACHINES_JSON=$(flyctl machines list -a "$APP" --json)
 CURRENT_COUNT=$(echo "$MACHINES_JSON" | jq -r 'length')
+STARTED_COUNT=$(echo "$MACHINES_JSON" | jq -r '[.[] | select(.state == "started")] | length')
+
+# Enforce the "at least one started machine" baseline regardless of pool
+# size — fly-autoscaler's MIN=1 is supposed to keep one running, but a
+# misconfigured autoscaler or manual intervention can leave the whole pool
+# stopped, breaking the API → dispatcher → worker chain.
+if [ "$STARTED_COUNT" -eq 0 ]; then
+  START_ID=$(echo "$MACHINES_JSON" | jq -r 'first(.[] | select(.state == "stopped") | .id) // empty')
+  if [ -z "$START_ID" ]; then
+    echo "❌ No started or stopped machine available to maintain the running baseline." >&2
+    flyctl machines list -a "$APP" >&2 || true
+    exit 1
+  fi
+  echo "▶️  No started machine — starting $START_ID to maintain baseline."
+  flyctl machine start "$START_ID" -a "$APP"
+fi
 
 if [ "$CURRENT_COUNT" -ge "$POOL_SIZE" ]; then
   echo "✅ Pool already at $CURRENT_COUNT machines (target: $POOL_SIZE) — no top-up needed."

--- a/scripts/fly-reconcile-pool.sh
+++ b/scripts/fly-reconcile-pool.sh
@@ -100,7 +100,10 @@ fi
 # --ha=false + immediate strategy on an existing pool can leave every
 # machine in stopped state.
 MACHINES_JSON=$(flyctl machines list -a "$APP" --json)
-CURRENT_COUNT=$(echo "$MACHINES_JSON" | jq -r 'length')
+# Exclude destroy-state machines from the pool count — Phase 1 destroys
+# may still surface briefly as `destroying` here and would otherwise
+# inflate CURRENT_COUNT and skip a needed top-up.
+CURRENT_COUNT=$(echo "$MACHINES_JSON" | jq -r '[.[] | select(.state != "destroyed" and .state != "destroying")] | length')
 STARTED_COUNT=$(echo "$MACHINES_JSON" | jq -r '[.[] | select(.state == "started")] | length')
 
 # Enforce the "at least one started machine" baseline regardless of pool

--- a/scripts/fly-reconcile-pool.sh
+++ b/scripts/fly-reconcile-pool.sh
@@ -116,12 +116,19 @@ fi
 NEEDED=$((POOL_SIZE - CURRENT_COUNT))
 echo "➕ Cloning $NEEDED stopped machine(s) from $RUNNING_ID to reach pool size $POOL_SIZE."
 
+# flyctl machine clone has no --json flag, so identify the new machine
+# by diffing the machine list before and after each clone.
 for i in $(seq 1 "$NEEDED"); do
   echo "  Clone $i/$NEEDED..."
-  CLONE_JSON=$(flyctl machine clone "$RUNNING_ID" -a "$APP" --region syd --json)
-  CLONE_ID=$(echo "$CLONE_JSON" | jq -r '.id')
-  if [ -z "$CLONE_ID" ] || [ "$CLONE_ID" = "null" ]; then
-    echo "  ❌ Clone failed: $CLONE_JSON" >&2
+  BEFORE_IDS=$(flyctl machines list -a "$APP" --json | jq -r '.[].id' | sort)
+  if ! flyctl machine clone "$RUNNING_ID" -a "$APP" --region syd; then
+    echo "  ❌ Clone command failed." >&2
+    exit 1
+  fi
+  AFTER_IDS=$(flyctl machines list -a "$APP" --json | jq -r '.[].id' | sort)
+  CLONE_ID=$(comm -13 <(echo "$BEFORE_IDS") <(echo "$AFTER_IDS") | head -n1)
+  if [ -z "$CLONE_ID" ]; then
+    echo "  ❌ Could not identify cloned machine — no new ID appeared in machine list." >&2
     exit 1
   fi
   flyctl machine stop "$CLONE_ID" -a "$APP"

--- a/scripts/fly-reconcile-pool.sh
+++ b/scripts/fly-reconcile-pool.sh
@@ -66,8 +66,20 @@ fi
 # rather than full image name so registry-host changes don't trip false
 # positives. fly-autoscaler-managed clones inherit the parent's image, so
 # they're identified by the same label.
+#
+# Safety guard: if zero machines currently report the target IMAGE_LABEL,
+# something is off (caller passed wrong label, Fly API hasn't yet caught
+# up). Aborting beats wiping the entire pool.
+TARGET_MATCH_COUNT=$(echo "$MACHINES_JSON" \
+  | jq -r --arg label "$IMAGE_LABEL" '[.[] | select((.config.image // "") | endswith(":" + $label))] | length')
+if [ "$TARGET_MATCH_COUNT" -eq 0 ]; then
+  echo "❌ No machine on $APP currently reports image label $IMAGE_LABEL — aborting before we destroy the running pool." >&2
+  flyctl machines list -a "$APP" >&2 || true
+  exit 1
+fi
+
 STALE_IDS=$(echo "$MACHINES_JSON" \
-  | jq -r --arg label "$IMAGE_LABEL" '.[] | select(.config.image | endswith(":" + $label) | not) | .id')
+  | jq -r --arg label "$IMAGE_LABEL" '.[] | select((.config.image // "") | endswith(":" + $label) | not) | .id')
 
 if [ -n "$STALE_IDS" ]; then
   echo "🗑  Destroying stale-image machines:"
@@ -90,10 +102,12 @@ fi
 # when the app has no [http_service] health check. Poll for up to 60s so
 # we don't race the launch.
 RUNNING_ID=""
+SOURCE_REGION=""
 for attempt in $(seq 1 12); do
   MACHINES_JSON=$(flyctl machines list -a "$APP" --json)
   RUNNING_ID=$(echo "$MACHINES_JSON" | jq -r 'first(.[] | select(.state == "started") | .id) // empty')
   if [ -n "$RUNNING_ID" ]; then
+    SOURCE_REGION=$(echo "$MACHINES_JSON" | jq -r --arg id "$RUNNING_ID" 'first(.[] | select(.id == $id) | .region) // empty')
     break
   fi
   echo "⏳ No started machine yet (attempt $attempt/12) — waiting 5s..."
@@ -103,6 +117,10 @@ done
 if [ -z "$RUNNING_ID" ]; then
   echo "❌ No started machine found on $APP after 60s — cannot clone pool. Did the deploy succeed?" >&2
   flyctl machines list -a "$APP" >&2 || true
+  exit 1
+fi
+if [ -z "$SOURCE_REGION" ]; then
+  echo "❌ Could not determine region of source machine $RUNNING_ID." >&2
   exit 1
 fi
 
@@ -125,13 +143,14 @@ for i in $(seq 1 "$NEEDED"); do
   for clone_attempt in 1 2 3; do
     echo "  Clone $i/$NEEDED (attempt $clone_attempt/3)..."
     BEFORE_IDS=$(flyctl machines list -a "$APP" --json | jq -r '.[].id' | sort)
-    if flyctl machine clone "$RUNNING_ID" -a "$APP" --region syd; then
+    if flyctl machine clone "$RUNNING_ID" -a "$APP" --region "$SOURCE_REGION"; then
       AFTER_IDS=$(flyctl machines list -a "$APP" --json | jq -r '.[].id' | sort)
       CLONE_ID=$(comm -13 <(echo "$BEFORE_IDS") <(echo "$AFTER_IDS") | head -n1)
       if [ -n "$CLONE_ID" ]; then
         break
       fi
-      echo "  ⚠️  Clone command succeeded but no new machine appeared — retrying..." >&2
+      echo "  ⚠️  Clone command succeeded but no new machine appeared — retrying after 3s..." >&2
+      sleep 3
     else
       echo "  ⚠️  Clone command failed (likely transient Fly error) — retrying after 10s..." >&2
       sleep 10

--- a/scripts/fly-reconcile-pool.sh
+++ b/scripts/fly-reconcile-pool.sh
@@ -93,37 +93,13 @@ else
   echo "✅ No stale-image machines to reap."
 fi
 
-# Phase 2 — top up the pool. Pick any running machine as the clone source;
-# fly machine clone copies the source's image + config, so as long as the
-# source is on IMAGE_LABEL (post-Phase 1 it must be), the clone is too.
-#
-# On a brand-new app's first deploy, `flyctl deploy --ha=false` returns as
-# soon as the machine is created — it doesn't wait for the started state
-# when the app has no [http_service] health check. Poll for up to 60s so
-# we don't race the launch.
-RUNNING_ID=""
-SOURCE_REGION=""
-for attempt in $(seq 1 12); do
-  MACHINES_JSON=$(flyctl machines list -a "$APP" --json)
-  RUNNING_ID=$(echo "$MACHINES_JSON" | jq -r 'first(.[] | select(.state == "started") | .id) // empty')
-  if [ -n "$RUNNING_ID" ]; then
-    SOURCE_REGION=$(echo "$MACHINES_JSON" | jq -r --arg id "$RUNNING_ID" 'first(.[] | select(.id == $id) | .region) // empty')
-    break
-  fi
-  echo "⏳ No started machine yet (attempt $attempt/12) — waiting 5s..."
-  sleep 5
-done
-
-if [ -z "$RUNNING_ID" ]; then
-  echo "❌ No started machine found on $APP after 60s — cannot clone pool. Did the deploy succeed?" >&2
-  flyctl machines list -a "$APP" >&2 || true
-  exit 1
-fi
-if [ -z "$SOURCE_REGION" ]; then
-  echo "❌ Could not determine region of source machine $RUNNING_ID." >&2
-  exit 1
-fi
-
+# Phase 2 — top up the pool. If the pool is already at target size we're
+# done; we don't need a clone source. Otherwise pick any non-destroyed
+# machine to clone from. flyctl machine clone works on stopped sources
+# too, so we don't require a "started" machine — a deploy with
+# --ha=false + immediate strategy on an existing pool can leave every
+# machine in stopped state.
+MACHINES_JSON=$(flyctl machines list -a "$APP" --json)
 CURRENT_COUNT=$(echo "$MACHINES_JSON" | jq -r 'length')
 
 if [ "$CURRENT_COUNT" -ge "$POOL_SIZE" ]; then
@@ -131,8 +107,22 @@ if [ "$CURRENT_COUNT" -ge "$POOL_SIZE" ]; then
   exit 0
 fi
 
+# Need to clone — pick any non-destroyed machine as the source. Prefer a
+# started one (faster clone path) but fall back to stopped/created.
+SOURCE_ID=$(echo "$MACHINES_JSON" | jq -r 'first(.[] | select(.state == "started") | .id) // first(.[] | select(.state == "stopped") | .id) // first(.[] | select(.state == "created") | .id) // empty')
+if [ -z "$SOURCE_ID" ]; then
+  echo "❌ No clone source available on $APP — every machine is in a destroyed/destroying state. Did the deploy succeed?" >&2
+  flyctl machines list -a "$APP" >&2 || true
+  exit 1
+fi
+SOURCE_REGION=$(echo "$MACHINES_JSON" | jq -r --arg id "$SOURCE_ID" 'first(.[] | select(.id == $id) | .region) // empty')
+if [ -z "$SOURCE_REGION" ]; then
+  echo "❌ Could not determine region of source machine $SOURCE_ID." >&2
+  exit 1
+fi
+
 NEEDED=$((POOL_SIZE - CURRENT_COUNT))
-echo "➕ Cloning $NEEDED stopped machine(s) from $RUNNING_ID to reach pool size $POOL_SIZE."
+echo "➕ Cloning $NEEDED machine(s) from $SOURCE_ID (region $SOURCE_REGION) to reach pool size $POOL_SIZE."
 
 # flyctl machine clone has no --json flag, so identify the new machine
 # by diffing the machine list before and after each clone. Retry on
@@ -143,7 +133,7 @@ for i in $(seq 1 "$NEEDED"); do
   for clone_attempt in 1 2 3; do
     echo "  Clone $i/$NEEDED (attempt $clone_attempt/3)..."
     BEFORE_IDS=$(flyctl machines list -a "$APP" --json | jq -r '.[].id' | sort)
-    if flyctl machine clone "$RUNNING_ID" -a "$APP" --region "$SOURCE_REGION"; then
+    if flyctl machine clone "$SOURCE_ID" -a "$APP" --region "$SOURCE_REGION"; then
       # Clone command accepted. Poll the machine list for visibility —
       # never re-run the clone command on this path, since that would
       # create a duplicate if the API is just slow to surface the new ID.

--- a/scripts/fly-reconcile-pool.sh
+++ b/scripts/fly-reconcile-pool.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+# Reconcile a Fly app's machine pool to (1 running + N-1 stopped) on the
+# just-released image. Replaces the historical `flyctl scale count` line in
+# CI release jobs (PR #369): keeps the stale-image reap behaviour while
+# allowing pre-provisioned stopped machines for fly-autoscaler to start.
+#
+# Idempotent — safe to run on every deploy. If the pool is already correct,
+# the script is a no-op.
+#
+# Usage:
+#   fly-reconcile-pool.sh APP IMAGE_LABEL POOL_SIZE
+#
+# Example:
+#   fly-reconcile-pool.sh hover-worker deployment-12345-1 5
+#
+# Behaviour:
+#   1. Destroys any machine whose image label != IMAGE_LABEL (running or
+#      stopped). This reaps the stragglers PR #369 was guarding against.
+#   2. Tops up the pool to POOL_SIZE by cloning the live machine and
+#      stopping the clones. New clones inherit the just-released image,
+#      so they're already on the latest version.
+#
+# Requires: flyctl, jq.
+
+set -euo pipefail
+
+if [ "$#" -ne 3 ]; then
+  echo "usage: $0 APP IMAGE_LABEL POOL_SIZE" >&2
+  exit 2
+fi
+
+APP="$1"
+IMAGE_LABEL="$2"
+POOL_SIZE="$3"
+
+if ! [[ "$POOL_SIZE" =~ ^[0-9]+$ ]] || [ "$POOL_SIZE" -lt 1 ]; then
+  echo "POOL_SIZE must be a positive integer, got: $POOL_SIZE" >&2
+  exit 2
+fi
+
+echo "🔍 Reconciling $APP to pool size $POOL_SIZE on image label $IMAGE_LABEL"
+
+MACHINES_JSON=$(flyctl machines list -a "$APP" --json)
+
+# Phase 1 — destroy stale-image machines. Match on image label suffix
+# rather than full image name so registry-host changes don't trip false
+# positives. fly-autoscaler-managed clones inherit the parent's image, so
+# they're identified by the same label.
+STALE_IDS=$(echo "$MACHINES_JSON" \
+  | jq -r --arg label "$IMAGE_LABEL" '.[] | select(.config.image | endswith(":" + $label) | not) | .id')
+
+if [ -n "$STALE_IDS" ]; then
+  echo "🗑  Destroying stale-image machines:"
+  echo "$STALE_IDS"
+  for id in $STALE_IDS; do
+    flyctl machine destroy "$id" -a "$APP" --force
+  done
+  # Refresh after destroys.
+  MACHINES_JSON=$(flyctl machines list -a "$APP" --json)
+else
+  echo "✅ No stale-image machines to reap."
+fi
+
+# Phase 2 — top up the pool. Pick any running machine as the clone source;
+# fly machine clone copies the source's image + config, so as long as the
+# source is on IMAGE_LABEL (post-Phase 1 it must be), the clone is too.
+CURRENT_COUNT=$(echo "$MACHINES_JSON" | jq -r 'length')
+RUNNING_ID=$(echo "$MACHINES_JSON" | jq -r 'first(.[] | select(.state == "started") | .id) // empty')
+
+if [ -z "$RUNNING_ID" ]; then
+  echo "❌ No started machine found on $APP — cannot clone pool. Did the deploy succeed?" >&2
+  exit 1
+fi
+
+if [ "$CURRENT_COUNT" -ge "$POOL_SIZE" ]; then
+  echo "✅ Pool already at $CURRENT_COUNT machines (target: $POOL_SIZE) — no top-up needed."
+  exit 0
+fi
+
+NEEDED=$((POOL_SIZE - CURRENT_COUNT))
+echo "➕ Cloning $NEEDED stopped machine(s) from $RUNNING_ID to reach pool size $POOL_SIZE."
+
+for i in $(seq 1 "$NEEDED"); do
+  echo "  Clone $i/$NEEDED..."
+  CLONE_JSON=$(flyctl machine clone "$RUNNING_ID" -a "$APP" --region syd --json)
+  CLONE_ID=$(echo "$CLONE_JSON" | jq -r '.id')
+  if [ -z "$CLONE_ID" ] || [ "$CLONE_ID" = "null" ]; then
+    echo "  ❌ Clone failed: $CLONE_JSON" >&2
+    exit 1
+  fi
+  flyctl machine stop "$CLONE_ID" -a "$APP"
+  echo "  ✅ Cloned and stopped: $CLONE_ID"
+done
+
+echo "✅ $APP pool reconciled to $POOL_SIZE machines."

--- a/scripts/fly-reconcile-pool.sh
+++ b/scripts/fly-reconcile-pool.sh
@@ -117,18 +117,28 @@ NEEDED=$((POOL_SIZE - CURRENT_COUNT))
 echo "➕ Cloning $NEEDED stopped machine(s) from $RUNNING_ID to reach pool size $POOL_SIZE."
 
 # flyctl machine clone has no --json flag, so identify the new machine
-# by diffing the machine list before and after each clone.
+# by diffing the machine list before and after each clone. Retry on
+# transient Fly platform errors (e.g. "machine is on an unreachable host")
+# which can hit any single clone in a long sequence.
 for i in $(seq 1 "$NEEDED"); do
-  echo "  Clone $i/$NEEDED..."
-  BEFORE_IDS=$(flyctl machines list -a "$APP" --json | jq -r '.[].id' | sort)
-  if ! flyctl machine clone "$RUNNING_ID" -a "$APP" --region syd; then
-    echo "  ❌ Clone command failed." >&2
-    exit 1
-  fi
-  AFTER_IDS=$(flyctl machines list -a "$APP" --json | jq -r '.[].id' | sort)
-  CLONE_ID=$(comm -13 <(echo "$BEFORE_IDS") <(echo "$AFTER_IDS") | head -n1)
+  CLONE_ID=""
+  for clone_attempt in 1 2 3; do
+    echo "  Clone $i/$NEEDED (attempt $clone_attempt/3)..."
+    BEFORE_IDS=$(flyctl machines list -a "$APP" --json | jq -r '.[].id' | sort)
+    if flyctl machine clone "$RUNNING_ID" -a "$APP" --region syd; then
+      AFTER_IDS=$(flyctl machines list -a "$APP" --json | jq -r '.[].id' | sort)
+      CLONE_ID=$(comm -13 <(echo "$BEFORE_IDS") <(echo "$AFTER_IDS") | head -n1)
+      if [ -n "$CLONE_ID" ]; then
+        break
+      fi
+      echo "  ⚠️  Clone command succeeded but no new machine appeared — retrying..." >&2
+    else
+      echo "  ⚠️  Clone command failed (likely transient Fly error) — retrying after 10s..." >&2
+      sleep 10
+    fi
+  done
   if [ -z "$CLONE_ID" ]; then
-    echo "  ❌ Could not identify cloned machine — no new ID appeared in machine list." >&2
+    echo "  ❌ Clone failed after 3 attempts." >&2
     exit 1
   fi
   flyctl machine stop "$CLONE_ID" -a "$APP"

--- a/scripts/fly-reconcile-pool.sh
+++ b/scripts/fly-reconcile-pool.sh
@@ -144,13 +144,20 @@ for i in $(seq 1 "$NEEDED"); do
     echo "  Clone $i/$NEEDED (attempt $clone_attempt/3)..."
     BEFORE_IDS=$(flyctl machines list -a "$APP" --json | jq -r '.[].id' | sort)
     if flyctl machine clone "$RUNNING_ID" -a "$APP" --region "$SOURCE_REGION"; then
-      AFTER_IDS=$(flyctl machines list -a "$APP" --json | jq -r '.[].id' | sort)
-      CLONE_ID=$(comm -13 <(echo "$BEFORE_IDS") <(echo "$AFTER_IDS") | head -n1)
-      if [ -n "$CLONE_ID" ]; then
-        break
-      fi
-      echo "  ⚠️  Clone command succeeded but no new machine appeared — retrying after 3s..." >&2
-      sleep 3
+      # Clone command accepted. Poll the machine list for visibility —
+      # never re-run the clone command on this path, since that would
+      # create a duplicate if the API is just slow to surface the new ID.
+      for visibility_attempt in 1 2 3 4 5; do
+        AFTER_IDS=$(flyctl machines list -a "$APP" --json | jq -r '.[].id' | sort)
+        CLONE_ID=$(comm -13 <(echo "$BEFORE_IDS") <(echo "$AFTER_IDS") | head -n1)
+        if [ -n "$CLONE_ID" ]; then
+          break 2
+        fi
+        echo "  ⏳ Clone accepted but the new machine is not visible yet (check $visibility_attempt/5) — waiting 3s..." >&2
+        sleep 3
+      done
+      echo "  ❌ Clone command succeeded but the new machine never appeared — aborting to avoid duplicate cloning." >&2
+      exit 1
     else
       echo "  ⚠️  Clone command failed (likely transient Fly error) — retrying after 10s..." >&2
       sleep 10

--- a/scripts/fly-reconcile-pool.sh
+++ b/scripts/fly-reconcile-pool.sh
@@ -71,7 +71,7 @@ fi
 # something is off (caller passed wrong label, Fly API hasn't yet caught
 # up). Aborting beats wiping the entire pool.
 TARGET_MATCH_COUNT=$(echo "$MACHINES_JSON" \
-  | jq -r --arg label "$IMAGE_LABEL" '[.[] | select((.config.image // "") | endswith(":" + $label))] | length')
+  | jq -r --arg label "$IMAGE_LABEL" '[.[] | select(.state != "destroyed" and .state != "destroying") | select((.config.image // "") | endswith(":" + $label))] | length')
 if [ "$TARGET_MATCH_COUNT" -eq 0 ]; then
   echo "❌ No machine on $APP currently reports image label $IMAGE_LABEL — aborting before we destroy the running pool." >&2
   flyctl machines list -a "$APP" >&2 || true
@@ -79,7 +79,7 @@ if [ "$TARGET_MATCH_COUNT" -eq 0 ]; then
 fi
 
 STALE_IDS=$(echo "$MACHINES_JSON" \
-  | jq -r --arg label "$IMAGE_LABEL" '.[] | select((.config.image // "") | endswith(":" + $label) | not) | .id')
+  | jq -r --arg label "$IMAGE_LABEL" '.[] | select(.state != "destroyed" and .state != "destroying") | select((.config.image // "") | endswith(":" + $label) | not) | .id')
 
 if [ -n "$STALE_IDS" ]; then
   echo "🗑  Destroying stale-image machines:"

--- a/scripts/fly-reconcile-pool.sh
+++ b/scripts/fly-reconcile-pool.sh
@@ -40,7 +40,27 @@ fi
 
 echo "🔍 Reconciling $APP to pool size $POOL_SIZE on image label $IMAGE_LABEL"
 
-MACHINES_JSON=$(flyctl machines list -a "$APP" --json)
+# Phase 0 — wait for all machines to reach a stable state before checking
+# image labels. `flyctl deploy` with --immediate strategy returns as soon
+# as the config update is accepted; the machine may still be in `replacing`
+# state with its old image label still reported. Without this wait, a
+# stable in-place update gets misclassified as stale and the live machine
+# is destroyed.
+TRANSIENT_STATES_FILTER='select(.state == "replacing" or .state == "starting" or .state == "stopping" or .state == "created")'
+for attempt in $(seq 1 24); do
+  MACHINES_JSON=$(flyctl machines list -a "$APP" --json)
+  TRANSIENT_COUNT=$(echo "$MACHINES_JSON" | jq -r "[.[] | $TRANSIENT_STATES_FILTER] | length")
+  if [ "$TRANSIENT_COUNT" = "0" ]; then
+    break
+  fi
+  echo "⏳ $TRANSIENT_COUNT machine(s) still in transitional state (attempt $attempt/24) — waiting 5s..."
+  sleep 5
+done
+if [ "$TRANSIENT_COUNT" != "0" ]; then
+  echo "❌ $TRANSIENT_COUNT machine(s) still transitioning after 120s — aborting before we destroy a live update." >&2
+  flyctl machines list -a "$APP" >&2 || true
+  exit 1
+fi
 
 # Phase 1 — destroy stale-image machines. Match on image label suffix
 # rather than full image name so registry-host changes don't trip false

--- a/scripts/fly-reconcile-pool.sh
+++ b/scripts/fly-reconcile-pool.sh
@@ -64,13 +64,29 @@ fi
 # Phase 2 — top up the pool. Pick any running machine as the clone source;
 # fly machine clone copies the source's image + config, so as long as the
 # source is on IMAGE_LABEL (post-Phase 1 it must be), the clone is too.
-CURRENT_COUNT=$(echo "$MACHINES_JSON" | jq -r 'length')
-RUNNING_ID=$(echo "$MACHINES_JSON" | jq -r 'first(.[] | select(.state == "started") | .id) // empty')
+#
+# On a brand-new app's first deploy, `flyctl deploy --ha=false` returns as
+# soon as the machine is created — it doesn't wait for the started state
+# when the app has no [http_service] health check. Poll for up to 60s so
+# we don't race the launch.
+RUNNING_ID=""
+for attempt in $(seq 1 12); do
+  MACHINES_JSON=$(flyctl machines list -a "$APP" --json)
+  RUNNING_ID=$(echo "$MACHINES_JSON" | jq -r 'first(.[] | select(.state == "started") | .id) // empty')
+  if [ -n "$RUNNING_ID" ]; then
+    break
+  fi
+  echo "⏳ No started machine yet (attempt $attempt/12) — waiting 5s..."
+  sleep 5
+done
 
 if [ -z "$RUNNING_ID" ]; then
-  echo "❌ No started machine found on $APP — cannot clone pool. Did the deploy succeed?" >&2
+  echo "❌ No started machine found on $APP after 60s — cannot clone pool. Did the deploy succeed?" >&2
+  flyctl machines list -a "$APP" >&2 || true
   exit 1
 fi
+
+CURRENT_COUNT=$(echo "$MACHINES_JSON" | jq -r 'length')
 
 if [ "$CURRENT_COUNT" -ge "$POOL_SIZE" ]; then
   echo "✅ Pool already at $CURRENT_COUNT machines (target: $POOL_SIZE) — no top-up needed."


### PR DESCRIPTION
## Summary

- Two `fly-autoscaler:0.3.1` instances (`hover-autoscaler-worker`, `hover-autoscaler-analysis`) start/stop pre-provisioned machines based on Redis stream backlog, replacing the static `flyctl scale count 1` lines for worker + analysis. API app stays on its current static count.
- Pre-provisioned pool: 5 stopped clones for `hover-worker`, 10 for `hover-analysis`. Pools sit at 1 running + N-1 stopped at idle; autoscaler can only ever start/stop existing machines (no `force destroy` mid-work — see [forum thread](https://community.fly.io/t/autoscaler-destroys-machines-that-are-still-processing-work/25530)).
- Per-PR review-app variants (`hover-autoscaler-worker-pr-N`, `hover-autoscaler-analysis-pr-N`) deploy + tear down with the rest of the review-app lifecycle, so this is fully exercised on the PR before merge.

## What changed

**Backend (Go):**
- `internal/broker/probe.go` — `probeJob` now pipelines lighthouse `XLen` + `XPending` alongside the worker stream.
- `internal/observability/observability.go` — `BrokerStreamStats` split into worker/lighthouse fields; `stream_type=worker|lighthouse` attribute on `bee_broker_stream_length` and `bee_broker_consumer_pending`; new `bee_broker_unclamped_scale_target` Float64 gauge surfaces "wanted N, capped at MAX" so a Grafana alert can detect chronic saturation.

**Fly TOMLs:**
- `fly.worker.toml`, `fly.analysis.toml`, `.fly/review_apps.worker.toml`, `.fly/review_apps.analysis.toml` — added `[metrics] port = 9464` so Fly's managed Prometheus auto-scrapes the OTel exporter. Existing Alloy → Grafana Cloud push is unchanged.
- Four new autoscaler TOMLs (`fly.autoscaler-{worker,analysis}.toml`, `.fly/review_apps.autoscaler-{worker,analysis}.toml`).

**CI:**
- `.github/workflows/fly-deploy.yml` — replaced both `flyctl scale count 1` lines with `scripts/fly-reconcile-pool.sh`; added `release-autoscaler-worker` + `release-autoscaler-analysis` jobs.
- `.github/workflows/review-apps.yml` — extended `provision` to create the two per-PR autoscaler apps and stage their secrets; added two `release-autoscaler-*-review` jobs; added autoscaler teardown step at the top of `cleanup-review` (runs *before* worker/analysis destroys so it can't issue Machines API calls against apps mid-destroy).
- `.github/actions/fly-setup/action.yml` — three new 1Password entries (see prerequisites below).
- `scripts/fly-reconcile-pool.sh` — idempotent pool reconciler. Reaps stale-image machines (replaces the PR #369 purpose) then tops up the pool by cloning + stopping.

## Why

`hover-worker` and `hover-analysis` were pinned to a single static machine each. A large crawl saturated the worker; the lighthouse downstream then queued behind a single analysis machine. This adds independent backlog-driven scaling for both, with separate caps (5/10) and per-machine throughput ratios (600 worker tasks/machine, 150 lighthouse tasks/machine).

## Architecture choices worth flagging

- **Two autoscaler apps, not one.** fly-autoscaler 0.3.x supports a single `FAS_APP_NAME` per instance (with `*` glob, but no enumeration). Worker and analysis have different caps + different metrics, so they can't share an instance cleanly. Cost is ~$8/month combined, negligible.
- **Fly's managed Prometheus, not Grafana Cloud Mimir.** fly-autoscaler 0.3.x only supports Bearer/FlyV1 auth (no Basic Auth, which Mimir requires). Adding `[metrics]` blocks to worker/analysis makes Fly's Prometheus auto-scrape them — single-token auth via `fly tokens create readonly`, dashboards on Grafana Cloud unaffected.
- **`FAS_STARTED_MACHINE_COUNT` mode.** Fly staff explicitly recommend it over `FAS_CREATED_MACHINE_COUNT` for jobs-in-flight: graceful stops via `kill_signal` + `wait_timeout`, vs. force-destroy in create/destroy mode.
- **Review apps reuse the org-scoped `FLY_API_TOKEN`** (already loaded by `fly-setup`) for both `FAS_API_TOKEN` and `FAS_PROMETHEUS_TOKEN`. Production uses app-scoped deploy tokens for least privilege.

## Prerequisites before merge (manual one-time setup)

1. **Create the two production autoscaler apps:**
   ```
   flyctl apps create hover-autoscaler-worker --org personal
   flyctl apps create hover-autoscaler-analysis --org personal
   ```

2. **Mint three tokens** and put them in 1Password under `op://Good Native/hover-fly/`:
   ```
   fly tokens create deploy -a hover-worker      → FAS_API_TOKEN_WORKER
   fly tokens create deploy -a hover-analysis    → FAS_API_TOKEN_ANALYSIS
   fly tokens create readonly                    → FAS_PROMETHEUS_TOKEN
   ```

Without these, the production `release-autoscaler-*` jobs fail. Review-app CI is unaffected (it reuses the existing org-scoped `FLY_API_TOKEN`).

## Test plan

- [ ] Review-app deploy succeeds — five Fly apps come up (`hover-pr-N`, `hover-worker-pr-N`, `hover-analysis-pr-N`, `hover-autoscaler-worker-pr-N`, `hover-autoscaler-analysis-pr-N`)
- [ ] `flyctl machines list -a hover-worker-pr-N` shows 1 started + 4 stopped after `release-worker` runs; analysis shows 1 + 9
- [ ] `bee_broker_stream_length{stream_type="lighthouse",app="hover-worker-pr-N"}` shows up in Grafana during a sized crawl with audits
- [ ] Trigger a sized crawl (~3000 URLs across two domains) — worker machine count climbs toward `ceil(backlog/600)` within 60s; analysis climbs toward `ceil(backlog/150)` once lighthouse stream fills
- [ ] Queue drains — both contract back to 1 running after the smoothing window
- [ ] `flyctl logs -a hover-autoscaler-worker-pr-N` shows clean Expr evaluations, no Machines API errors
- [ ] Manually clone an old-image machine on the review-app worker, redeploy, confirm reconciler reaps it
- [ ] Close the PR — `cleanup-review` destroys both autoscaler apps before workers/analysis without errors

## Stability notes

fly-autoscaler 0.3.1 is the current upstream release (June 2024); repo has gone quiet since Dec 2024. We pin to `:0.3.1` and avoid the known issues:
- Issue [#41](https://github.com/superfly/fly-autoscaler/issues/41) (autostop string parsing) — doesn't affect us, no `[http_service]` blocks on worker/analysis.
- The mid-work destroy bug — avoided by `FAS_STARTED_MACHINE_COUNT` mode.

If upstream stagnation becomes a problem the exit ramps are: fork + bump `fly-go`, revert to `flyctl scale count N` (one-line git revert), or migrate to Judoscale.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per‑PR autoscaler apps added for worker & analysis pools; services now expose Prometheus metrics (new /metrics endpoints) for autoscaler scraping.
  * Metrics now include stream_type (worker/lighthouse) and a new unclamped autoscaler-target gauge.

* **Bug Fixes**
  * Probe logic avoids publishing misleading zeroed stream stats when all probes fail.

* **Chores**
  * CI/workflows deploy autoscalers, sync secrets, add release jobs, and reconcile machine pools via a new reconciliation script.

* **Documentation**
  * Changelog and config reference updated with autoscaler and observability details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->