### PR TITLE
Retry Redis ping on startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,16 @@ On merge, CI will:
 
 ## [Unreleased]
 
-_Add unreleased changes here._
+### Fixed
+
+- App, worker, and analysis binaries no longer `Fatal` on the first Redis `PING`
+  failure at startup. The ping is now wrapped in a bounded retry loop (30 s
+  total, 3 s per attempt, capped exponential backoff) so the binary rides out
+  the Upstash-on-Fly cold-start window that briefly closes connections with EOF
+  on freshly-provisioned review apps. Production behaviour is unchanged — a
+  healthy Redis still succeeds on the first attempt and persistent
+  misconfiguration still fails fast. Resolves the recurring EOF burst on every
+  PR preview deploy (Sentry: HOVER-JX, HOVER-MD, HOVER-JZ).
 
 ## Full changelog history
 

--- a/cmd/analysis/main.go
+++ b/cmd/analysis/main.go
@@ -95,7 +95,7 @@ func main() {
 		analysisLog.Fatal("failed to create Redis client", "error", err)
 	}
 	defer redisClient.Close()
-	if err := redisClient.Ping(context.Background()); err != nil {
+	if err := redisClient.PingWithRetry(context.Background(), 30*time.Second, 3*time.Second); err != nil {
 		analysisLog.Fatal("failed to ping Redis", "error", err)
 	}
 	analysisLog.Info("connected to Redis")

--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -547,7 +547,7 @@ func main() {
 		redisClient = client
 		defer redisClient.Close()
 
-		if err := redisClient.Ping(context.Background()); err != nil {
+		if err := redisClient.PingWithRetry(context.Background(), 30*time.Second, 3*time.Second); err != nil {
 			startupLog.Fatal("failed to ping Redis", "error", err)
 		}
 		startupLog.Info("connected to Redis")

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -115,7 +115,7 @@ func main() {
 	}
 	defer redisClient.Close()
 
-	if err := redisClient.Ping(context.Background()); err != nil {
+	if err := redisClient.PingWithRetry(context.Background(), 30*time.Second, 3*time.Second); err != nil {
 		workerLog.Fatal("failed to ping Redis", "error", err)
 	}
 	workerLog.Info("connected to Redis")

--- a/internal/broker/redis.go
+++ b/internal/broker/redis.go
@@ -77,6 +77,51 @@ func (c *Client) Ping(ctx context.Context) error {
 	return c.rdb.Ping(ctx).Err()
 }
 
+// PingWithRetry retries Ping with capped exponential backoff until the
+// total budget elapses. Each attempt uses its own perAttempt timeout so
+// a hung server can't stall the loop. Returns nil on first success or
+// the last error if the budget is exhausted. Exists because Upstash-on-Fly
+// review apps occasionally close the first PING with EOF during cold
+// start, which used to Fatal the binary on boot (see HOVER-JX/MD/JZ).
+func (c *Client) PingWithRetry(ctx context.Context, total, perAttempt time.Duration) error {
+	return pingWithRetry(ctx, total, perAttempt, c.Ping)
+}
+
+func pingWithRetry(ctx context.Context, total, perAttempt time.Duration, ping func(context.Context) error) error {
+	deadline := time.Now().Add(total)
+	backoff := 100 * time.Millisecond
+	const maxBackoff = 2 * time.Second
+
+	var lastErr error
+	for {
+		attemptCtx, cancel := context.WithTimeout(ctx, perAttempt)
+		err := ping(attemptCtx)
+		cancel()
+		if err == nil {
+			return nil
+		}
+		lastErr = err
+
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		if !time.Now().Add(backoff).Before(deadline) {
+			return lastErr
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(backoff):
+		}
+
+		backoff *= 2
+		if backoff > maxBackoff {
+			backoff = maxBackoff
+		}
+	}
+}
+
 func (c *Client) Close() error {
 	return c.rdb.Close()
 }

--- a/internal/broker/redis.go
+++ b/internal/broker/redis.go
@@ -94,7 +94,19 @@ func pingWithRetry(ctx context.Context, total, perAttempt time.Duration, ping fu
 
 	var lastErr error
 	for {
-		attemptCtx, cancel := context.WithTimeout(ctx, perAttempt)
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			if lastErr != nil {
+				return lastErr
+			}
+			return context.DeadlineExceeded
+		}
+
+		attemptTimeout := perAttempt
+		if attemptTimeout > remaining {
+			attemptTimeout = remaining
+		}
+		attemptCtx, cancel := context.WithTimeout(ctx, attemptTimeout)
 		err := ping(attemptCtx)
 		cancel()
 		if err == nil {
@@ -105,14 +117,19 @@ func pingWithRetry(ctx context.Context, total, perAttempt time.Duration, ping fu
 		if ctx.Err() != nil {
 			return ctx.Err()
 		}
-		if !time.Now().Add(backoff).Before(deadline) {
+
+		sleep := backoff
+		if remaining := time.Until(deadline); sleep > remaining {
+			sleep = remaining
+		}
+		if sleep <= 0 {
 			return lastErr
 		}
 
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
-		case <-time.After(backoff):
+		case <-time.After(sleep):
 		}
 
 		backoff *= 2

--- a/internal/broker/redis_test.go
+++ b/internal/broker/redis_test.go
@@ -2,13 +2,58 @@ package broker
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// TestPingWithRetry covers the helper that wraps Ping with a bounded
+// retry loop. It uses a stub ping function so the test stays
+// hermetic and fast — no miniredis, no sleeps longer than the
+// helper's first backoff (100 ms).
+func TestPingWithRetry(t *testing.T) {
+	t.Run("immediate success", func(t *testing.T) {
+		var calls int
+		err := pingWithRetry(context.Background(), time.Second, 100*time.Millisecond,
+			func(context.Context) error { calls++; return nil })
+		require.NoError(t, err)
+		assert.Equal(t, 1, calls)
+	})
+
+	t.Run("succeeds after transient errors", func(t *testing.T) {
+		var calls int
+		err := pingWithRetry(context.Background(), 2*time.Second, 100*time.Millisecond,
+			func(context.Context) error {
+				calls++
+				if calls < 3 {
+					return errors.New("EOF")
+				}
+				return nil
+			})
+		require.NoError(t, err)
+		assert.Equal(t, 3, calls)
+	})
+
+	t.Run("exhausts budget returning last error", func(t *testing.T) {
+		want := errors.New("still EOF")
+		err := pingWithRetry(context.Background(), 250*time.Millisecond, 50*time.Millisecond,
+			func(context.Context) error { return want })
+		require.ErrorIs(t, err, want)
+	})
+
+	t.Run("aborts on context cancellation", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		err := pingWithRetry(ctx, time.Second, 100*time.Millisecond,
+			func(context.Context) error { return errors.New("boom") })
+		require.ErrorIs(t, err, context.Canceled)
+	})
+}
 
 // TestClient_ClearAll seeds every prefix the broker owns plus an
 // unrelated key, then asserts ClearAll wipes only the hover:* keys.

--- a/internal/broker/redis_test.go
+++ b/internal/broker/redis_test.go
@@ -53,6 +53,21 @@ func TestPingWithRetry(t *testing.T) {
 			func(context.Context) error { return errors.New("boom") })
 		require.ErrorIs(t, err, context.Canceled)
 	})
+
+	// Guards against a regression where perAttempt > total let the
+	// final attempt run past the overall budget. The ping function
+	// blocks until its per-attempt context expires, so without the
+	// clamp the call would take perAttempt rather than total.
+	t.Run("clamps attempt timeout to remaining budget", func(t *testing.T) {
+		start := time.Now()
+		err := pingWithRetry(context.Background(), 80*time.Millisecond, time.Second,
+			func(ctx context.Context) error {
+				<-ctx.Done()
+				return ctx.Err()
+			})
+		require.Error(t, err)
+		assert.LessOrEqual(t, time.Since(start), 250*time.Millisecond)
+	})
 }
 
 // TestClient_ClearAll seeds every prefix the broker owns plus an


### PR DESCRIPTION
## Summary

- Add `(*broker.Client).PingWithRetry(ctx, total, perAttempt)` with capped exponential backoff and per-attempt timeout.
- Swap the three `Ping` call sites in `cmd/app`, `cmd/worker`, `cmd/analysis` to use it (30s budget, 3s per attempt).
- Add unit coverage for the retry loop (immediate success, transient errors, budget exhaustion, context cancellation).

## Why

Every PR preview spin-up generated a small burst of Sentry errors on `staging` — `*errors.errorString: EOF` reported as ``failed to ping Redis`` from each of the three binaries. Triaged in Sentry:

- [HOVER-JX](https://harvey-au.sentry.io/issues/HOVER-JX) — `hover-worker-pr-*`, 169 occurrences since 2026-04-19.
- [HOVER-MD](https://harvey-au.sentry.io/issues/HOVER-MD) — `hover-analysis-pr-*`, 158 occurrences since 2026-04-28.
- [HOVER-JZ](https://harvey-au.sentry.io/issues/HOVER-JZ) — `hover-pr-*`, 153 occurrences since 2026-04-20.

Review apps provision a fresh per-PR Upstash-on-Fly Redis and pass the URL as a secret. The Fly machine boots and calls `client.Ping(context.Background())` immediately. During the Upstash cold-start window TCP connects but the server closes the connection with EOF before answering PING. The client's built-in `MaxRetries: 3` burns through in milliseconds inside the same dead window, the binary `Fatal`s, Fly restarts the machine, and the next boot succeeds — hence the burst-per-deploy pattern with zero prod impact (production Redis is warm).

The fix lets the binary ride out the cold-start window instead of crashing. On a healthy Redis the first ping succeeds and the helper returns immediately, so there's no production latency regression. On genuine misconfiguration the helper still exhausts its budget and `Fatal`s — Sentry still gets one signal instead of three back-to-back.

Fixes HOVER-JX HOVER-MD HOVER-JZ

## Test plan

- [x] `gofmt`, `goimports`, `go vet ./internal/broker/... ./cmd/app ./cmd/worker ./cmd/analysis`
- [x] `go test ./internal/broker/` — full package, including new `TestPingWithRetry`
- [x] `go build ./cmd/app ./cmd/worker ./cmd/analysis`
- [ ] PR review-apps deploy: confirm no EOF events on `hover-pr-<N>`, `hover-worker-pr-<N>`, `hover-analysis-pr-<N>` during boot and that `connected to Redis` appears in all three startup logs

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Good-Native/codesmith/hover/pr/386"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Redis startup resilience: services now retry connecting for a bounded window to tolerate transient connection issues.

* **Bug Fixes**
  * Prevents premature shutdown on transient Redis failures while still failing on persistent misconfiguration.

* **Tests**
  * Added tests covering retry behavior, failure handling, and cancellation scenarios.

* **Documentation**
  * Changelog updated to reflect the startup retry behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Good-Native/hover/pull/386)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->