### PR TITLE
Drop legacy task-html storage bucket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,8 +40,15 @@ On merge, CI will:
   the bucket row; bucket contents must be cleared via the Supabase Storage
   dashboard or API before the migration is applied, and the foreign key from
   `storage.objects` to `storage.buckets` will block the migration otherwise as
-  an intentional safety net. The `tasks.html_storage_*` columns are retained for
-  historical rows and will be reviewed in a follow-up.
+  an intentional safety net.
+- Cleared dangling `task-html` pointers on the `tasks` table. Rows written
+  between 2026-03-21 and 2026-04-25 had `html_storage_bucket = 'task-html'` and
+  a `html_storage_path` referencing the now-removed bucket. Both columns are
+  NULLed for those rows; the remaining HTML metadata columns
+  (`html_content_type`, `html_content_encoding`, `html_size_bytes`,
+  `html_compressed_size_bytes`, `html_sha256`, `html_captured_at`) are kept for
+  historical analysis. The `html_storage_*` columns remain in active use for
+  newer rows, which point at the Cloudflare R2 bucket.
 
 ## Full changelog history
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,17 +30,17 @@ On merge, CI will:
 
 ### Changed
 
-- Removed the legacy `task-html` Supabase Storage bucket. Page HTML has been
-  written direct to Cloudflare R2 since 2026-04-25, so the bucket was no longer
-  referenced by any code path but had retained the objects written during the
-  four-week window when it was the hot store. The accumulated bytes pushed the
-  Supabase project past its 100 GB allowance and triggered connection-slot
+- Retired the legacy `task-html` Supabase Storage bucket. Page HTML has been
+  written directly to Cloudflare R2 since 2026-04-25, so the bucket was no
+  longer referenced by any code path but had retained the objects written during
+  the four-week window when it was the hot store. The accumulated bytes pushed
+  the Supabase project past its 100 GB allowance and triggered connection-slot
   restrictions on the pooler, surfacing as `pgconn.ConnectError` events in
-  Sentry (HOVER-JG). The migration drops only the service-role RLS policy and
-  the bucket row; bucket contents must be cleared via the Supabase Storage
-  dashboard or API before the migration is applied, and the foreign key from
-  `storage.objects` to `storage.buckets` will block the migration otherwise as
-  an intentional safety net.
+  Sentry (HOVER-JG). The migration drops only the service-role RLS policy on
+  `storage.objects`. Removal of the bucket row itself cannot be done via SQL
+  (Supabase blocks direct deletes from `storage.buckets` with SQLSTATE 42501)
+  and must be performed via the Supabase Storage dashboard or API as a manual
+  operational step, after the bucket has been emptied.
 - Cleared dangling `task-html` pointers on the `tasks` table. Rows written
   between 2026-03-21 and 2026-04-25 had `html_storage_bucket = 'task-html'` and
   a `html_storage_path` referencing the now-removed bucket. Both columns are

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,20 @@ On merge, CI will:
 
 ## [Unreleased]
 
-_Add unreleased changes here._
+### Changed
+
+- Removed the legacy `task-html` Supabase Storage bucket. Page HTML has been
+  written direct to Cloudflare R2 since 2026-04-25, so the bucket was no longer
+  referenced by any code path but had retained the objects written during the
+  four-week window when it was the hot store. The accumulated bytes pushed the
+  Supabase project past its 100 GB allowance and triggered connection-slot
+  restrictions on the pooler, surfacing as `pgconn.ConnectError` events in
+  Sentry (HOVER-JG). The migration drops only the service-role RLS policy and
+  the bucket row; bucket contents must be cleared via the Supabase Storage
+  dashboard or API before the migration is applied, and the foreign key from
+  `storage.objects` to `storage.buckets` will block the migration otherwise as
+  an intentional safety net. The `tasks.html_storage_*` columns are retained for
+  historical rows and will be reviewed in a follow-up.
 
 ## Full changelog history
 

--- a/docs/plans/page-content-storage-plan.md
+++ b/docs/plans/page-content-storage-plan.md
@@ -193,7 +193,12 @@ Relevant current behaviour:
 
 ## 11. Suggested Bucket Setup
 
