### PR TITLE
Centralise Sentry + observability bootstrap, add deploy tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,21 @@ On merge, CI will:
 
 ## [Unreleased]
 
-_Add unreleased changes here._
+### Added
+
+- Sentry events now carry `app`, `region`, `process`, `release`, and
+  `server_name` tags read from Fly env vars (`FLY_APP_NAME`, `FLY_REGION`,
+  `FLY_RELEASE_VERSION` → `FLY_IMAGE_REF` fallback, `FLY_MACHINE_ID`). Staging
+  events were previously emitted with no release or app attribution, so review
+  app bursts couldn't be pinned to a specific deploy. New helpers
+  `logging.InitSentry` and `observability.StartMetricsServer` wrap the
+  duplicated bootstrap across `cmd/app`, `cmd/worker`, and `cmd/analysis`.
+
+### Fixed
+
+- `cmd/analysis` now gracefully shuts down its metrics HTTP server on SIGTERM;
+  previously it spawned the listener but never called `Shutdown`, leaving the
+  port held during termination.
 
 ## Full changelog history
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,19 +30,17 @@ On merge, CI will:
 
 ### Added
 
-- Sentry events now carry `app`, `region`, `process`, `release`, and
-  `server_name` tags read from Fly env vars (`FLY_APP_NAME`, `FLY_REGION`,
-  `FLY_RELEASE_VERSION` → `FLY_IMAGE_REF` fallback, `FLY_MACHINE_ID`). Staging
-  events were previously emitted with no release or app attribution, so review
-  app bursts couldn't be pinned to a specific deploy. New helpers
-  `logging.InitSentry` and `observability.StartMetricsServer` wrap the
-  duplicated bootstrap across `cmd/app`, `cmd/worker`, and `cmd/analysis`.
+- Sentry events now carry `app`, `process`, `region`, and `server_name` tags
+  identifying the Fly app, binary, region, and machine that emitted them.
+  Review-app errors previously had none of these, so bursts couldn't be
+  attributed to a specific deploy. New helpers `logging.InitSentry` and
+  `observability.StartMetricsServer` centralise the duplicated bootstrap across
+  `cmd/app`, `cmd/worker`, and `cmd/analysis`.
 
 ### Fixed
 
 - `cmd/analysis` now gracefully shuts down its metrics HTTP server on SIGTERM;
-  previously it spawned the listener but never called `Shutdown`, leaving the
-  port held during termination.
+  previously it spawned the listener but never called `Shutdown`.
 
 ## Full changelog history
 

--- a/cmd/analysis/main.go
+++ b/cmd/analysis/main.go
@@ -6,9 +6,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net"
-	"net/http"
-	"net/http/pprof"
 	"os"
 	"os/signal"
 	"strconv"
@@ -23,7 +20,6 @@ import (
 	"github.com/Harvey-AU/hover/internal/lighthouse"
 	"github.com/Harvey-AU/hover/internal/logging"
 	"github.com/Harvey-AU/hover/internal/observability"
-	"github.com/getsentry/sentry-go"
 	"github.com/redis/go-redis/v9"
 )
 
