### PR TITLE
Drop Worker-id suffix from crawler UA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,8 +31,8 @@ On merge, CI will:
 ### Changed
 
 - Crawler user agent is now always exactly `config.UserAgent`. Dropped the dead
-  ` Worker-<id>` suffix branch in `crawler.New` along with the unused variadic
-  ID parameter and struct field.
+  `Worker-<id>` suffix branch in `crawler.New` along with the unused variadic ID
+  parameter and struct field.
 
 ## Full changelog history
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,11 @@ On merge, CI will:
 
 ## [Unreleased]
 
-_Add unreleased changes here._
+### Changed
+
+- Crawler user agent is now always exactly `config.UserAgent`. Dropped the dead
+  ` Worker-<id>` suffix branch in `crawler.New` along with the unused variadic
+  ID parameter and struct field.
 
 ## Full changelog history
 

--- a/internal/crawler/crawler.go
+++ b/internal/crawler/crawler.go
@@ -223,7 +223,6 @@ func buildRequestAttemptDiagnostics(
 type Crawler struct {
 	config      *Config
 	colly       *colly.Collector
-	id          string
 	metricsMap  *sync.Map
 	aia         *aiaTransport
 	probeClient *http.Client // Shared to avoid per-call transport leaks.
@@ -291,23 +290,13 @@ func (t *tracingRoundTripper) RoundTrip(req *http.Request) (*http.Response, erro
 	return t.transport.RoundTrip(req)
 }
 
-func New(config *Config, id ...string) *Crawler {
+func New(config *Config) *Crawler {
 	if config == nil {
 		config = DefaultConfig()
 	}
 
-	crawlerID := ""
-	if len(id) > 0 {
-		crawlerID = id[0]
-	}
-
-	userAgent := config.UserAgent
-	if crawlerID != "" {
-		userAgent = fmt.Sprintf("%s Worker-%s", config.UserAgent, crawlerID)
-	}
-
 	c := colly.NewCollector(
-		colly.UserAgent(userAgent),
+		colly.UserAgent(config.UserAgent),
 		colly.MaxDepth(1),
 		colly.Async(true),
 		colly.AllowURLRevisit(),
@@ -373,7 +362,6 @@ func New(config *Config, id ...string) *Crawler {
 	return &Crawler{
 		config:     config,
 		colly:      c,
-		id:         crawlerID,
 		metricsMap: metricsMap,
 		aia:        aiaRT,
 		probeClient: &http.Client{


### PR DESCRIPTION
## Summary

- `crawler.New(config, id...)` had a dead branch that appended ` Worker-<id>` to the configured `UserAgent`. No production caller passes an ID — all three call sites (`cmd/worker/main.go`, `cmd/app/main.go`, `internal/jobs/manager.go`) use `crawler.New(crawlerConfig)`, so the suffix has never been emitted.
- Removed the suffix branch plus the now-unused `id ...string` variadic, `crawlerID` local, and the never-read `id` field on the `Crawler` struct.
- Signature change is non-breaking (no caller passed an ID); behaviour unchanged in production.

## Why

`docs/research/2025-10/crawling-best-practice/issue-6-user-agent-rotation.md` already notes the Worker-N suffix isn't used. Leaving the branch in place was a foot-gun — any future caller passing an ID would silently mutate the UA we publish on `/bot` and rely on for robots.txt identification.

## Test plan

- [x] `gofmt -w internal/crawler/crawler.go`
- [x] `go build ./...`
- [x] `go test ./internal/crawler/...` (passes, 15.3s)
- [ ] Spot-check `/bot` page renders `HoverBot/1.0 (+https://goodnative.co)` (no behavioural change expected — production UA was already this exact string)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Good-Native/codesmith/hover/pr/384"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified crawler initialization: per-crawler identifiers removed and worker-specific User-Agent suffixes dropped.
  * Crawler now consistently uses the User-Agent defined in configuration, ensuring uniform request headers across workers.

* **Documentation**
  * Changelog updated to reflect the User-Agent behavior change and removal of the prior per-worker ID behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Good-Native/hover/pull/384)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->