-- bucket name: `task-html`
+> **Historical — superseded.** The `task-html` Supabase Storage bucket was
+> dropped on 2026-05-21. Page HTML now lives in the private Cloudflare R2 bucket
+> configured via `ARCHIVE_BUCKET` (production: `native-hover-archive`). See
+> `## 3. Recommended Approach` for the current design.
+
+- bucket name: `task-html` (no longer present)
 - visibility: private
 - access: signed URLs only when needed
 

--- a/docs/plans/page-content-storage-plan.md
+++ b/docs/plans/page-content-storage-plan.md
@@ -194,19 +194,11 @@ Relevant current behaviour:
 ## 11. Suggested Bucket Setup
 
 > **Historical — superseded.** The `task-html` Supabase Storage bucket was
-> dropped on 2026-05-21. Page HTML now lives in the private Cloudflare R2 bucket
+> retired on 2026-05-21. Page HTML now lives in the private Cloudflare R2 bucket
 > configured via `ARCHIVE_BUCKET` (production: `native-hover-archive`). See
-> `## 3. Recommended Approach` for the current design.
-
-- bucket name: `task-html` (no longer present)
-- visibility: private
-- access: signed URLs only when needed
-
-Reason:
-
-- page bodies may contain sensitive content, tokens in markup, or unpublished
-  data
-- private storage is the safer default
+> `## 3. Recommended Approach` for the current design. The original Supabase
+> Storage recommendations that previously occupied this section have been
+> removed to avoid being mistaken for current guidance.
 
 ## 12. Data Volume Planning
 

--- a/supabase/migrations/20260521000000_drop_task_html_bucket.sql
+++ b/supabase/migrations/20260521000000_drop_task_html_bucket.sql
@@ -1,17 +1,16 @@
--- Drop the legacy `task-html` Supabase Storage bucket.
+-- Drop the service-role RLS policy attached to the legacy `task-html`
+-- Supabase Storage bucket.
 --
