### PR TITLE
Persist pacer adaptive delay across restarts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,20 @@ On merge, CI will:
 
 ## [Unreleased]
 
-_Add unreleased changes here._
+### Changed
+
+- Pacer's per-domain adaptive delay is now durable:
+  `domains.adaptive_delay_seconds` is read on every job-info cache miss and
+  reseeded into Redis, and the learned value is written back from the pacer's
+  success/rate-limit path (debounced per domain at five-minute intervals). The
+  startup `FlushAdaptiveDelays` is now opt-in via
+  `GNH_PACER_FLUSH_ON_START=true` for incident recovery; default behaviour
+  preserves the learned rate across worker restarts.
+- Dispatcher now caps per-domain inflight tasks at
+  `ceil(GNH_PACER_EST_RESPONSE_MS / adaptive_delay_ms)` (default response
+  estimate 1500ms). Above the cap, additional entries skip dispatch without
+  consuming the gate, preventing the burst-then-collapse pattern that elevates
+  egress IP reputation on CF-fronted domains.
 
 ## Full changelog history
 

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -128,10 +128,12 @@ func main() {
 	pacer := broker.NewDomainPacer(redisClient, pacerCfg)
 	counters := broker.NewRunningCounters(redisClient)
 
-	// Adaptive-delay state lives in Redis with 24h TTL; without this flush a
-	// brief 429 burst can throttle a domain for a full day after upstream
-	// recovers. Disable via GNH_PACER_FLUSH_ON_START=false.
-	if strings.TrimSpace(os.Getenv("GNH_PACER_FLUSH_ON_START")) != "false" {
+	// Adaptive delay is now durable in domains.adaptive_delay_seconds and
+	// reseeded into Redis on every job-info cache miss. The startup flush
+	// is opt-in for incident recovery only: enable via
+	// GNH_PACER_FLUSH_ON_START=true to wipe Redis state and rebuild from
+	// Postgres. Default off so the learned rate survives worker restarts.
+	if strings.TrimSpace(os.Getenv("GNH_PACER_FLUSH_ON_START")) == "true" {
 		flushCtx, flushCancel := context.WithTimeout(context.Background(), 10*time.Second)
 		deleted, err := pacer.FlushAdaptiveDelays(flushCtx)
 		flushCancel()

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -131,9 +131,19 @@ func main() {
 	// Adaptive delay is now durable in domains.adaptive_delay_seconds and
 	// reseeded into Redis on every job-info cache miss. The startup flush
 	// is opt-in for incident recovery only: enable via
-	// GNH_PACER_FLUSH_ON_START=true to wipe Redis state and rebuild from
-	// Postgres. Default off so the learned rate survives worker restarts.
-	if strings.TrimSpace(os.Getenv("GNH_PACER_FLUSH_ON_START")) == "true" {
+	// GNH_PACER_FLUSH_ON_START=<truthy> to wipe Redis state and rebuild
+	// from Postgres. Default off so the learned rate survives worker
+	// restarts.
+	flushOnStart := false
+	if raw := strings.TrimSpace(os.Getenv("GNH_PACER_FLUSH_ON_START")); raw != "" {
+		parsed, err := strconv.ParseBool(raw)
+		if err != nil {
+			workerLog.Warn("invalid GNH_PACER_FLUSH_ON_START; expected boolean", "value", raw)
+		} else {
+			flushOnStart = parsed
+		}
+	}
+	if flushOnStart {
 		flushCtx, flushCancel := context.WithTimeout(context.Background(), 10*time.Second)
 		deleted, err := pacer.FlushAdaptiveDelays(flushCtx)
 		flushCancel()

--- a/internal/broker/dispatcher.go
+++ b/internal/broker/dispatcher.go
@@ -231,12 +231,15 @@ func (d *Dispatcher) dispatchJob(ctx context.Context, jobID string, now time.Tim
 		// a 20-wide burst against a CF-fronted Shopify domain learning a
 		// 2s adaptive delay does no useful work and elevates the egress
 		// reputation score (collateral CF challenges on adjacent stores
-		// observed 2026-05-11). Skip cheaply before consuming the gate.
+		// observed 2026-05-11). The total is summed across every job
+		// hitting the same host — a per-job slot would let N concurrent
+		// jobs each consume the cap and defeat the burst guard. Skip
+		// cheaply before consuming the gate.
 		domainCap, err := d.pacer.EffectiveCap(ctx, domain)
 		if err != nil {
 			brokerLog.Warn("effective cap lookup failed", "error", err, "domain", domain)
 		} else if domainCap > 0 {
-			inflight, err := d.pacer.GetInflight(ctx, domain, jobID)
+			inflight, err := d.pacer.GetDomainInflight(ctx, domain)
 			if err != nil {
 				brokerLog.Warn("inflight lookup failed", "error", err, "domain", domain)
 			} else if inflight >= int64(domainCap) {

--- a/internal/broker/dispatcher.go
+++ b/internal/broker/dispatcher.go
@@ -226,6 +226,25 @@ func (d *Dispatcher) dispatchJob(ctx context.Context, jobID string, now time.Tim
 		d.clearStuck(jobID)
 
 		domain := entry.Host
+
+		// Per-domain inflight cap derived from the learned adaptive delay:
+		// a 20-wide burst against a CF-fronted Shopify domain learning a
+		// 2s adaptive delay does no useful work and elevates the egress
+		// reputation score (collateral CF challenges on adjacent stores
+		// observed 2026-05-11). Skip cheaply before consuming the gate.
+		domainCap, err := d.pacer.EffectiveCap(ctx, domain)
+		if err != nil {
+			brokerLog.Warn("effective cap lookup failed", "error", err, "domain", domain)
+		} else if domainCap > 0 {
+			inflight, err := d.pacer.GetInflight(ctx, domain, jobID)
+			if err != nil {
+				brokerLog.Warn("inflight lookup failed", "error", err, "domain", domain)
+			} else if inflight >= int64(domainCap) {
+				observability.RecordBrokerPacerPushback(ctx, domain, "domain_cap")
+				continue
+			}
+		}
+
 		paceResult, err := d.pacer.TryAcquire(ctx, domain)
 		if err != nil {
 			brokerLog.Warn("pacer check failed", "error", err, "domain", domain)

--- a/internal/broker/dispatcher_test.go
+++ b/internal/broker/dispatcher_test.go
@@ -3,6 +3,7 @@ package broker
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -239,6 +240,36 @@ func TestDispatcher_DomainPacing_ReschedulesWhenGated(t *testing.T) {
 	// Sanity: dispatched entry's member is gone; rescheduled entry's member is unchanged.
 	_ = e1
 	_ = e2
+}
+
+// A domain whose learned adaptive_delay implies useful-concurrency=1
+// should saturate after the first dispatched task; subsequent entries
+// in the same tick must be skipped without consuming the gate. This is
+// the burst-prevention path that stops a 20-wide opening volley from
+// elevating the egress CF reputation score.
+func TestDispatcher_DomainCap_SaturatesAtUsefulConcurrency(t *testing.T) {
+	lister := &staticJobLister{ids: []string{"job-cap"}}
+	conc := &staticConcurrency{can: true}
+	d, s, pacer, _, _, _ := newDispatcherRig(t, lister, conc)
+	ctx := context.Background()
+
+	// adaptive_delay 5s with estResponseMS 1500 -> cap=1.
+	require.NoError(t, pacer.Seed(ctx, "capped.com", 0, 5000, 0))
+
+	now := time.Now()
+	for i := 0; i < 5; i++ {
+		seedEntry(t, s, "job-cap", fmt.Sprintf("t%d", i), "capped.com", now)
+	}
+
+	n, err := d.dispatchJob(ctx, "job-cap", now)
+	require.NoError(t, err)
+	assert.Equal(t, 1, n, "domain cap should hold dispatch to one under high adaptive delay")
+
+	// Four remain in the ZSET, due now (not paced/rescheduled — domain
+	// cap skips before the gate is touched).
+	remaining, err := s.DueItems(ctx, "job-cap", now, 10)
+	require.NoError(t, err)
+	assert.Len(t, remaining, 4, "remaining entries must stay at their original run_at")
 }
 
 // --- Malformed ZSET entry cleanup --------------------------------------

--- a/internal/broker/dispatcher_test.go
+++ b/internal/broker/dispatcher_test.go
@@ -242,6 +242,35 @@ func TestDispatcher_DomainPacing_ReschedulesWhenGated(t *testing.T) {
 	_ = e2
 }
 
+// The per-domain cap must compare against total inflight across every
+// job hitting the host. With per-job slots, two concurrent jobs each
+// get one dispatch and the burst doubles — defeating the guard.
+func TestDispatcher_DomainCap_AggregatesAcrossJobs(t *testing.T) {
+	lister := &staticJobLister{ids: []string{"job-a", "job-b"}}
+	conc := &staticConcurrency{can: true}
+	d, s, pacer, _, _, _ := newDispatcherRig(t, lister, conc)
+	ctx := context.Background()
+
+	// Cap=1 against capped.com for both jobs combined.
+	require.NoError(t, pacer.Seed(ctx, "capped.com", 0, 5000, 0))
+
+	// Job A already has one inflight against the domain.
+	require.NoError(t, pacer.IncrementInflight(ctx, "capped.com", "job-a"))
+
+	// Job B tries to dispatch — the cap should hold because total
+	// inflight (1 from job-a) already equals domainCap.
+	now := time.Now()
+	seedEntry(t, s, "job-b", "t1", "capped.com", now)
+
+	n, err := d.dispatchJob(ctx, "job-b", now)
+	require.NoError(t, err)
+	assert.Equal(t, 0, n, "domain cap must aggregate across jobs to prevent cross-job burst")
+
+	pending, err := s.PendingCount(ctx, "job-b")
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), pending)
+}
+
 // A domain whose learned adaptive_delay implies useful-concurrency=1
 // should saturate after the first dispatched task; subsequent entries
 // in the same tick must be skipped without consuming the gate. This is

--- a/internal/broker/pacer.go
+++ b/internal/broker/pacer.go
@@ -20,6 +20,12 @@ type PacerConfig struct {
 	// Floor on RetryAfter so a near-zero gate TTL doesn't tight-loop
 	// the dispatcher (Dispatcher tick is 100ms).
 	MinPushbackMS int
+	// EstResponseMS bounds the per-domain inflight cap: when
+	// adaptive_delay_ms is non-zero, useful concurrency is
+	// ceil(EstResponseMS / adaptive_delay_ms). Holding a fixed 20-wide
+	// burst against a CF-fronted domain elevates Fly's egress score; the
+	// cap collapses the burst to whatever the learned rate can sustain.
+	EstResponseMS int
 }
 
 func DefaultPacerConfig() PacerConfig {
@@ -31,6 +37,7 @@ func DefaultPacerConfig() PacerConfig {
 		DelayStepDownMS:  stepDown,
 		MaxDelayMS:       envInt("GNH_RATE_LIMIT_MAX_DELAY_MS", 60000),
 		MinPushbackMS:    envInt("GNH_DOMAIN_DELAY_PAUSE_MS", 100),
+		EstResponseMS:    envInt("GNH_PACER_EST_RESPONSE_MS", 1500),
 	}
 }
 
@@ -121,35 +128,49 @@ func (p *DomainPacer) pushbackFloor(d time.Duration) time.Duration {
 	return d
 }
 
-func (p *DomainPacer) Release(ctx context.Context, domain, jobID string, success, rateLimited bool) error {
+// Release decrements inflight and updates adaptive_delay_ms. Returns the
+// post-update adaptive delay in ms (or -1 if Release did not touch it, e.g.
+// neither success nor rateLimited). Callers use the returned value to drive
+// debounced write-back to Postgres without an extra Redis read.
+func (p *DomainPacer) Release(ctx context.Context, domain, jobID string, success, rateLimited bool) (int, error) {
 	cfgKey := DomainConfigKey(domain)
+	newDelayMS := -1
 
 	if success {
 		stepDown := p.cfg.DelayStepDownMS
 		if stepDown <= 0 {
 			stepDown = p.cfg.DelayStepMS
 		}
-		_, err := adaptiveDelayOnSuccessScript.Run(ctx, p.client.rdb,
+		raw, err := adaptiveDelayOnSuccessScript.Run(ctx, p.client.rdb,
 			[]string{cfgKey},
 			p.cfg.SuccessThreshold,
 			stepDown,
 		).Result()
 		if err != nil {
-			return fmt.Errorf("broker: release success %s: %w", domain, err)
+			return -1, fmt.Errorf("broker: release success %s: %w", domain, err)
+		}
+		if v, ok := raw.(int64); ok {
+			newDelayMS = int(v)
 		}
 	} else if rateLimited {
-		_, err := adaptiveDelayOnErrorScript.Run(ctx, p.client.rdb,
+		raw, err := adaptiveDelayOnErrorScript.Run(ctx, p.client.rdb,
 			[]string{cfgKey},
 			p.cfg.DelayStepMS,
 			p.cfg.MaxDelayMS,
 		).Result()
 		if err != nil {
-			return fmt.Errorf("broker: release rate-limited %s: %w", domain, err)
+			return -1, fmt.Errorf("broker: release rate-limited %s: %w", domain, err)
+		}
+		if v, ok := raw.(int64); ok {
+			newDelayMS = int(v)
 		}
 		observability.RecordBrokerPacerPushback(ctx, domain, "rate_limited")
 	}
 
-	return p.DecrementInflight(ctx, domain, jobID)
+	if err := p.DecrementInflight(ctx, domain, jobID); err != nil {
+		return newDelayMS, err
+	}
+	return newDelayMS, nil
 }
 
 // Restores pre-merge behaviour: in-memory limiter reset on each worker
@@ -203,6 +224,33 @@ func (p *DomainPacer) DecrementInflight(ctx context.Context, domain, jobID strin
 		}
 	}
 	return nil
+}
+
+// EffectiveCap returns the maximum useful per-domain inflight count given
+// the learned adaptive delay and the configured response-time estimate.
+// Returns 0 when no cap applies (adaptive_delay_ms <= 0): the dispatcher
+// then falls back to the per-job concurrency check alone.
+func (p *DomainPacer) EffectiveCap(ctx context.Context, domain string) (int, error) {
+	raw, err := p.client.rdb.HGet(ctx, DomainConfigKey(domain), "adaptive_delay_ms").Result()
+	if err == redis.Nil {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, fmt.Errorf("broker: effective cap %s: %w", domain, err)
+	}
+	adaptiveMS, err := strconv.Atoi(raw)
+	if err != nil || adaptiveMS <= 0 {
+		return 0, nil
+	}
+	est := p.cfg.EstResponseMS
+	if est <= 0 {
+		return 0, nil
+	}
+	ceilCap := (est + adaptiveMS - 1) / adaptiveMS
+	if ceilCap < 1 {
+		ceilCap = 1
+	}
+	return ceilCap, nil
 }
 
 func (p *DomainPacer) GetInflight(ctx context.Context, domain, jobID string) (int64, error) {

--- a/internal/broker/pacer.go
+++ b/internal/broker/pacer.go
@@ -130,11 +130,15 @@ func (p *DomainPacer) pushbackFloor(d time.Duration) time.Duration {
 
 // Release decrements inflight and updates adaptive_delay_ms. Returns the
 // post-update adaptive delay in ms (or -1 if Release did not touch it, e.g.
-// neither success nor rateLimited). Callers use the returned value to drive
-// debounced write-back to Postgres without an extra Redis read.
+// neither success nor rateLimited). DecrementInflight runs unconditionally:
+// if the adaptive update fails we still need to release the inflight slot
+// because the worker has already ACKed the message, otherwise the domain
+// inflight count drifts upward forever and the per-domain cap starts
+// refusing dispatches for work that is no longer running.
 func (p *DomainPacer) Release(ctx context.Context, domain, jobID string, success, rateLimited bool) (int, error) {
 	cfgKey := DomainConfigKey(domain)
 	newDelayMS := -1
+	var adaptiveErr error
 
 	if success {
 		stepDown := p.cfg.DelayStepDownMS
@@ -147,9 +151,8 @@ func (p *DomainPacer) Release(ctx context.Context, domain, jobID string, success
 			stepDown,
 		).Result()
 		if err != nil {
-			return -1, fmt.Errorf("broker: release success %s: %w", domain, err)
-		}
-		if v, ok := raw.(int64); ok {
+			adaptiveErr = fmt.Errorf("broker: release success %s: %w", domain, err)
+		} else if v, ok := raw.(int64); ok {
 			newDelayMS = int(v)
 		}
 	} else if rateLimited {
@@ -159,18 +162,20 @@ func (p *DomainPacer) Release(ctx context.Context, domain, jobID string, success
 			p.cfg.MaxDelayMS,
 		).Result()
 		if err != nil {
-			return -1, fmt.Errorf("broker: release rate-limited %s: %w", domain, err)
-		}
-		if v, ok := raw.(int64); ok {
+			adaptiveErr = fmt.Errorf("broker: release rate-limited %s: %w", domain, err)
+		} else if v, ok := raw.(int64); ok {
 			newDelayMS = int(v)
 		}
 		observability.RecordBrokerPacerPushback(ctx, domain, "rate_limited")
 	}
 
-	if err := p.DecrementInflight(ctx, domain, jobID); err != nil {
-		return newDelayMS, err
+	if decErr := p.DecrementInflight(ctx, domain, jobID); decErr != nil {
+		if adaptiveErr != nil {
+			return newDelayMS, fmt.Errorf("%w; decrement inflight: %v", adaptiveErr, decErr)
+		}
+		return newDelayMS, decErr
 	}
-	return newDelayMS, nil
+	return newDelayMS, adaptiveErr
 }
 
 // Restores pre-merge behaviour: in-memory limiter reset on each worker
@@ -259,4 +264,27 @@ func (p *DomainPacer) GetInflight(ctx context.Context, domain, jobID string) (in
 		return 0, nil
 	}
 	return val, err
+}
+
+// GetDomainInflight returns the sum of inflight counts across all jobs
+// targeting this domain. The per-domain cap must compare against this
+// total rather than any single job's slot, otherwise N concurrent jobs
+// against the same host each get to dispatch their own copy of the cap
+// and the burst-prevention path is defeated.
+func (p *DomainPacer) GetDomainInflight(ctx context.Context, domain string) (int64, error) {
+	vals, err := p.client.rdb.HVals(ctx, DomainInflightKey(domain)).Result()
+	if err != nil {
+		return 0, fmt.Errorf("broker: domain inflight %s: %w", domain, err)
+	}
+	var total int64
+	for _, v := range vals {
+		n, parseErr := strconv.ParseInt(v, 10, 64)
+		if parseErr != nil {
+			continue
+		}
+		if n > 0 {
+			total += n
+		}
+	}
+	return total, nil
 }

--- a/internal/broker/pacer_test.go
+++ b/internal/broker/pacer_test.go
@@ -116,9 +116,11 @@ func TestDomainPacer_Release_AdaptiveDelay(t *testing.T) {
 	require.NoError(t, pacer.IncrementInflight(ctx, "test.com", "j1"))
 
 	// Two successes should reduce the adaptive delay.
-	require.NoError(t, pacer.Release(ctx, "test.com", "j1", true, false))
+	_, err := pacer.Release(ctx, "test.com", "j1", true, false)
+	require.NoError(t, err)
 	require.NoError(t, pacer.IncrementInflight(ctx, "test.com", "j1"))
-	require.NoError(t, pacer.Release(ctx, "test.com", "j1", true, false))
+	_, err = pacer.Release(ctx, "test.com", "j1", true, false)
+	require.NoError(t, err)
 
 	key := DomainConfigKey("test.com")
 	adaptive, err := client.rdb.HGet(ctx, key, "adaptive_delay_ms").Result()
@@ -127,7 +129,8 @@ func TestDomainPacer_Release_AdaptiveDelay(t *testing.T) {
 
 	// A rate-limit error should increase it.
 	require.NoError(t, pacer.IncrementInflight(ctx, "test.com", "j1"))
-	require.NoError(t, pacer.Release(ctx, "test.com", "j1", false, true))
+	_, err = pacer.Release(ctx, "test.com", "j1", false, true)
+	require.NoError(t, err)
 
 	adaptive, err = client.rdb.HGet(ctx, key, "adaptive_delay_ms").Result()
 	require.NoError(t, err)
@@ -171,4 +174,66 @@ func TestDomainPacer_FlushAdaptiveDelays_Empty(t *testing.T) {
 	deleted, err := pacer.FlushAdaptiveDelays(ctx)
 	require.NoError(t, err)
 	assert.Equal(t, 0, deleted)
+}
+
+func TestDomainPacer_Release_ReturnsAdaptiveDelay(t *testing.T) {
+	client := newTestClient(t)
+	cfg := DefaultPacerConfig()
+	cfg.SuccessThreshold = 1
+	cfg.DelayStepMS = 100
+	cfg.DelayStepDownMS = 100
+	cfg.MaxDelayMS = 60000
+	pacer := NewDomainPacer(client, cfg)
+	ctx := context.Background()
+
+	require.NoError(t, pacer.Seed(ctx, "test.com", 50, 500, 50))
+
+	// Rate-limit increases the delay; Release returns the new value.
+	require.NoError(t, pacer.IncrementInflight(ctx, "test.com", "j1"))
+	got, err := pacer.Release(ctx, "test.com", "j1", false, true)
+	require.NoError(t, err)
+	assert.Equal(t, 600, got, "rate-limited release should return adaptive_delay_ms + step")
+
+	// Success when streak threshold met reduces the delay.
+	require.NoError(t, pacer.IncrementInflight(ctx, "test.com", "j1"))
+	got, err = pacer.Release(ctx, "test.com", "j1", true, false)
+	require.NoError(t, err)
+	assert.Equal(t, 500, got, "successful release at threshold should step adaptive_delay down")
+
+	// Neither success nor rate-limited: Release returns -1 (no observation).
+	require.NoError(t, pacer.IncrementInflight(ctx, "test.com", "j1"))
+	got, err = pacer.Release(ctx, "test.com", "j1", false, false)
+	require.NoError(t, err)
+	assert.Equal(t, -1, got)
+}
+
+func TestDomainPacer_EffectiveCap(t *testing.T) {
+	client := newTestClient(t)
+	cfg := DefaultPacerConfig()
+	cfg.EstResponseMS = 1500
+	pacer := NewDomainPacer(client, cfg)
+	ctx := context.Background()
+
+	// No config: cap disabled (0).
+	c, err := pacer.EffectiveCap(ctx, "unseeded.com")
+	require.NoError(t, err)
+	assert.Equal(t, 0, c)
+
+	// adaptive_delay_ms == 0: cap disabled.
+	require.NoError(t, pacer.Seed(ctx, "fast.com", 50, 0, 50))
+	c, err = pacer.EffectiveCap(ctx, "fast.com")
+	require.NoError(t, err)
+	assert.Equal(t, 0, c)
+
+	// adaptive_delay_ms == 500: ceil(1500 / 500) = 3.
+	require.NoError(t, pacer.Seed(ctx, "moderate.com", 50, 500, 50))
+	c, err = pacer.EffectiveCap(ctx, "moderate.com")
+	require.NoError(t, err)
+	assert.Equal(t, 3, c)
+
+	// adaptive_delay_ms == 2000: ceil(1500 / 2000) -> floor of 1.
+	require.NoError(t, pacer.Seed(ctx, "slow.com", 50, 2000, 50))
+	c, err = pacer.EffectiveCap(ctx, "slow.com")
+	require.NoError(t, err)
+	assert.Equal(t, 1, c)
 }

--- a/internal/broker/pacer_test.go
+++ b/internal/broker/pacer_test.go
@@ -207,6 +207,25 @@ func TestDomainPacer_Release_ReturnsAdaptiveDelay(t *testing.T) {
 	assert.Equal(t, -1, got)
 }
 
+func TestDomainPacer_GetDomainInflight_SumsAcrossJobs(t *testing.T) {
+	client := newTestClient(t)
+	pacer := NewDomainPacer(client, DefaultPacerConfig())
+	ctx := context.Background()
+
+	// Empty hash returns 0.
+	total, err := pacer.GetDomainInflight(ctx, "fresh.com")
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), total)
+
+	require.NoError(t, pacer.IncrementInflight(ctx, "shared.com", "job-a"))
+	require.NoError(t, pacer.IncrementInflight(ctx, "shared.com", "job-a"))
+	require.NoError(t, pacer.IncrementInflight(ctx, "shared.com", "job-b"))
+
+	total, err = pacer.GetDomainInflight(ctx, "shared.com")
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), total, "domain inflight must sum every job's slot")
+}
+
 func TestDomainPacer_EffectiveCap(t *testing.T) {
 	client := newTestClient(t)
 	cfg := DefaultPacerConfig()

--- a/internal/jobs/manager.go
+++ b/internal/jobs/manager.go
@@ -54,6 +54,10 @@ type JobManagerInterface interface {
 
 	// Returns nil rules (not error) when crawler is unavailable; callers treat that as "no restriction".
 	GetRobotsRules(ctx context.Context, domain string) (*crawler.RobotsRules, error)
+
+	// UpdateDomainAdaptiveDelay persists the pacer's learned per-domain
+	// delay (seconds). Callers debounce — this is a blind UPDATE.
+	UpdateDomainAdaptiveDelay(ctx context.Context, domain string, adaptiveDelaySeconds int) error
 }
 
 // Nil callback means legacy DB-queue mode (no external broker scheduling).
@@ -1300,6 +1304,24 @@ func (jm *JobManager) updateDomainCrawlDelay(ctx context.Context, domain string,
 	} else {
 		jobsLog.Info("Updated domain with crawl delay from robots.txt", "domain", domain, "crawl_delay", crawlDelay)
 	}
+}
+
+// UpdateDomainAdaptiveDelay persists the pacer's learned per-domain delay
+// (in seconds) so that the next worker restart can seed Redis from
+// Postgres rather than relearning from a 429 burst. Callers are expected
+// to debounce — this is a blind UPDATE.
+func (jm *JobManager) UpdateDomainAdaptiveDelay(ctx context.Context, domain string, adaptiveDelaySeconds int) error {
+	if adaptiveDelaySeconds < 0 {
+		return nil
+	}
+	return jm.dbQueue.Execute(ctx, func(tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx, `
+			UPDATE domains
+			SET adaptive_delay_seconds = $1
+			WHERE name = $2
+		`, adaptiveDelaySeconds, domain)
+		return err
+	})
 }
 
 func (jm *JobManager) IsJobComplete(job *Job) bool {

--- a/internal/jobs/pacer_writeback.go
+++ b/internal/jobs/pacer_writeback.go
@@ -18,9 +18,11 @@ type adaptiveDelayPersister interface {
 }
 
 type domainWriteState struct {
-	lastWriteAt  time.Time
-	lastValueSec int
-	inFlight     bool
+	// lastAttemptAt drives the debounce window so a failing Postgres
+	// can't trigger one retry per Release on the hot path.
+	lastAttemptAt time.Time
+	lastValueSec  int
+	inFlight      bool
 }
 
 // adaptiveDelayWriteback debounces writes of the pacer's learned per-domain
@@ -53,7 +55,15 @@ func (w *adaptiveDelayWriteback) Observe(ctx context.Context, domain string, new
 		return
 	}
 
-	seconds := newDelayMS / 1000
+	// Ceil ms→sec so a sub-second learned back-off (e.g. the default 500ms
+	// step) doesn't serialise to zero and reseed an empty adaptive delay
+	// after restart. The schema column is integer seconds; rounding up is
+	// the conservative choice — preferring slightly slower next-start
+	// crawl rate over reopening the burst we are trying to prevent.
+	seconds := 0
+	if newDelayMS > 0 {
+		seconds = (newDelayMS + 999) / 1000
+	}
 
 	w.mu.Lock()
 	state, ok := w.states[domain]
@@ -63,16 +73,26 @@ func (w *adaptiveDelayWriteback) Observe(ctx context.Context, domain string, new
 	}
 
 	now := time.Now()
-	tooSoon := !state.lastWriteAt.IsZero() && now.Sub(state.lastWriteAt) < w.interval
+	tooSoon := !state.lastAttemptAt.IsZero() && now.Sub(state.lastAttemptAt) < w.interval
 	unchanged := state.lastValueSec == seconds
 	if state.inFlight || tooSoon || unchanged {
 		w.mu.Unlock()
 		return
 	}
 	state.inFlight = true
+	state.lastAttemptAt = now
 	w.mu.Unlock()
 
-	go w.persist(ctx, domain, seconds)
+	// Detach from the caller's context: when the worker pool's Stop()
+	// cancels its ctx, in-flight write-backs would abort and the learned
+	// adaptive delay would be lost. A bounded timeout keeps a hung DB
+	// from leaking goroutines.
+	_ = ctx
+	go func() { //nolint:gosec // G118: detached on purpose so Stop() cannot abort the write-back
+		persistCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		w.persist(persistCtx, domain, seconds)
+	}()
 }
 
 func (w *adaptiveDelayWriteback) persist(ctx context.Context, domain string, seconds int) {
@@ -86,11 +106,12 @@ func (w *adaptiveDelayWriteback) persist(ctx context.Context, domain string, sec
 	}
 	state.inFlight = false
 	if err != nil {
-		jobsLog.Warn("adaptive-delay write-back failed, will retry next window",
+		// Debounce keys off lastAttemptAt (set in Observe) so a failing
+		// Postgres doesn't get retried on every subsequent Release.
+		jobsLog.Warn("adaptive-delay write-back failed, will retry after debounce window",
 			"error", err, "domain", domain, "adaptive_delay_seconds", seconds)
 		return
 	}
-	state.lastWriteAt = time.Now()
 	state.lastValueSec = seconds
 	jobsLog.Debug("persisted adaptive delay",
 		"domain", domain, "adaptive_delay_seconds", seconds)

--- a/internal/jobs/pacer_writeback.go
+++ b/internal/jobs/pacer_writeback.go
@@ -1,0 +1,97 @@
+package jobs
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// Default cadence: write-back at most every 5 minutes per domain. Each
+// Release returns a fresh adaptive_delay_ms reading, but the value rarely
+// changes between calls — debouncing keeps the per-task hot path off of
+// Postgres while still persisting the learned rate within an order of
+// magnitude of when it stabilises.
+const defaultAdaptiveWritebackInterval = 5 * time.Minute
+
+type adaptiveDelayPersister interface {
+	UpdateDomainAdaptiveDelay(ctx context.Context, domain string, adaptiveDelaySeconds int) error
+}
+
+type domainWriteState struct {
+	lastWriteAt  time.Time
+	lastValueSec int
+	inFlight     bool
+}
+
+// adaptiveDelayWriteback debounces writes of the pacer's learned per-domain
+// delay to the durable domains.adaptive_delay_seconds column. The pacer
+// surfaces the post-update delay on every Release; this type swallows the
+// firehose and lets through one UPDATE per domain per debounce window when
+// the value has actually moved.
+type adaptiveDelayWriteback struct {
+	persister adaptiveDelayPersister
+	interval  time.Duration
+
+	mu     sync.Mutex
+	states map[string]*domainWriteState
+}
+
+func newAdaptiveDelayWriteback(persister adaptiveDelayPersister) *adaptiveDelayWriteback {
+	return &adaptiveDelayWriteback{
+		persister: persister,
+		interval:  defaultAdaptiveWritebackInterval,
+		states:    make(map[string]*domainWriteState),
+	}
+}
+
+// Observe is called from the Release hot path. newDelayMS < 0 means the
+// pacer did not touch adaptive_delay this release (no success and no
+// rate-limit) — nothing to persist. The write fires in a goroutine so the
+// caller never blocks on Postgres.
+func (w *adaptiveDelayWriteback) Observe(ctx context.Context, domain string, newDelayMS int) {
+	if w == nil || w.persister == nil || domain == "" || newDelayMS < 0 {
+		return
+	}
+
+	seconds := newDelayMS / 1000
+
+	w.mu.Lock()
+	state, ok := w.states[domain]
+	if !ok {
+		state = &domainWriteState{lastValueSec: -1}
+		w.states[domain] = state
+	}
+
+	now := time.Now()
+	tooSoon := !state.lastWriteAt.IsZero() && now.Sub(state.lastWriteAt) < w.interval
+	unchanged := state.lastValueSec == seconds
+	if state.inFlight || tooSoon || unchanged {
+		w.mu.Unlock()
+		return
+	}
+	state.inFlight = true
+	w.mu.Unlock()
+
+	go w.persist(ctx, domain, seconds)
+}
+
+func (w *adaptiveDelayWriteback) persist(ctx context.Context, domain string, seconds int) {
+	err := w.persister.UpdateDomainAdaptiveDelay(ctx, domain, seconds)
+
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	state, ok := w.states[domain]
+	if !ok {
+		return
+	}
+	state.inFlight = false
+	if err != nil {
+		jobsLog.Warn("adaptive-delay write-back failed, will retry next window",
+			"error", err, "domain", domain, "adaptive_delay_seconds", seconds)
+		return
+	}
+	state.lastWriteAt = time.Now()
+	state.lastValueSec = seconds
+	jobsLog.Debug("persisted adaptive delay",
+		"domain", domain, "adaptive_delay_seconds", seconds)
+}

--- a/internal/jobs/pacer_writeback_test.go
+++ b/internal/jobs/pacer_writeback_test.go
@@ -126,12 +126,15 @@ func TestAdaptiveDelayWriteback_FailureClearsInFlight(t *testing.T) {
 	w.Observe(ctx, "retry.com", 3000)
 
 	// First write errors; in-flight flag must clear so a follow-up can retry.
+	// Hold the lock for the duration of the field read — persist mutates
+	// these fields, so checking them lock-free would race the goroutine.
 	deadline := time.Now().Add(time.Second)
 	for time.Now().Before(deadline) {
 		w.mu.Lock()
 		state, ok := w.states["retry.com"]
+		cleared := ok && !state.inFlight && state.lastValueSec == -1
 		w.mu.Unlock()
-		if ok && !state.inFlight && state.lastValueSec == -1 {
+		if cleared {
 			break
 		}
 		time.Sleep(5 * time.Millisecond)

--- a/internal/jobs/pacer_writeback_test.go
+++ b/internal/jobs/pacer_writeback_test.go
@@ -81,7 +81,21 @@ func TestAdaptiveDelayWriteback_FirstObservationPersists(t *testing.T) {
 	calls := p.snapshot()
 	require.Len(t, calls, 1)
 	assert.Equal(t, "first.com", calls[0].domain)
-	assert.Equal(t, 2, calls[0].seconds, "ms->seconds should integer-divide")
+	assert.Equal(t, 3, calls[0].seconds, "ms->seconds should round up so sub-second learning is preserved")
+}
+
+func TestAdaptiveDelayWriteback_SubSecondRoundsUpToOne(t *testing.T) {
+	p := &recordingPersister{}
+	w := newAdaptiveDelayWriteback(p)
+
+	// 500ms is the default pacer step; truncating to 0 would reseed an
+	// empty adaptive delay after a worker restart.
+	w.Observe(context.Background(), "subsec.com", 500)
+	waitForCalls(t, p, 1)
+
+	calls := p.snapshot()
+	require.Len(t, calls, 1)
+	assert.Equal(t, 1, calls[0].seconds)
 }
 
 func TestAdaptiveDelayWriteback_DebouncesWithinWindow(t *testing.T) {

--- a/internal/jobs/pacer_writeback_test.go
+++ b/internal/jobs/pacer_writeback_test.go
@@ -1,0 +1,142 @@
+package jobs
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type recordingPersister struct {
+	mu    sync.Mutex
+	calls []struct {
+		domain  string
+		seconds int
+	}
+	failNext atomic.Bool
+}
+
+func (p *recordingPersister) UpdateDomainAdaptiveDelay(_ context.Context, domain string, seconds int) error {
+	if p.failNext.Load() {
+		p.failNext.Store(false)
+		return errors.New("simulated write error")
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.calls = append(p.calls, struct {
+		domain  string
+		seconds int
+	}{domain, seconds})
+	return nil
+}
+
+func (p *recordingPersister) snapshot() []struct {
+	domain  string
+	seconds int
+} {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	out := make([]struct {
+		domain  string
+		seconds int
+	}, len(p.calls))
+	copy(out, p.calls)
+	return out
+}
+
+func waitForCalls(t *testing.T, p *recordingPersister, want int) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if len(p.snapshot()) >= want {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("expected at least %d persister calls, got %d", want, len(p.snapshot()))
+}
+
+func TestAdaptiveDelayWriteback_NegativeIsNoop(t *testing.T) {
+	p := &recordingPersister{}
+	w := newAdaptiveDelayWriteback(p)
+
+	w.Observe(context.Background(), "noop.com", -1)
+	time.Sleep(50 * time.Millisecond)
+
+	assert.Empty(t, p.snapshot(), "negative newDelayMS must not trigger a write")
+}
+
+func TestAdaptiveDelayWriteback_FirstObservationPersists(t *testing.T) {
+	p := &recordingPersister{}
+	w := newAdaptiveDelayWriteback(p)
+
+	w.Observe(context.Background(), "first.com", 2500)
+	waitForCalls(t, p, 1)
+
+	calls := p.snapshot()
+	require.Len(t, calls, 1)
+	assert.Equal(t, "first.com", calls[0].domain)
+	assert.Equal(t, 2, calls[0].seconds, "ms->seconds should integer-divide")
+}
+
+func TestAdaptiveDelayWriteback_DebouncesWithinWindow(t *testing.T) {
+	p := &recordingPersister{}
+	w := newAdaptiveDelayWriteback(p)
+	w.interval = time.Hour // ensure window swallows repeat observations
+
+	ctx := context.Background()
+	w.Observe(ctx, "debounce.com", 1000)
+	waitForCalls(t, p, 1)
+
+	// Same value, then a moved value — both must be suppressed by the window.
+	w.Observe(ctx, "debounce.com", 1000)
+	w.Observe(ctx, "debounce.com", 5000)
+	time.Sleep(100 * time.Millisecond)
+
+	assert.Len(t, p.snapshot(), 1, "second observation inside window must not write")
+}
+
+func TestAdaptiveDelayWriteback_UnchangedValueSkipsWrite(t *testing.T) {
+	p := &recordingPersister{}
+	w := newAdaptiveDelayWriteback(p)
+	w.interval = time.Nanosecond // window non-blocking; suppression must come from value equality
+
+	ctx := context.Background()
+	w.Observe(ctx, "still.com", 2000)
+	waitForCalls(t, p, 1)
+
+	w.Observe(ctx, "still.com", 2000)
+	time.Sleep(50 * time.Millisecond)
+
+	assert.Len(t, p.snapshot(), 1, "unchanged seconds value must not produce a second write")
+}
+
+func TestAdaptiveDelayWriteback_FailureClearsInFlight(t *testing.T) {
+	p := &recordingPersister{}
+	p.failNext.Store(true)
+	w := newAdaptiveDelayWriteback(p)
+	w.interval = time.Nanosecond
+
+	ctx := context.Background()
+	w.Observe(ctx, "retry.com", 3000)
+
+	// First write errors; in-flight flag must clear so a follow-up can retry.
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		w.mu.Lock()
+		state, ok := w.states["retry.com"]
+		w.mu.Unlock()
+		if ok && !state.inFlight && state.lastValueSec == -1 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	w.Observe(ctx, "retry.com", 3000)
+	waitForCalls(t, p, 1)
+}

--- a/internal/jobs/pacer_writeback_test.go
+++ b/internal/jobs/pacer_writeback_test.go
@@ -22,8 +22,7 @@ type recordingPersister struct {
 }
 
 func (p *recordingPersister) UpdateDomainAdaptiveDelay(_ context.Context, domain string, seconds int) error {
-	if p.failNext.Load() {
-		p.failNext.Store(false)
+	if p.failNext.Swap(false) {
 		return errors.New("simulated write error")
 	}
 	p.mu.Lock()
@@ -61,14 +60,30 @@ func waitForCalls(t *testing.T, p *recordingPersister, want int) {
 	t.Fatalf("expected at least %d persister calls, got %d", want, len(p.snapshot()))
 }
 
+// assertCallCountStable polls the persister for `window` and fails if the
+// observed call count ever exceeds `want`. Catches late writes that a
+// single Sleep+assert would miss.
+func assertCallCountStable(t *testing.T, p *recordingPersister, want int, window time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(window)
+	for time.Now().Before(deadline) {
+		if got := len(p.snapshot()); got > want {
+			t.Fatalf("expected at most %d persister calls during %s window, got %d", want, window, got)
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if got := len(p.snapshot()); got != want {
+		t.Fatalf("expected exactly %d persister calls after %s, got %d", want, window, got)
+	}
+}
+
 func TestAdaptiveDelayWriteback_NegativeIsNoop(t *testing.T) {
 	p := &recordingPersister{}
 	w := newAdaptiveDelayWriteback(p)
 
 	w.Observe(context.Background(), "noop.com", -1)
-	time.Sleep(50 * time.Millisecond)
 
-	assert.Empty(t, p.snapshot(), "negative newDelayMS must not trigger a write")
+	assertCallCountStable(t, p, 0, 50*time.Millisecond)
 }
 
 func TestAdaptiveDelayWriteback_FirstObservationPersists(t *testing.T) {
@@ -110,9 +125,8 @@ func TestAdaptiveDelayWriteback_DebouncesWithinWindow(t *testing.T) {
 	// Same value, then a moved value — both must be suppressed by the window.
 	w.Observe(ctx, "debounce.com", 1000)
 	w.Observe(ctx, "debounce.com", 5000)
-	time.Sleep(100 * time.Millisecond)
 
-	assert.Len(t, p.snapshot(), 1, "second observation inside window must not write")
+	assertCallCountStable(t, p, 1, 100*time.Millisecond)
 }
 
 func TestAdaptiveDelayWriteback_UnchangedValueSkipsWrite(t *testing.T) {
@@ -125,9 +139,8 @@ func TestAdaptiveDelayWriteback_UnchangedValueSkipsWrite(t *testing.T) {
 	waitForCalls(t, p, 1)
 
 	w.Observe(ctx, "still.com", 2000)
-	time.Sleep(50 * time.Millisecond)
 
-	assert.Len(t, p.snapshot(), 1, "unchanged seconds value must not produce a second write")
+	assertCallCountStable(t, p, 1, 50*time.Millisecond)
 }
 
 func TestAdaptiveDelayWriteback_FailureClearsInFlight(t *testing.T) {

--- a/internal/jobs/stream_worker.go
+++ b/internal/jobs/stream_worker.go
@@ -384,7 +384,9 @@ func (swp *StreamWorkerPool) handleOutcome(ctx context.Context, msg broker.Strea
 	if err != nil {
 		jobsLog.Warn("pacer release failed", "error", err, "domain", domain)
 	}
-	swp.adaptiveWriteback.Observe(ctx, domain, newDelayMS)
+	if swp.adaptiveWriteback != nil {
+		swp.adaptiveWriteback.Observe(ctx, domain, newDelayMS)
+	}
 
 	// Hand the payload to the persister BEFORE QueueTaskUpdate — the
 	// batch manager mutates the row in place. Enqueue is non-blocking

--- a/internal/jobs/stream_worker.go
+++ b/internal/jobs/stream_worker.go
@@ -109,6 +109,8 @@ type StreamWorkerPool struct {
 	jobInfoMutex sync.RWMutex
 	jobInfoGroup singleflight.Group
 
+	adaptiveWriteback *adaptiveDelayWriteback
+
 	activeJobs   []string
 	activeJobsMu sync.RWMutex
 
@@ -149,7 +151,7 @@ func linkDiscoveryMaxInflight() int {
 }
 
 func NewStreamWorkerPool(deps StreamWorkerDeps, opts StreamWorkerOpts) *StreamWorkerPool {
-	return &StreamWorkerPool{
+	pool := &StreamWorkerPool{
 		consumer:         deps.Consumer,
 		scheduler:        deps.Scheduler,
 		counters:         deps.Counters,
@@ -164,6 +166,10 @@ func NewStreamWorkerPool(deps StreamWorkerDeps, opts StreamWorkerOpts) *StreamWo
 		jobInfoCache:     make(map[string]*cachedJobInfo),
 		linkDiscoverySem: make(chan struct{}, linkDiscoveryMaxInflight()),
 	}
+	if deps.JobManager != nil {
+		pool.adaptiveWriteback = newAdaptiveDelayWriteback(deps.JobManager)
+	}
+	return pool
 }
 
 // Start launches consumer goroutines and the reclaim loop.
@@ -374,9 +380,11 @@ func (swp *StreamWorkerPool) handleOutcome(ctx context.Context, msg broker.Strea
 		}
 	}
 
-	if err := swp.pacer.Release(ctx, domain, msg.JobID, outcome.Success, outcome.RateLimited); err != nil {
+	newDelayMS, err := swp.pacer.Release(ctx, domain, msg.JobID, outcome.Success, outcome.RateLimited)
+	if err != nil {
 		jobsLog.Warn("pacer release failed", "error", err, "domain", domain)
 	}
+	swp.adaptiveWriteback.Observe(ctx, domain, newDelayMS)
 
 	// Hand the payload to the persister BEFORE QueueTaskUpdate — the
 	// batch manager mutates the row in place. Enqueue is non-blocking
@@ -533,7 +541,7 @@ func (swp *StreamWorkerPool) reclaimStaleMessages(ctx context.Context) {
 			if _, err := swp.counters.Decrement(ctx, jobID); err != nil {
 				jobsLog.Warn("counter decrement on dead-letter failed", "error", err)
 			}
-			if err := swp.pacer.Release(ctx, msg.Host, jobID, false, false); err != nil {
+			if _, err := swp.pacer.Release(ctx, msg.Host, jobID, false, false); err != nil {
 				jobsLog.Warn("pacer release on dead-letter failed", "error", err, "domain", msg.Host)
 			}
 
@@ -739,6 +747,20 @@ func (swp *StreamWorkerPool) fetchJobInfo(ctx context.Context, jobID string) (*J
 	}
 	if adaptiveFloor.Valid {
 		info.AdaptiveDelayFloor = int(adaptiveFloor.Int64)
+	}
+
+	// Seed the pacer from the durable Postgres value so a new worker /
+	// freshly flushed Redis doesn't relearn the domain's rate limit from
+	// scratch. HSETNX inside Seed preserves any live state, so re-seeding
+	// on every job-info cache miss is safe and cheap.
+	if swp.pacer != nil {
+		baseDelayMS := info.CrawlDelay * 1000
+		adaptiveDelayMS := info.AdaptiveDelay * 1000
+		floorMS := info.AdaptiveDelayFloor * 1000
+		if seedErr := swp.pacer.Seed(ctx, info.DomainName, baseDelayMS, adaptiveDelayMS, floorMS); seedErr != nil {
+			jobsLog.Warn("pacer seed from postgres failed, continuing",
+				"error", seedErr, "domain", info.DomainName)
+		}
 	}
 
 	// Without robots rules, link discovery would let every URL through

--- a/internal/jobs/waf_circuit_breaker_dispatch_test.go
+++ b/internal/jobs/waf_circuit_breaker_dispatch_test.go
@@ -44,6 +44,7 @@ func (s *stubJobManager) MarkJobRunning(context.Context, string) error          
 func (s *stubJobManager) GetRobotsRules(context.Context, string) (*crawler.RobotsRules, error) {
 	return nil, nil
 }
+func (s *stubJobManager) UpdateDomainAdaptiveDelay(context.Context, string, int) error { return nil }
 
 // TestMaybeTripFromOutcome_AsyncDispatch verifies the stream worker
 // hot path isn't held up by BlockJob's terminal-state DB write. We


### PR DESCRIPTION
## Summary

The Redis-backed `DomainPacer` learns a per-domain `adaptive_delay_ms` from
429/success signals but had no durable backing store: worker restarts called
`FlushAdaptiveDelays` and every job relearned the rate limit from scratch. The
unbounded 20-wide opening burst that this produced elevated Fly's egress IP
score in Cloudflare's bot management and caused the merrypeople.com slowness
(≈5h for 1,414 pages at ~5 pages/min) plus collateral CF managed challenges on
adjacent Shopify stores (milkcan.com.au, hinu.co) on 2026-05-11.

This PR closes the loop:

- **Seed from Postgres** — `fetchJobInfo` reseeds the pacer from
  `domains.adaptive_delay_seconds` (and the floor) on every job-info cache
  miss. `HSETNX` makes it safe to re-call; live Redis state wins.
- **Write back to Postgres** — `pacer.Release` now returns the post-update
  `adaptive_delay_ms`. A small debouncer (`internal/jobs/pacer_writeback.go`)
  swallows the firehose and lets through one UPDATE per domain per 5-minute
  window when the value has moved. Fire-and-forget goroutine so the hot path
  never blocks on Postgres.
- **Stop the unconditional flush** — `GNH_PACER_FLUSH_ON_START` defaults to
  off; flag flipped to opt-in for incident recovery only.
- **Useful per-domain concurrency** — dispatcher now caps inflight at
  `ceil(GNH_PACER_EST_RESPONSE_MS / adaptive_delay_ms)` (default est 1500ms).
  Above the cap, additional ZSET entries skip dispatch cheaply without
  consuming the per-domain gate. This collapses the burst that fragments CF
  reputation.

## Test plan

- [x] `go test ./...` passes (short suite, all packages)
- [x] `go vet ./...` clean
- [x] `gofmt`/`goimports` clean
- [x] `scripts/security-check.sh` clean (govulncheck, trivy, gosec)
- [x] New unit tests:
  - `TestDomainPacer_Release_ReturnsAdaptiveDelay` — Release surfaces new delay
  - `TestDomainPacer_EffectiveCap` — cap=0 when disabled, ceil otherwise
  - `TestDispatcher_DomainCap_SaturatesAtUsefulConcurrency` — 5 entries → 1 dispatch under high adaptive delay; remaining stay at original run_at
  - `TestAdaptiveDelayWriteback_*` — debouncing, negative no-op, failure clears in-flight, value-equality suppression
- [ ] Soak test on staging against a Shopify domain: confirm `domains.adaptive_delay_seconds` is non-zero after first job and second job opens at the learned rate (no rediscovery burst)

## Risk

- `Release` signature changed from `error` to `(int, error)`. Two production
  call sites updated; one test updated. No external API.
- Per-domain cap depends on `GNH_PACER_EST_RESPONSE_MS` (default 1500ms). If a
  domain is materially faster, the cap is too low — easy to tune via env or
  replace the constant with an EWMA in a follow-up.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Good-Native/codesmith/hover/pr/383"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-domain adaptive pacing values are now durably persisted, reseeded from durable storage on cache miss, and written back asynchronously.
  * Dispatcher enforces a per-domain inflight-task cap derived from adaptive delay to prevent burst-driven reputation problems.

* **Behavior Changes**
  * Adaptive-delay flush at startup is now opt-in (enable with GNH_PACER_FLUSH_ON_START=true).

* **Tests**
  * Added tests covering domain-cap behavior and adaptive-delay writeback/persistence.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Good-Native/hover/pull/383)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->