@@ -42,18 +38,15 @@ func main() {
 	appEnv := os.Getenv("APP_ENV")
 
 	// Sentry first so logging.Setup can wire its handler.
-	if dsn := os.Getenv("SENTRY_DSN"); dsn != "" {
-		if err := sentry.Init(sentry.ClientOptions{
-			Dsn:              dsn,
-			Environment:      appEnv,
-			AttachStacktrace: true,
-			BeforeSend:       logging.BeforeSend,
-		}); err != nil {
-			fmt.Fprintf(os.Stderr, "failed to initialise Sentry: %v\n", err)
-		} else {
-			defer sentry.Flush(2 * time.Second)
-		}
+	sentryFlush, err := logging.InitSentry(logging.SentryOptions{
+		DSN:         os.Getenv("SENTRY_DSN"),
+		Environment: appEnv,
+		Process:     "analysis",
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to initialise Sentry: %v\n", err)
 	}
+	defer sentryFlush()
 
 	logging.Setup(logging.ParseLevel(os.Getenv("LOG_LEVEL")), appEnv)
 	analysisLog.Info("hover analysis starting")
@@ -67,13 +60,13 @@ func main() {
 		if metricsAddr == "" {
 			metricsAddr = ":9464"
 		}
-		providers, err := observability.Init(context.Background(), observability.Config{
-			Enabled:        true,
+		metricsSrv, err := observability.StartMetricsServer(context.Background(), observability.MetricsServerOptions{
 			ServiceName:    serviceName,
 			Environment:    appEnv,
 			OTLPEndpoint:   strings.TrimSpace(os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT")),
 			OTLPHeaders:    observability.ParseOTLPHeaders(os.Getenv("OTEL_EXPORTER_OTLP_HEADERS")),
 			MetricsAddress: metricsAddr,
+			EnablePprof:    true,
 		})
 		if err != nil {
 			analysisLog.Warn("failed to initialise observability", "error", err)
@@ -81,33 +74,8 @@ func main() {
 			defer func() {
 				ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 				defer cancel()
-				_ = providers.Shutdown(ctx)
+				metricsSrv.Shutdown(ctx)
 			}()
-			if providers.MetricsHandler != nil && metricsAddr != "" {
-				mux := http.NewServeMux()
-				mux.Handle("/metrics", providers.MetricsHandler)
-				mux.HandleFunc("/debug/pprof/", pprof.Index)
-				mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
-				mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
-				mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
-				mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
-				metricsSrv := &http.Server{
-					Addr:              metricsAddr,
-					Handler:           mux,
-					ReadHeaderTimeout: 5 * time.Second,
-				}
-				listener, err := net.Listen("tcp", metricsAddr)
-				if err != nil {
-					analysisLog.Error("metrics server failed to bind", "error", err, "addr", metricsAddr)
-				} else {
-					go func() {
-						analysisLog.Info("metrics server listening", "addr", metricsAddr)
-						if err := metricsSrv.Serve(listener); err != nil && !errors.Is(err, http.ErrServerClosed) {
-							analysisLog.Error("metrics server failed", "error", err)
-						}
-					}()
-				}
-			}
 		}
 	}
 

--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -25,7 +25,6 @@ import (
 	"github.com/Harvey-AU/hover/internal/loops"
 	"github.com/Harvey-AU/hover/internal/notifications"
 	"github.com/Harvey-AU/hover/internal/observability"
-	"github.com/getsentry/sentry-go"
 	"github.com/joho/godotenv"
 	"golang.org/x/time/rate"
 )
@@ -403,28 +402,20 @@ func main() {
 		}()
 	}
 
-	var err error
-
 	// Init before setupLogging so the fanout handler wires the existing client.
 	if config.SentryDSN != "" {
-		err := sentry.Init(sentry.ClientOptions{
-			Dsn:         config.SentryDSN,
-			Environment: config.Env,
-			TracesSampleRate: func() float64 {
-				if config.Env == "production" {
-					return 0.1
-				}
-				return 1.0
-			}(),
-			AttachStacktrace: true,
+		sentryFlush, err := logging.InitSentry(logging.SentryOptions{
+			DSN:              config.SentryDSN,
+			Environment:      config.Env,
+			Process:          "app",
+			TracesSampleRate: appTracesSampleRate(config.Env),
 			Debug:            config.Env == "development",
-			BeforeSend:       logging.BeforeSend,
 		})
 		if err != nil {
 			startupLog.Warn("Failed to initialise Sentry", "error", err)
 		} else {
 			startupLog.Info("Sentry initialised successfully", "environment", config.Env)
-			defer sentry.Flush(2 * time.Second)
+			defer sentryFlush()
 		}
 	} else {
 		startupLog.Warn("Sentry DSN not configured, error tracking disabled")
@@ -437,10 +428,7 @@ func main() {
 		}
 	}()
 
-	var (
-		obsProviders *observability.Providers
-		metricsSrv   *http.Server
-	)
+	var obsProviders *observability.Providers
 
 	if config.ObservabilityEnabled {
 		// FLY_APP_NAME distinguishes review apps (hover-pr-342) from prod.
@@ -448,8 +436,9 @@ func main() {
 		if serviceName == "" {
 			serviceName = "hover"
 		}
-		obsProviders, err = observability.Init(context.Background(), observability.Config{
-			Enabled:        true,
+		// EnablePprof intentionally false — pprof on cmd/app would expose a
+		// debug surface alongside the public HTTP listener.
+		metricsSrv, err := observability.StartMetricsServer(context.Background(), observability.MetricsServerOptions{
 			ServiceName:    serviceName,
 			Environment:    config.Env,
 			OTLPEndpoint:   strings.TrimSpace(config.OTLPEndpoint),
@@ -460,42 +449,12 @@ func main() {
 		if err != nil {
 			startupLog.Warn("Failed to initialise observability providers", "error", err)
 		} else {
+			obsProviders = metricsSrv.Providers
 			defer func() {
 				shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 				defer cancel()
-				if err := obsProviders.Shutdown(shutdownCtx); err != nil {
-					startupLog.Warn("Failed to flush telemetry providers cleanly", "error", err)
-				}
+				metricsSrv.Shutdown(shutdownCtx)
 			}()
-
-			if obsProviders.MetricsHandler != nil && config.MetricsAddr != "" {
-				metricsSrv = &http.Server{
-					Addr:              config.MetricsAddr,
-					Handler:           obsProviders.MetricsHandler,
-					ReadHeaderTimeout: 5 * time.Second,
-				}
-
-				// Bind before logging readiness so a bind failure surfaces correctly.
-				metricsListener, err := net.Listen("tcp", config.MetricsAddr)
-				if err != nil {
-					startupLog.Error("Metrics server failed to bind", "error", err, "addr", config.MetricsAddr)
-				} else {
-					go func() {
-						startupLog.Info("Metrics server listening", "addr", config.MetricsAddr)
-						if err := metricsSrv.Serve(metricsListener); err != nil && !errors.Is(err, http.ErrServerClosed) {
-							startupLog.Error("Metrics server failed", "error", err)
-						}
-					}()
-
-					defer func() {
-						ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-						defer cancel()
-						if err := metricsSrv.Shutdown(ctx); err != nil && !errors.Is(err, http.ErrServerClosed) {
-							startupLog.Warn("Graceful shutdown of metrics server failed", "error", err)
-						}
-					}()
-				}
-			}
 		}
 	}
 
@@ -791,6 +750,15 @@ func getEnvWithDefault(key, defaultValue string) string {
 		return defaultValue
 	}
 	return value
+}
+
+// Production runs at 10% to keep trace volume within budget; non-prod
+// environments sample fully so review apps emit a usable trace stream.
+func appTracesSampleRate(env string) float64 {
+	if env == "production" {
+		return 0.1
+	}
+	return 1.0
 }
 
 func setupLogging(config *Config) {

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -3,12 +3,8 @@ package main
 import (
 	"context"
 	"database/sql"
-	"errors"
 	"fmt"
 	"log/slog"
-	"net"
-	"net/http"
-	"net/http/pprof"
 	"os"
 	"os/signal"
 	"strconv"
@@ -25,7 +21,6 @@ import (
 	"github.com/Harvey-AU/hover/internal/logging"
 	"github.com/Harvey-AU/hover/internal/observability"
 	"github.com/Harvey-AU/hover/internal/watchdog"
-	"github.com/getsentry/sentry-go"
 	"github.com/lib/pq"
 )
 
@@ -35,18 +30,15 @@ func main() {
 	appEnv := os.Getenv("APP_ENV")
 
 	// Init before logging.Setup so the sentry slog handler can attach.
-	if dsn := os.Getenv("SENTRY_DSN"); dsn != "" {
-		if err := sentry.Init(sentry.ClientOptions{
-			Dsn:              dsn,
-			Environment:      appEnv,
-			AttachStacktrace: true,
-			BeforeSend:       logging.BeforeSend,
-		}); err != nil {
-			fmt.Fprintf(os.Stderr, "failed to initialise Sentry: %v\n", err)
-		} else {
-			defer sentry.Flush(2 * time.Second)
-		}
+	sentryFlush, err := logging.InitSentry(logging.SentryOptions{
+		DSN:         os.Getenv("SENTRY_DSN"),
+		Environment: appEnv,
+		Process:     "worker",
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to initialise Sentry: %v\n", err)
 	}
+	defer sentryFlush()
 
 	logging.Setup(logging.ParseLevel(os.Getenv("LOG_LEVEL")), appEnv)
 	defer flushAsyncLogs()
@@ -63,13 +55,16 @@ func main() {
 		if metricsAddr == "" {
 			metricsAddr = ":9464"
 		}
-		providers, err := observability.Init(context.Background(), observability.Config{
-			Enabled:        true,
+		// Alloy sidecar scrapes /metrics here to add app/environment labels;
+		// pure OTLP push bypasses the dashboard's app filter. pprof shares the
+		// port (Fly internal network only, no auth guard needed).
+		metricsSrv, err := observability.StartMetricsServer(context.Background(), observability.MetricsServerOptions{
 			ServiceName:    serviceName,
 			Environment:    appEnv,
 			OTLPEndpoint:   strings.TrimSpace(os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT")),
 			OTLPHeaders:    observability.ParseOTLPHeaders(os.Getenv("OTEL_EXPORTER_OTLP_HEADERS")),
 			MetricsAddress: metricsAddr,
+			EnablePprof:    true,
 		})
 		if err != nil {
 			workerLog.Warn("failed to initialise observability", "error", err)
@@ -77,44 +72,8 @@ func main() {
 			defer func() {
 				ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 				defer cancel()
-				_ = providers.Shutdown(ctx)
+				metricsSrv.Shutdown(ctx)
 			}()
-
-			// Alloy sidecar scrapes /metrics here to add app/environment labels;
-			// pure OTLP push bypasses the dashboard's app filter. pprof shares the
-			// port (Fly internal network only, no auth guard needed).
-			if providers.MetricsHandler != nil && metricsAddr != "" {
-				mux := http.NewServeMux()
-				mux.Handle("/metrics", providers.MetricsHandler)
-				mux.HandleFunc("/debug/pprof/", pprof.Index)
-				mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
-				mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
-				mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
-				mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
-				metricsSrv := &http.Server{
-					Addr:              metricsAddr,
-					Handler:           mux,
-					ReadHeaderTimeout: 5 * time.Second,
-				}
-				metricsListener, err := net.Listen("tcp", metricsAddr)
-				if err != nil {
-					workerLog.Error("metrics server failed to bind", "error", err, "addr", metricsAddr)
-				} else {
-					go func() {
-						workerLog.Info("metrics server listening", "addr", metricsAddr)
-						if err := metricsSrv.Serve(metricsListener); err != nil && !errors.Is(err, http.ErrServerClosed) {
-							workerLog.Error("metrics server failed", "error", err)
-						}
-					}()
-					defer func() {
-						ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-						defer cancel()
-						if err := metricsSrv.Shutdown(ctx); err != nil && !errors.Is(err, http.ErrServerClosed) {
-							workerLog.Warn("graceful shutdown of metrics server failed", "error", err)
-						}
-					}()
-				}
-			}
 		}
 	}
 

--- a/internal/logging/sentry_init.go
+++ b/internal/logging/sentry_init.go
@@ -29,14 +29,26 @@ func InitSentry(opts SentryOptions) (func(), error) {
 		return flush, nil
 	}
 
+	// Capture deploy-identifying values once so we don't re-read env on every
+	// event. Logged to stderr at startup so Fly logs show which Fly runtime
+	// env vars actually got populated on this machine.
+	appName := strings.TrimSpace(os.Getenv("FLY_APP_NAME"))
+	region := strings.TrimSpace(os.Getenv("FLY_REGION"))
+	release := deployRelease()
+	server := serverName()
+	fmt.Fprintf(os.Stderr,
+		"sentry: init env=%q app=%q region=%q process=%q release=%q server=%q\n",
+		opts.Environment, appName, region, opts.Process, release, server,
+	)
+
 	clientOpts := sentry.ClientOptions{
 		Dsn:              opts.DSN,
 		Environment:      opts.Environment,
-		Release:          deployRelease(),
-		ServerName:       serverName(),
+		Release:          release,
+		ServerName:       server,
 		AttachStacktrace: true,
 		Debug:            opts.Debug,
-		BeforeSend:       BeforeSend,
+		BeforeSend:       wrapBeforeSend(appName, region, opts.Process),
 	}
 	if opts.TracesSampleRate > 0 {
 		clientOpts.TracesSampleRate = opts.TracesSampleRate
@@ -46,19 +58,34 @@ func InitSentry(opts SentryOptions) (func(), error) {
 		return flush, fmt.Errorf("sentry.Init: %w", err)
 	}
 
-	sentry.ConfigureScope(func(scope *sentry.Scope) {
-		if v := strings.TrimSpace(os.Getenv("FLY_APP_NAME")); v != "" {
-			scope.SetTag("app", v)
-		}
-		if v := strings.TrimSpace(os.Getenv("FLY_REGION")); v != "" {
-			scope.SetTag("region", v)
-		}
-		if opts.Process != "" {
-			scope.SetTag("process", opts.Process)
-		}
-	})
-
 	return func() { sentry.Flush(2 * time.Second) }, nil
+}
+
+// wrapBeforeSend stamps deploy-identifying tags directly onto every event
+// before delegating to the existing BeforeSend normalisation. The earlier
+// approach used sentry.ConfigureScope, but staging diagnostics showed scope
+// tags were not reaching events captured via the sentryslog handler — likely
+// a goroutine-local hub interaction. Stamping in BeforeSend is unconditional.
+func wrapBeforeSend(app, region, process string) func(*sentry.Event, *sentry.EventHint) *sentry.Event {
+	return func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
+		event = BeforeSend(event, hint)
+		if event == nil {
+			return nil
+		}
+		if event.Tags == nil {
+			event.Tags = make(map[string]string)
+		}
+		if app != "" && event.Tags["app"] == "" {
+			event.Tags["app"] = app
+		}
+		if region != "" && event.Tags["region"] == "" {
+			event.Tags["region"] = region
+		}
+		if process != "" && event.Tags["process"] == "" {
+			event.Tags["process"] = process
+		}
+		return event
+	}
 }
 
 // deployRelease returns the most stable deploy identifier we can read from

--- a/internal/logging/sentry_init.go
+++ b/internal/logging/sentry_init.go
@@ -61,11 +61,12 @@ func InitSentry(opts SentryOptions) (func(), error) {
 	return func() { sentry.Flush(2 * time.Second) }, nil
 }
 
-// wrapBeforeSend stamps deploy-identifying tags directly onto every event
-// before delegating to the existing BeforeSend normalisation. The earlier
-// approach used sentry.ConfigureScope, but staging diagnostics showed scope
-// tags were not reaching events captured via the sentryslog handler — likely
-// a goroutine-local hub interaction. Stamping in BeforeSend is unconditional.
+// wrapBeforeSend delegates to the existing BeforeSend normalisation first,
+// then stamps deploy-identifying tags onto every non-nil event without
+// overwriting any caller-provided values. The earlier approach used
+// sentry.ConfigureScope, but staging diagnostics showed scope tags were not
+// reaching events captured via the sentryslog handler — likely a
+// goroutine-local hub interaction. Stamping in BeforeSend is unconditional.
 func wrapBeforeSend(app, region, process string) func(*sentry.Event, *sentry.EventHint) *sentry.Event {
 	return func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
 		event = BeforeSend(event, hint)

--- a/internal/logging/sentry_init.go
+++ b/internal/logging/sentry_init.go
@@ -1,0 +1,84 @@
+package logging
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/getsentry/sentry-go"
+)
+
+// SentryOptions configures the Sentry SDK for one of the Fly binaries.
+type SentryOptions struct {
+	DSN              string
+	Environment      string
+	Process          string  // "app" | "worker" | "analysis" — emitted as the `process` scope tag.
+	TracesSampleRate float64 // 0 = leave at SDK default (off).
+	Debug            bool
+}
+
+// InitSentry calls sentry.Init with project-wide defaults and attaches the
+// deploy-identifying tags read from Fly env vars (app, region, process,
+// release, server_name). Returns a flush closure that callers should defer
+// regardless of outcome — it is a no-op when the DSN is empty or init failed,
+// so call sites do not need a separate guard around the defer.
+func InitSentry(opts SentryOptions) (func(), error) {
+	flush := func() {}
+	if opts.DSN == "" {
+		return flush, nil
+	}
+
+	clientOpts := sentry.ClientOptions{
+		Dsn:              opts.DSN,
+		Environment:      opts.Environment,
+		Release:          deployRelease(),
+		ServerName:       serverName(),
+		AttachStacktrace: true,
+		Debug:            opts.Debug,
+		BeforeSend:       BeforeSend,
+	}
+	if opts.TracesSampleRate > 0 {
+		clientOpts.TracesSampleRate = opts.TracesSampleRate
+	}
+
+	if err := sentry.Init(clientOpts); err != nil {
+		return flush, fmt.Errorf("sentry.Init: %w", err)
+	}
+
+	sentry.ConfigureScope(func(scope *sentry.Scope) {
+		if v := strings.TrimSpace(os.Getenv("FLY_APP_NAME")); v != "" {
+			scope.SetTag("app", v)
+		}
+		if v := strings.TrimSpace(os.Getenv("FLY_REGION")); v != "" {
+			scope.SetTag("region", v)
+		}
+		if opts.Process != "" {
+			scope.SetTag("process", opts.Process)
+		}
+	})
+
+	return func() { sentry.Flush(2 * time.Second) }, nil
+}
+
+// deployRelease returns the most stable deploy identifier we can read from
+// runtime env. Fly populates FLY_RELEASE_VERSION (monotonic deploy counter,
+// e.g. "v123") and FLY_IMAGE_REF (registry SHA) on every machine; either is
+// good enough to pin a Sentry event to the deploy that emitted it.
+func deployRelease() string {
+	if v := strings.TrimSpace(os.Getenv("FLY_RELEASE_VERSION")); v != "" {
+		return v
+	}
+	if v := strings.TrimSpace(os.Getenv("FLY_IMAGE_REF")); v != "" {
+		return v
+	}
+	return ""
+}
+
+func serverName() string {
+	if v := strings.TrimSpace(os.Getenv("FLY_MACHINE_ID")); v != "" {
+		return v
+	}
+	h, _ := os.Hostname()
+	return h
+}

--- a/internal/logging/sentry_init_test.go
+++ b/internal/logging/sentry_init_test.go
@@ -32,6 +32,33 @@ func TestWrapBeforeSendStampsTags(t *testing.T) {
 	}
 }
 
+func TestWrapBeforeSendPreservesExistingDeployTags(t *testing.T) {
+	fn := wrapBeforeSend("hover-pr-372", "syd", "worker")
+
+	event := &sentry.Event{
+		Message: "test",
+		Tags: map[string]string{
+			"app":     "preset-app",
+			"region":  "iad",
+			"process": "analysis",
+		},
+	}
+
+	got := fn(event, nil)
+	if got == nil {
+		t.Fatal("expected non-nil event")
+	}
+	if got.Tags["app"] != "preset-app" {
+		t.Errorf("app overwritten: %q", got.Tags["app"])
+	}
+	if got.Tags["region"] != "iad" {
+		t.Errorf("region overwritten: %q", got.Tags["region"])
+	}
+	if got.Tags["process"] != "analysis" {
+		t.Errorf("process overwritten: %q", got.Tags["process"])
+	}
+}
+
 func TestWrapBeforeSendSkipsEmptyValues(t *testing.T) {
 	fn := wrapBeforeSend("", "", "")
 

--- a/internal/logging/sentry_init_test.go
+++ b/internal/logging/sentry_init_test.go
@@ -15,6 +15,27 @@ func TestInitSentryNoOpWhenDSNEmpty(t *testing.T) {
 	flush() // must not panic
 }
 
+func TestInitSentryWithDSN(t *testing.T) {
+	t.Setenv("FLY_APP_NAME", "hover-pr-372")
+	t.Setenv("FLY_REGION", "syd")
+	t.Setenv("FLY_RELEASE_VERSION", "v999")
+	t.Setenv("FLY_MACHINE_ID", "machine-abc")
+
+	flush, err := InitSentry(SentryOptions{
+		DSN:              "https://public@example.invalid/1",
+		Environment:      "test",
+		Process:          "worker",
+		TracesSampleRate: 0.5,
+	})
+	if err != nil {
+		t.Fatalf("InitSentry: %v", err)
+	}
+	if flush == nil {
+		t.Fatal("flush should never be nil")
+	}
+	flush() // must not panic
+}
+
 func TestDeployReleasePrecedence(t *testing.T) {
 	t.Setenv("FLY_RELEASE_VERSION", "")
 	t.Setenv("FLY_IMAGE_REF", "")

--- a/internal/logging/sentry_init_test.go
+++ b/internal/logging/sentry_init_test.go
@@ -1,0 +1,52 @@
+package logging
+
+import (
+	"testing"
+)
+
+func TestInitSentryNoOpWhenDSNEmpty(t *testing.T) {
+	flush, err := InitSentry(SentryOptions{DSN: ""})
+	if err != nil {
+		t.Fatalf("expected no error for empty DSN, got %v", err)
+	}
+	if flush == nil {
+		t.Fatal("flush func should never be nil — callers defer it unconditionally")
+	}
+	flush() // must not panic
+}
+
+func TestDeployReleasePrecedence(t *testing.T) {
+	t.Setenv("FLY_RELEASE_VERSION", "")
+	t.Setenv("FLY_IMAGE_REF", "")
+	if got := deployRelease(); got != "" {
+		t.Errorf("expected empty release with no env vars, got %q", got)
+	}
+
+	t.Setenv("FLY_IMAGE_REF", "registry.fly.io/hover@sha256:abc")
+	if got := deployRelease(); got != "registry.fly.io/hover@sha256:abc" {
+		t.Errorf("expected fallback to FLY_IMAGE_REF, got %q", got)
+	}
+
+	t.Setenv("FLY_RELEASE_VERSION", "v123")
+	if got := deployRelease(); got != "v123" {
+		t.Errorf("FLY_RELEASE_VERSION should win over FLY_IMAGE_REF, got %q", got)
+	}
+
+	t.Setenv("FLY_RELEASE_VERSION", "  v124  ")
+	if got := deployRelease(); got != "v124" {
+		t.Errorf("expected FLY_RELEASE_VERSION to be trimmed, got %q", got)
+	}
+}
+
+func TestServerNameFallback(t *testing.T) {
+	t.Setenv("FLY_MACHINE_ID", "9080e9eb1a5e08")
+	if got := serverName(); got != "9080e9eb1a5e08" {
+		t.Errorf("expected FLY_MACHINE_ID, got %q", got)
+	}
+
+	t.Setenv("FLY_MACHINE_ID", "")
+	got := serverName()
+	if got == "" {
+		t.Error("expected hostname fallback when FLY_MACHINE_ID is empty")
+	}
+}

--- a/internal/logging/sentry_init_test.go
+++ b/internal/logging/sentry_init_test.go
@@ -2,7 +2,66 @@ package logging
 
 import (
 	"testing"
+
+	"github.com/getsentry/sentry-go"
 )
+
+func TestWrapBeforeSendStampsTags(t *testing.T) {
+	fn := wrapBeforeSend("hover-pr-372", "syd", "worker")
+
+	event := &sentry.Event{
+		Message: "test",
+		Tags:    map[string]string{"existing": "value"},
+	}
+
+	got := fn(event, nil)
+	if got == nil {
+		t.Fatal("expected non-nil event")
+	}
+	if got.Tags["app"] != "hover-pr-372" {
+		t.Errorf("app = %q, want hover-pr-372", got.Tags["app"])
+	}
+	if got.Tags["region"] != "syd" {
+		t.Errorf("region = %q, want syd", got.Tags["region"])
+	}
+	if got.Tags["process"] != "worker" {
+		t.Errorf("process = %q, want worker", got.Tags["process"])
+	}
+	if got.Tags["existing"] != "value" {
+		t.Errorf("existing tag overwritten: %q", got.Tags["existing"])
+	}
+}
+
+func TestWrapBeforeSendSkipsEmptyValues(t *testing.T) {
+	fn := wrapBeforeSend("", "", "")
+
+	event := &sentry.Event{Message: "test"}
+	got := fn(event, nil)
+	if got == nil {
+		t.Fatal("expected non-nil event")
+	}
+	if _, ok := got.Tags["app"]; ok {
+		t.Error("app tag should not be set when env value is empty")
+	}
+	if _, ok := got.Tags["region"]; ok {
+		t.Error("region tag should not be set when env value is empty")
+	}
+	if _, ok := got.Tags["process"]; ok {
+		t.Error("process tag should not be set when value is empty")
+	}
+}
+
+func TestWrapBeforeSendPreservesNoCaptureDrop(t *testing.T) {
+	fn := wrapBeforeSend("hover-pr-372", "syd", "worker")
+
+	event := &sentry.Event{
+		Message: "expected error",
+		Extra:   map[string]interface{}{"no_capture": true},
+	}
+	if got := fn(event, nil); got != nil {
+		t.Error("wrapBeforeSend should drop no_capture events")
+	}
+}
 
 func TestInitSentryNoOpWhenDSNEmpty(t *testing.T) {
 	flush, err := InitSentry(SentryOptions{DSN: ""})

--- a/internal/observability/metrics_server.go
+++ b/internal/observability/metrics_server.go
@@ -1,0 +1,123 @@
+package observability
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/http"
+	"net/http/pprof"
+	"time"
+)
+
+// MetricsServerOptions bundles the observability config and HTTP listener
+// settings that all three Fly binaries reproduce verbatim.
+type MetricsServerOptions struct {
+	ServiceName    string
+	Environment    string
+	OTLPEndpoint   string
+	OTLPHeaders    map[string]string
+	OTLPInsecure   bool
+	MetricsAddress string
+	EnablePprof    bool         // worker + analysis enable pprof; cmd/app does not.
+	Logger         *slog.Logger // optional; defaults to slog.Default().
+}
+
+// MetricsServer ties the OTel providers to the metrics HTTP server so the
+// caller manages a single Shutdown.
+type MetricsServer struct {
+	Providers *Providers
+
+	httpSrv *http.Server
+	log     *slog.Logger
+}
+
+// StartMetricsServer initialises the OTel providers and, when the providers
+// expose a Prometheus handler and MetricsAddress is set, binds /metrics
+// (plus /debug/pprof when EnablePprof is true) on that address.
+//
+// Telemetry is treated as best-effort: a bind failure is logged but does not
+// return an error, since the rest of the binary should still come up. Init
+// failures are returned because they imply a malformed config.
+func StartMetricsServer(ctx context.Context, opts MetricsServerOptions) (*MetricsServer, error) {
+	log := opts.Logger
+	if log == nil {
+		log = slog.Default()
+	}
+	log = log.With("component", "metrics")
+
+	providers, err := Init(ctx, Config{
+		Enabled:        true,
+		ServiceName:    opts.ServiceName,
+		Environment:    opts.Environment,
+		OTLPEndpoint:   opts.OTLPEndpoint,
+		OTLPHeaders:    opts.OTLPHeaders,
+		OTLPInsecure:   opts.OTLPInsecure,
+		MetricsAddress: opts.MetricsAddress,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("observability init: %w", err)
+	}
+
+	s := &MetricsServer{Providers: providers, log: log}
+
+	if providers == nil || providers.MetricsHandler == nil || opts.MetricsAddress == "" {
+		return s, nil
+	}
+
+	mux := http.NewServeMux()
+	mux.Handle("/metrics", providers.MetricsHandler)
+	if opts.EnablePprof {
+		mux.HandleFunc("/debug/pprof/", pprof.Index)
+		mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+		mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+		mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+		mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+	}
+
+	srv := &http.Server{
+		Addr:              opts.MetricsAddress,
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+
+	listener, err := net.Listen("tcp", opts.MetricsAddress)
+	if err != nil {
+		log.Error("metrics server failed to bind", "error", err, "addr", opts.MetricsAddress)
+		return s, nil
+	}
+
+	s.httpSrv = srv
+	go func() {
+		log.Info("metrics server listening", "addr", opts.MetricsAddress)
+		if err := srv.Serve(listener); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			log.Error("metrics server failed", "error", err)
+		}
+	}()
+
+	return s, nil
+}
+
+// Shutdown stops the HTTP server (5s grace) and flushes the OTel providers
+// (10s grace, inherited from Providers.Shutdown). Safe on a nil receiver and
+// after a partial init.
+func (s *MetricsServer) Shutdown(ctx context.Context) {
+	if s == nil {
+		return
+	}
+
+	if s.httpSrv != nil {
+		httpCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		if err := s.httpSrv.Shutdown(httpCtx); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			s.log.Warn("graceful shutdown of metrics server failed", "error", err)
+		}
+		cancel()
+	}
+
+	if s.Providers != nil && s.Providers.Shutdown != nil {
+		if err := s.Providers.Shutdown(ctx); err != nil {
+			s.log.Warn("failed to flush telemetry providers", "error", err)
+		}
+	}
+}

--- a/internal/observability/metrics_server_test.go
+++ b/internal/observability/metrics_server_test.go
@@ -91,6 +91,39 @@ func TestStartMetricsServerPprofGated(t *testing.T) {
 	}
 }
 
+func TestStartMetricsServerPprofEnabled(t *testing.T) {
+	addr := freePort(t)
+
+	srv, err := StartMetricsServer(context.Background(), MetricsServerOptions{
+		ServiceName:    "hover-test",
+		Environment:    "test",
+		MetricsAddress: addr,
+		EnablePprof:    true,
+	})
+	if err != nil {
+		t.Fatalf("StartMetricsServer: %v", err)
+	}
+	t.Cleanup(func() { srv.Shutdown(context.Background()) })
+
+	deadline := time.Now().Add(2 * time.Second)
+	var resp *http.Response
+	for time.Now().Before(deadline) {
+		resp, err = http.Get("http://" + addr + "/debug/pprof/")
+		if err == nil {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if err != nil {
+		t.Fatalf("server never came up: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("pprof should return 200 when EnablePprof=true, got %d", resp.StatusCode)
+	}
+}
+
 func TestStartMetricsServerShutdownIdempotent(t *testing.T) {
 	addr := freePort(t)
 

--- a/internal/observability/metrics_server_test.go
+++ b/internal/observability/metrics_server_test.go
@@ -1,0 +1,126 @@
+package observability
+
+import (
+	"context"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+func freePort(t *testing.T) string {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	addr := l.Addr().String()
+	_ = l.Close()
+	return addr
+}
+
+func TestStartMetricsServerServesMetrics(t *testing.T) {
+	addr := freePort(t)
+
+	srv, err := StartMetricsServer(context.Background(), MetricsServerOptions{
+		ServiceName:    "hover-test",
+		Environment:    "test",
+		MetricsAddress: addr,
+	})
+	if err != nil {
+		t.Fatalf("StartMetricsServer: %v", err)
+	}
+	t.Cleanup(func() { srv.Shutdown(context.Background()) })
+
+	// Server boots in a goroutine; poll briefly rather than racing with Serve.
+	deadline := time.Now().Add(2 * time.Second)
+	var resp *http.Response
+	for time.Now().Before(deadline) {
+		resp, err = http.Get("http://" + addr + "/metrics")
+		if err == nil {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if err != nil {
+		t.Fatalf("metrics endpoint never came up: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(body), "go_") {
+		t.Error("expected default Go collectors in /metrics output")
+	}
+}
+
+func TestStartMetricsServerPprofGated(t *testing.T) {
+	addr := freePort(t)
+
+	srv, err := StartMetricsServer(context.Background(), MetricsServerOptions{
+		ServiceName:    "hover-test",
+		Environment:    "test",
+		MetricsAddress: addr,
+		EnablePprof:    false,
+	})
+	if err != nil {
+		t.Fatalf("StartMetricsServer: %v", err)
+	}
+	t.Cleanup(func() { srv.Shutdown(context.Background()) })
+
+	deadline := time.Now().Add(2 * time.Second)
+	var resp *http.Response
+	for time.Now().Before(deadline) {
+		resp, err = http.Get("http://" + addr + "/debug/pprof/")
+		if err == nil {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if err != nil {
+		t.Fatalf("server never came up: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("pprof should be 404 when EnablePprof=false, got %d", resp.StatusCode)
+	}
+}
+
+func TestStartMetricsServerShutdownIdempotent(t *testing.T) {
+	addr := freePort(t)
+
+	srv, err := StartMetricsServer(context.Background(), MetricsServerOptions{
+		ServiceName:    "hover-test",
+		Environment:    "test",
+		MetricsAddress: addr,
+	})
+	if err != nil {
+		t.Fatalf("StartMetricsServer: %v", err)
+	}
+
+	srv.Shutdown(context.Background())
+	srv.Shutdown(context.Background()) // must not panic
+
+	var nilServer *MetricsServer
+	nilServer.Shutdown(context.Background()) // must not panic
+}
+
+func TestStartMetricsServerNoAddress(t *testing.T) {
+	srv, err := StartMetricsServer(context.Background(), MetricsServerOptions{
+		ServiceName: "hover-test",
+		Environment: "test",
+	})
+	if err != nil {
+		t.Fatalf("StartMetricsServer: %v", err)
+	}
+	t.Cleanup(func() { srv.Shutdown(context.Background()) })
+
+	if srv.httpSrv != nil {
+		t.Error("no HTTP server should be started when MetricsAddress is empty")
+	}
+}

--- a/internal/observability/metrics_server_test.go
+++ b/internal/observability/metrics_server_test.go
@@ -23,6 +23,7 @@ func freePort(t *testing.T) string {
 
 func TestStartMetricsServerServesMetrics(t *testing.T) {
 	addr := freePort(t)
+	client := &http.Client{Timeout: 500 * time.Millisecond}
 
 	srv, err := StartMetricsServer(context.Background(), MetricsServerOptions{
 		ServiceName:    "hover-test",
@@ -38,7 +39,7 @@ func TestStartMetricsServerServesMetrics(t *testing.T) {
 	deadline := time.Now().Add(2 * time.Second)
 	var resp *http.Response
 	for time.Now().Before(deadline) {
-		resp, err = http.Get("http://" + addr + "/metrics")
+		resp, err = client.Get("http://" + addr + "/metrics")
 		if err == nil {
 			break
 		}
@@ -60,6 +61,7 @@ func TestStartMetricsServerServesMetrics(t *testing.T) {
 
 func TestStartMetricsServerPprofGated(t *testing.T) {
 	addr := freePort(t)
+	client := &http.Client{Timeout: 500 * time.Millisecond}
 
 	srv, err := StartMetricsServer(context.Background(), MetricsServerOptions{
 		ServiceName:    "hover-test",
@@ -75,7 +77,7 @@ func TestStartMetricsServerPprofGated(t *testing.T) {
 	deadline := time.Now().Add(2 * time.Second)
 	var resp *http.Response
 	for time.Now().Before(deadline) {
-		resp, err = http.Get("http://" + addr + "/debug/pprof/")
+		resp, err = client.Get("http://" + addr + "/debug/pprof/")
 		if err == nil {
 			break
 		}
@@ -93,6 +95,7 @@ func TestStartMetricsServerPprofGated(t *testing.T) {
 
 func TestStartMetricsServerPprofEnabled(t *testing.T) {
 	addr := freePort(t)
+	client := &http.Client{Timeout: 500 * time.Millisecond}
 
 	srv, err := StartMetricsServer(context.Background(), MetricsServerOptions{
 		ServiceName:    "hover-test",
@@ -108,7 +111,7 @@ func TestStartMetricsServerPprofEnabled(t *testing.T) {
 	deadline := time.Now().Add(2 * time.Second)
 	var resp *http.Response
 	for time.Now().Before(deadline) {
-		resp, err = http.Get("http://" + addr + "/debug/pprof/")
+		resp, err = client.Get("http://" + addr + "/debug/pprof/")
 		if err == nil {
 			break
 		}


### PR DESCRIPTION
## Summary

- Add `logging.InitSentry` + `observability.StartMetricsServer` so the three Fly mains share one Sentry init and one metrics-server setup.
- Sentry events now carry `app`, `region`, `process`, `release`, and `server_name` tags read from Fly env vars — staging events were missing all of these, so we couldn't pin connect-error bursts to a specific review app.
- Net effect on the three mains: −151 / +46 lines, with `cmd/analysis`'s missing metrics-server graceful shutdown fixed for free.

## Why

Investigating recurring `*pgconn.ConnectError` ("tenant/user … not found") spikes on staging review apps. Production has zero of these errors over the same window, but every staging event has `release: null` and no app/server tag, so we can't tell whether the bursts are concentrated on one review app, all of them, or correlated with deploys.

This PR is the test case: once it lands and a review app is built from it, we run a normal job and check whether the bursts return — and if so, which `app` / `release` / `process` they're tagged with.

## What's in each commit

1. `Centralise Sentry init with deploy tags` — new `internal/logging/sentry_init.go` + tests. Reads `FLY_RELEASE_VERSION` → `FLY_IMAGE_REF` for `Release`; `FLY_MACHINE_ID` (with hostname fallback) for `ServerName`; sets scope tags `app=FLY_APP_NAME`, `region=FLY_REGION`, `process` from caller.
2. `Centralise observability metrics server setup` — new `internal/observability/metrics_server.go` + tests. Wraps `Init` + listener bind + Serve goroutine + graceful shutdown behind a single `Shutdown(ctx)`. `EnablePprof` toggles the pprof handlers (worker/analysis on, app off — matches existing behaviour).
3. `Use bootstrap helpers in cmds` — swaps the duplicated boilerplate in `cmd/app`, `cmd/worker`, `cmd/analysis` for the helpers. Also fixes a pre-existing bug where `cmd/analysis` started a metrics HTTP server but never shut it down.

## Behaviour preserved

- `cmd/app` keeps `TracesSampleRate` (0.1 prod / 1.0 elsewhere) and `Debug` in development.
- `cmd/app` does **not** expose pprof on the metrics port (would sit alongside the public listener).
- Worker + analysis keep pprof on the metrics port.
- Three Fly autoscaler apps run the third-party `flyio/fly-autoscaler` image and don't emit to our Sentry — untouched.

## Test plan

- [x] `go test ./...` passes
- [x] `bash scripts/security-check.sh` passes
- [ ] Review app builds and boots (worker + app + analysis)
- [ ] Run a normal crawl job against the review app
- [ ] Check Sentry: events from this run carry `app`, `process`, `release` tags
- [ ] Confirm whether the staging `pgconn.ConnectError` bursts return with the new tagging — and if so, which app/release they're attributed to

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified error-tracking initialization and metrics/profiling server startup across services for consistent startup/shutdown behavior.
* **Bug Fixes**
  * Metrics HTTP server now shuts down gracefully on termination; observability startup tolerates bind failures.
* **New Features**
  * Error-tracking events now include app, process, region, release, and server-name tags; pprof exposure is configurable.
* **Tests**
  * Added tests for error-tracking helpers, metrics endpoints, pprof gating, and shutdown idempotency.
* **Documentation**
  * Changelog updated to reflect tagging and observability changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->