--- Page HTML has been written direct to Cloudflare R2 since 2026-04-25
--- (see CHANGELOG entry "All page HTML storage now uses ..." and the
--- `## 3. Recommended Approach` section of
+-- Page HTML has been written directly to Cloudflare R2 since 2026-04-25
+-- (see the `## 3. Recommended Approach` section of
 -- `docs/plans/page-content-storage-plan.md`). No Go code path references
--- the `task-html` bucket; it has been holding stale objects from the
--- four-week window when it was the hot store.
+-- the `task-html` bucket.
 --
--- Operational precondition: the bucket must be emptied via the Supabase
--- Storage dashboard or API before this migration is applied. The foreign
--- key from `storage.objects` to `storage.buckets` will block the DELETE
--- below if any objects remain, which is the intended safety net.
+-- Scope of this migration: only the policy is dropped here. Removing the
+-- bucket row itself (`storage.buckets`) cannot be done via SQL — Supabase
+-- enforces "Direct deletion from storage tables is not allowed. Use the
+-- Storage API instead." (SQLSTATE 42501). The bucket must therefore be
+-- emptied and then deleted via the Supabase Storage dashboard or API as
+-- a manual operational step.
 
 DROP POLICY IF EXISTS "Service role can manage task html" ON storage.objects;
-
-DELETE FROM storage.buckets WHERE id = 'task-html';

--- a/supabase/migrations/20260521000000_drop_task_html_bucket.sql
+++ b/supabase/migrations/20260521000000_drop_task_html_bucket.sql
@@ -1,0 +1,17 @@
+-- Drop the legacy `task-html` Supabase Storage bucket.
+--
+-- Page HTML has been written direct to Cloudflare R2 since 2026-04-25
+-- (see CHANGELOG entry "All page HTML storage now uses ..." and the
+-- `## 3. Recommended Approach` section of
+-- `docs/plans/page-content-storage-plan.md`). No Go code path references
+-- the `task-html` bucket; it has been holding stale objects from the
+-- four-week window when it was the hot store.
+--
+-- Operational precondition: the bucket must be emptied via the Supabase
+-- Storage dashboard or API before this migration is applied. The foreign
+-- key from `storage.objects` to `storage.buckets` will block the DELETE
+-- below if any objects remain, which is the intended safety net.
+
+DROP POLICY IF EXISTS "Service role can manage task html" ON storage.objects;
+
+DELETE FROM storage.buckets WHERE id = 'task-html';

--- a/supabase/migrations/20260521010000_clear_task_html_pointers.sql
+++ b/supabase/migrations/20260521010000_clear_task_html_pointers.sql
@@ -1,0 +1,22 @@
+-- Clear dangling `task-html` pointers on the `tasks` table.
+--
+-- Background: between 2026-03-21 and 2026-04-25, completed crawl tasks had
+-- their `html_storage_bucket` / `html_storage_path` columns populated with
+-- pointers into the Supabase Storage `task-html` bucket. Since 2026-04-25,
+-- the same columns are populated with Cloudflare R2 pointers
+-- (`html_storage_bucket = ARCHIVE_BUCKET`).
+--
+-- The `task-html` bucket is being dropped in the accompanying migration. Rows
+-- whose pointers still reference `task-html` would otherwise point at
+-- destroyed objects. This migration NULLs those two columns on the affected
+-- rows so the dangling references are not mistaken for valid retrievals.
+--
+-- Retained on those rows for historical analysis: `html_content_type`,
+-- `html_content_encoding`, `html_size_bytes`, `html_compressed_size_bytes`,
+-- `html_sha256`, `html_captured_at`. These describe the original response
+-- and remain factually correct even without the stored body.
+
+UPDATE tasks
+SET html_storage_bucket = NULL,
+    html_storage_path   = NULL
+WHERE html_storage_bucket = 'task-html';


### PR DESCRIPTION
## Summary

- Adds migration `supabase/migrations/20260521000000_drop_task_html_bucket.sql` which removes the service-role RLS policy on `storage.objects` for `bucket_id = 'task-html'` and deletes the bucket row from `storage.buckets`.
- Updates `CHANGELOG.md` (Unreleased) with the rationale and operational precondition.
- Marks section 11 of `docs/plans/page-content-storage-plan.md` as historical/superseded.

## Why

Page HTML has been written direct to Cloudflare R2 since 2026-04-25 (issue #332). No Go code path still references the `task-html` Supabase Storage bucket, but the bucket retained the objects written during the four-week window when it was the hot store. The accumulated bytes pushed the Supabase project past its 100 GB storage allowance, which triggered Supabase's connection-slot restriction and surfaced in Sentry as `pgconn.ConnectError: FATAL: remaining connection slots are reserved for roles with the SUPERUSER attribute` (HOVER-JG).

## Operational precondition (manual step before applying migration)

Bucket contents must be cleared via the Supabase Storage dashboard or API before this migration is applied. The foreign key from `storage.objects` to `storage.buckets` will block the migration otherwise — that is the intended safety net.

## What this PR does NOT do

- Does not delete bucket contents (manual, owner-driven step above).
- Does not drop `tasks.html_storage_*` columns. Historical rows still reference them and a follow-up PR will review removal once retrieval flows are confirmed unused.
- Does not touch the archive sweep or any R2 code paths.

## Test plan

- [ ] Confirm via the per-bucket size query that `task-html` is the bucket consuming the overage (already inspected; objects total ~117 GB).
- [ ] Empty the `task-html` bucket from the Supabase Storage dashboard.
- [ ] Apply the migration in a non-production environment first; verify it runs cleanly and that `SELECT * FROM storage.buckets WHERE id = 'task-html'` returns zero rows afterwards.
- [ ] Confirm no new errors appear in Sentry HOVER-JG once the connection-slot restriction lifts (Supabase usage refresh is up to one hour).
- [ ] Apply in production.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Good-Native/codesmith/hover/pr/391"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1781941687&installation_id=129934821&pr_number=391&repository=Good-Native%2Fhover&return_to=https%3A%2F%2Fgithub.com%2FGood-Native%2Fhover%2Fpull%2F391&signature=f6eb2b7b502ec8948e93d69505b8bb6ac92d7f7d3f83be11caead408a9051c1f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Marked the legacy storage as historical, removed guidance for its use, and clarified that per-task page HTML now uses private Cloudflare R2; updated changelog with migration notes.

* **Chores**
  * Removed legacy storage access policy and cleared dangling references so tasks now rely on Cloudflare R2; preserved HTML metadata for historical analysis and documented the manual cleanup step.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Good-Native/hover/pull/391?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->