### PR TITLE
Detect Cloudflare challenge on 429

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,15 @@ On merge, CI will:
 
 ## [Unreleased]
 
-_Add unreleased changes here._
+### Fixed
+
+- WAF detection now recognises Cloudflare managed challenges served as HTTP 429
+  with `Cf-Mitigated: challenge`. Previously the verdict was gated behind status
+  403 or 202 only, so CF challenge responses (observed against CF-fronted
+  Shopify storefronts with Super Bot Fight Mode enabled) were misclassified as
+  plain "Too Many Requests" and jobs burnt three retries before failing with a
+  misleading error. Jobs now fail fast and stamp `domains.waf_blocked = true`
+  with `waf_vendor = cloudflare`.
 
 ## Full changelog history
 

--- a/internal/crawler/waf.go
+++ b/internal/crawler/waf.go
@@ -29,13 +29,15 @@ const (
 // DetectWAF inspects a response and reports whether it carries a
 // fingerprint of a known bot-protection layer. The function is pure: no
 // I/O, safe for table-driven tests. It is intentionally conservative on
-// 200 responses — only blocking status codes (typically 403 or 202)
+// 200 responses — only non-200 responses (typically 403, 429, or 202)
 // combined with corroborating fingerprints trigger a verdict, so a
 // healthy site that happens to use Cloudflare for caching does not get
 // flagged.
 //
 // Fingerprints (issue #365 row 1 + comment 4334238167):
 //   - Cloudflare: cf-mitigated header set on a non-200 response
+//     (includes 429 managed-challenge responses where CF returns the
+//     challenge HTML wrapped as Too Many Requests)
 //   - Imperva: body contains _Incapsula_Resource
 //   - DataDome: Server header equals DataDome
 //   - Akamai: Server header AkamaiGHost OR akaalb_/_abck/bm_sz cookie OR
@@ -50,7 +52,12 @@ func DetectWAF(statusCode int, headers http.Header, bodySample []byte) WAFDetect
 
 	blocking := isBlockingStatus(statusCode)
 
-	if v := strings.TrimSpace(headers.Get("Cf-Mitigated")); v != "" && blocking {
+	// cf-mitigated indicates Cloudflare took bot-management action
+	// (challenge, block, jschallenge, managed_challenge). It is only
+	// emitted on responses where CF intervened, so a non-empty value on
+	// any non-200 status is a reliable signal — including 429 challenges
+	// against datacentre egress IPs.
+	if v := strings.TrimSpace(headers.Get("Cf-Mitigated")); v != "" && statusCode != http.StatusOK {
 		return WAFDetection{
 			Blocked: true,
 			Vendor:  WAFVendorCloudflare,
@@ -149,6 +156,8 @@ func statusLabel(code int) string {
 		return "403"
 	case http.StatusAccepted:
 		return "202"
+	case http.StatusTooManyRequests:
+		return "429"
 	default:
 		return http.StatusText(code)
 	}

--- a/internal/crawler/waf_test.go
+++ b/internal/crawler/waf_test.go
@@ -123,6 +123,24 @@ func TestDetectWAF(t *testing.T) {
 			reasonPrefix: "cf-mitigated",
 		},
 		{
+			// Real failure mode observed against Shopify storefronts when
+			// CF "Super Bot Fight Mode" is enabled: CF returns 429 with
+			// the challenge HTML in the body and Cf-Mitigated: challenge.
+			// Prior to this case, isBlockingStatus only allowed 403/202
+			// so the detector silently no-op'd and jobs burnt 3 retries
+			// before failing with a misleading "Too Many Requests" error.
+			name:   "cloudflare — cf-mitigated challenge on 429",
+			status: http.StatusTooManyRequests,
+			headers: http.Header{
+				"Cf-Mitigated": []string{"challenge"},
+				"Server":       []string{"cloudflare"},
+			},
+			body:         []byte(strings.Repeat("x", 9000)), // CF challenge page is ~9KB
+			wantBlocked:  true,
+			wantVendor:   WAFVendorCloudflare,
+			reasonPrefix: "cf-mitigated header present on 429",
+		},
+		{
 			name:   "cloudflare — cf-mitigated alone on 200 must NOT trip (caching path)",
 			status: http.StatusOK,
 			headers: http.Header{


### PR DESCRIPTION
## Summary
- Widen `DetectWAF` cf-mitigated check to fire on any non-200 status (was: 403/202 only), so the 429 + `Cf-Mitigated: challenge` response shape Cloudflare uses for Super Bot Fight Mode managed challenges is now classified correctly as a WAF block instead of a generic "Too Many Requests".
- Add a `statusLabel` case for 429 so the recorded reason reads `cf-mitigated header present on 429` rather than the verbose `Too Many Requests`.
- Add a regression test (`cloudflare — cf-mitigated challenge on 429`) covering the failing shape captured against `hinu.co` and `www.milkcan.com.au` today.

## Why
Today four jobs against two Shopify storefronts (`hinu.co`, `www.milkcan.com.au`) failed after one task each. The captured `request_diagnostics` for the failed tasks show:

```
HTTP/2 429
Cf-Mitigated: challenge
Server: cloudflare
Content-Length: 9246          ← CF challenge HTML
```

That is Cloudflare serving a managed bot challenge, not a true rate limit. `DetectWAF` already has a cf-mitigated branch that would have set `domains.waf_blocked = true` and surfaced a clear error, but it was gated behind `isBlockingStatus` which only matched 403 and 202 — so the verdict silently no-op'd, the executor burnt three retries, and the user saw a misleading "Too Many Requests" failure.

The doc comment on `DetectWAF` already described the intent as "cf-mitigated header set on a non-200 response"; this PR aligns the implementation with the documented behaviour.

## Test plan
- [x] `go test ./internal/crawler/... ` — all WAF cases pass including the new 429 case and the existing "must NOT trip on 200" negative case.
- [x] `go vet ./internal/crawler/...`
- [x] `gofmt -l` — clean.
- [ ] Trigger a fresh job against a CF-challenged Shopify storefront in staging and confirm:
  - the job moves to `failed` after the first task, not after 3 retries
  - `domains.waf_blocked` flips to `true` with `waf_vendor = cloudflare`
  - the surfaced error message names Cloudflare rather than "Too Many Requests"

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Good-Native/codesmith/hover/pr/382"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Cloudflare WAF detection to recognize managed challenges and 429 rate-limit responses as blocked.

* **Tests**
  * Added test coverage verifying detection of Cloudflare-managed 429 challenge responses.

* **Documentation**
  * Updated changelog to reflect the WAF detection fix and its impact on job classification and recording.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Good-Native/hover/pull/382)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->